### PR TITLE
Remove junit dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,6 @@ lazy val commonDependencies = Seq(
 
   // Test dependencies
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
-  "junit" % "junit" % "4.12" % "test",
   "org.mockito" %% "mockito-scala" % "0.4.0" % "test",
   "org.apache.spark" %% "spark-catalyst" % sparkVersion % "test" classifier "tests",
   "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",
@@ -52,7 +51,7 @@ scalacOptions in ThisBuild ++= Seq(
   "-target:jvm-1.8"
 )
 
-javaOptions += "-Xmx1024m"
+javaOptions in ThisBuild += "-Xmx1024m"
 
 /********************************
  * Tests related configurations *

--- a/core/src/test/scala/com/microsoft/hyperspace/actions/ActionTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/actions/ActionTest.scala
@@ -16,16 +16,13 @@
 
 package com.microsoft.hyperspace.actions
 
-import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
 import com.microsoft.hyperspace.SparkInvolvedSuite
 import com.microsoft.hyperspace.index._
 
-@RunWith(classOf[JUnitRunner])
 class ActionTest extends FunSuite with SparkInvolvedSuite with BeforeAndAfter {
   var mockLogManager: IndexLogManager = _
   var testObject: Action = _

--- a/core/src/test/scala/com/microsoft/hyperspace/actions/CancelActionTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/actions/CancelActionTest.scala
@@ -16,17 +16,14 @@
 
 package com.microsoft.hyperspace.actions
 
-import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mockito.{mock, when}
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.SparkInvolvedSuite
 import com.microsoft.hyperspace.actions.Constants.States._
 import com.microsoft.hyperspace.index._
 
-@RunWith(classOf[JUnitRunner])
 class CancelActionTest extends FunSuite with SparkInvolvedSuite {
   private val mockLogManager: IndexLogManager = mock(classOf[IndexLogManager])
 

--- a/core/src/test/scala/com/microsoft/hyperspace/actions/CreateActionTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/actions/CreateActionTest.scala
@@ -18,17 +18,14 @@ package com.microsoft.hyperspace.actions
 
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.DataFrame
-import org.junit.runner.RunWith
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.actions.Constants.States._
 import com.microsoft.hyperspace.index._
 import com.microsoft.hyperspace.util.FileUtils
 import com.microsoft.hyperspace.{HyperspaceException, SampleData, SparkInvolvedSuite}
 
-@RunWith(classOf[JUnitRunner])
 class CreateActionTest extends FunSuite with SparkInvolvedSuite {
   private val indexSystemPath = "src/test/resources/indexLocation"
   private val sampleData = SampleData.testData

--- a/core/src/test/scala/com/microsoft/hyperspace/actions/DeleteActionTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/actions/DeleteActionTest.scala
@@ -16,17 +16,14 @@
 
 package com.microsoft.hyperspace.actions
 
-import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.{mock, when}
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.actions.Constants.States._
 import com.microsoft.hyperspace.index._
 import com.microsoft.hyperspace.{HyperspaceException, SparkInvolvedSuite}
 
-@RunWith(classOf[JUnitRunner])
 class DeleteActionTest extends FunSuite with SparkInvolvedSuite {
   private val mockLogManager: IndexLogManager = mock(classOf[IndexLogManager])
 

--- a/core/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
@@ -19,18 +19,15 @@ package com.microsoft.hyperspace.actions
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.DataFrame
-import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mockito.{mock, when}
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.actions.Constants.States.{ACTIVE, CREATING}
 import com.microsoft.hyperspace.index._
 import com.microsoft.hyperspace.index.serde.LogicalPlanSerDeUtils
 import com.microsoft.hyperspace.{HyperspaceException, SampleData, SparkInvolvedSuite}
 
-@RunWith(classOf[JUnitRunner])
 class RefreshActionTest extends FunSuite with SparkInvolvedSuite {
   private val sampleParquetDataLocation = "src/test/resources/sampleparquet"
   private val fileSystem = new Path(sampleParquetDataLocation).getFileSystem(new Configuration)

--- a/core/src/test/scala/com/microsoft/hyperspace/actions/RestoreActionTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/actions/RestoreActionTest.scala
@@ -16,17 +16,14 @@
 
 package com.microsoft.hyperspace.actions
 
-import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.{mock, when}
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.actions.Constants.States._
 import com.microsoft.hyperspace.index._
 import com.microsoft.hyperspace.{HyperspaceException, SparkInvolvedSuite}
 
-@RunWith(classOf[JUnitRunner])
 class RestoreActionTest extends FunSuite with SparkInvolvedSuite {
   private val mockLogManager: IndexLogManager = mock(classOf[IndexLogManager])
 

--- a/core/src/test/scala/com/microsoft/hyperspace/actions/VacuumActionTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/actions/VacuumActionTest.scala
@@ -16,18 +16,15 @@
 
 package com.microsoft.hyperspace.actions
 
-import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.{mock, verify, when}
 import org.mockito.internal.verification.Times
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.actions.Constants.States._
 import com.microsoft.hyperspace.index._
 import com.microsoft.hyperspace.{HyperspaceException, SparkInvolvedSuite}
 
-@RunWith(classOf[JUnitRunner])
 class VacuumActionTest extends FunSuite with SparkInvolvedSuite {
   private val mockLogManager: IndexLogManager = mock(classOf[IndexLogManager])
   private val mockDataManager: IndexDataManager = mock(classOf[IndexDataManager])

--- a/core/src/test/scala/com/microsoft/hyperspace/index/CreateIndexTests.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/CreateIndexTests.scala
@@ -18,14 +18,11 @@ package com.microsoft.hyperspace.index
 
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.DataFrame
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.util.FileUtils
 import com.microsoft.hyperspace.{Hyperspace, HyperspaceException, SampleData, SparkInvolvedSuite}
 
-@RunWith(classOf[JUnitRunner])
 class CreateIndexTests extends FunSuite with SparkInvolvedSuite {
 
   private val sampleData = SampleData.testData

--- a/core/src/test/scala/com/microsoft/hyperspace/index/DataFrameWriterExtensionsTests.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/DataFrameWriterExtensionsTests.scala
@@ -26,15 +26,12 @@ import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.execution.datasources.BucketingUtils
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, Row}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.index.DataFrameWriterExtensions.Bucketizer
 import com.microsoft.hyperspace.util.FileUtils
 import com.microsoft.hyperspace.{SampleData, SparkInvolvedSuite}
 
-@RunWith(classOf[JUnitRunner])
 class DataFrameWriterExtensionsTests extends FunSuite with SparkInvolvedSuite {
 
   private val sampleData = SampleData.testData

--- a/core/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
@@ -21,13 +21,10 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InMemoryFileIndex, LogicalRelation}
 import org.apache.spark.sql.{DataFrame, Row}
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.index.rules.{FilterIndexRule, JoinIndexRule}
 import com.microsoft.hyperspace.{Hyperspace, Implicits, SampleData}
 
-@RunWith(classOf[JUnitRunner])
 class E2EHyperspaceRulesTests extends HyperspaceSuite {
 
   private val sampleData = SampleData.testData

--- a/core/src/test/scala/com/microsoft/hyperspace/index/FileBasedSignatureProviderTests.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/FileBasedSignatureProviderTests.scala
@@ -24,13 +24,10 @@ import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation, PartitionSpec, PartitioningAwareFileIndex}
 import org.apache.spark.sql.types.StructType
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.SparkInvolvedSuite
 
-@RunWith(classOf[JUnitRunner])
 class FileBasedSignatureProviderTests extends FunSuite with SparkInvolvedSuite {
   private val fileLength = 100
   private val fileModificationTime = 10000

--- a/core/src/test/scala/com/microsoft/hyperspace/index/IndexCacheTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/IndexCacheTest.scala
@@ -19,15 +19,12 @@ package com.microsoft.hyperspace.index
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.actions.Constants
 import com.microsoft.hyperspace.util.FileUtils
 import com.microsoft.hyperspace.{Hyperspace, HyperspaceException, SampleData, SparkInvolvedSuite}
 
-@RunWith(classOf[JUnitRunner])
 class IndexCacheTest extends FunSuite with SparkInvolvedSuite {
   val sampleParquetDataLocation = "src/test/resources/sampleparquet"
   val indexSystemPath = "src/test/resources/indexLocation"

--- a/core/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
@@ -17,16 +17,13 @@
 package com.microsoft.hyperspace.index
 
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
-import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, when}
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.actions.Constants
 import com.microsoft.hyperspace.{HyperspaceException, SparkInvolvedSuite}
 
-@RunWith(classOf[JUnitRunner])
 class IndexCollectionManagerTest extends FunSuite with SparkInvolvedSuite {
   private val indexSystemPath = "src/test/resources/indexLocation"
   private val testLogManagerFactory: IndexLogManagerFactory = new IndexLogManagerFactory {

--- a/core/src/test/scala/com/microsoft/hyperspace/index/IndexConfigTests.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/IndexConfigTests.scala
@@ -16,11 +16,8 @@
 
 package com.microsoft.hyperspace.index
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class IndexConfigTests extends FunSuite {
   test("Empty index name is not allowed.") {
     intercept[IllegalArgumentException](IndexConfig("", Seq("c1"), Seq("c2")))

--- a/core/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -17,13 +17,10 @@
 package com.microsoft.hyperspace.index
 
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.util.JsonUtils
 
-@RunWith(classOf[JUnitRunner])
 class IndexLogEntryTest extends FunSuite {
   test("IndexLogEntry spec example") {
     val schemaString =

--- a/core/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
@@ -20,15 +20,12 @@ import java.util.UUID
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 import com.microsoft.hyperspace.index.IndexConstants.HYPERSPACE_LOG
 import com.microsoft.hyperspace.util.{FileUtils, JsonUtils}
 import com.microsoft.hyperspace.{SparkInvolvedSuite, TestUtils}
 
-@RunWith(classOf[JUnitRunner])
 class IndexLogManagerImplTest extends FunSuite with SparkInvolvedSuite with BeforeAndAfterAll {
   val testRoot = "src/test/resources/indexLogManagerTests"
   val sampleIndexLogEntry: IndexLogEntry = IndexLogEntry(

--- a/core/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -20,9 +20,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation, PartitioningAwareFileIndex}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.TestUtils.copyWithState
 import com.microsoft.hyperspace.actions.Constants
@@ -30,7 +28,6 @@ import com.microsoft.hyperspace.index.serde.LogicalPlanSerDeUtils
 import com.microsoft.hyperspace.util.FileUtils
 import com.microsoft.hyperspace.{Hyperspace, SampleData, SparkInvolvedSuite}
 
-@RunWith(classOf[JUnitRunner])
 class IndexManagerTests extends FunSuite with SparkInvolvedSuite {
   private val sampleParquetDataLocation = "src/test/resources/sampleparquet"
   private val indexStorageLocation = "src/test/resources/indexLocation"

--- a/core/src/test/scala/com/microsoft/hyperspace/index/IndexTests.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/IndexTests.scala
@@ -17,13 +17,10 @@
 package com.microsoft.hyperspace.index
 
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.actions.Constants
 
-@RunWith(classOf[JUnitRunner])
 class IndexTests extends FunSuite {
   val indexConfig1 = IndexConfig("myIndex1", Array("id"), Seq("name"))
   val indexConfig2 = IndexConfig("myIndex2", Array("id"), Seq("school"))

--- a/core/src/test/scala/com/microsoft/hyperspace/index/LogicalPlanSerDeTests.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/LogicalPlanSerDeTests.scala
@@ -23,9 +23,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.SparkInvolvedSuite
 import com.microsoft.hyperspace.index.serde.LogicalPlanSerDeUtils
@@ -34,7 +32,6 @@ import com.microsoft.hyperspace.index.serde.LogicalPlanSerDeUtils
  * Some tests are adapted from examples in ExpressionParserSuite.scala, PlanParserSuite.scala,
  * and QueryPlanSuite.scala.
  */
-@RunWith(classOf[JUnitRunner])
 class LogicalPlanSerDeTests extends FunSuite with SparkInvolvedSuite {
   val c1: AttributeReference = AttributeReference("c1", StringType)()
   val c2: AttributeReference = AttributeReference("c2", StringType)()

--- a/core/src/test/scala/com/microsoft/hyperspace/index/plananalysis/BufferStreamTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/plananalysis/BufferStreamTest.scala
@@ -16,11 +16,8 @@
 
 package com.microsoft.hyperspace.index.plananalysis
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class BufferStreamTest extends FunSuite {
   test("Testing buffer stream highlight with spaces.") {
     val s = "   Please highlight me.  "

--- a/core/src/test/scala/com/microsoft/hyperspace/index/plananalysis/DisplayModeTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/plananalysis/DisplayModeTest.scala
@@ -16,13 +16,10 @@
 
 package com.microsoft.hyperspace.index.plananalysis
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.index.IndexConstants
 
-@RunWith(classOf[JUnitRunner])
 class DisplayModeTest extends FunSuite {
   test("Testing default tags in Display Mode.") {
     val htmlMode = new HTMLMode(Map.empty)

--- a/core/src/test/scala/com/microsoft/hyperspace/index/plananalysis/ExplainTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/plananalysis/ExplainTest.scala
@@ -20,14 +20,11 @@ import org.apache.commons.lang.StringUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.DataFrame
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.index.{HyperspaceSuite, IndexConfig, IndexConstants}
 import com.microsoft.hyperspace.{Hyperspace, Implicits}
 
-@RunWith(classOf[JUnitRunner])
 class ExplainTest extends FunSuite with HyperspaceSuite {
   private val sampleParquetDataLocation = "src/test/resources/sampleparquet"
   private val indexStorageLocation = "src/test/resources/indexLocation"

--- a/core/src/test/scala/com/microsoft/hyperspace/index/plananalysis/PhysicalOperatorAnalyzerTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/plananalysis/PhysicalOperatorAnalyzerTest.scala
@@ -21,13 +21,10 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.{Distribution, Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.SparkPlan
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.SparkInvolvedSuite
 
-@RunWith(classOf[JUnitRunner])
 class PhysicalOperatorAnalyzerTest extends FunSuite with SparkInvolvedSuite {
   test("Two plans are the same") {
     val plan = DummySparkPlan("plan1", Seq(DummySparkPlan("plan1"), DummySparkPlan("plan2")))

--- a/core/src/test/scala/com/microsoft/hyperspace/index/rankers/JoinIndexRankerTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/rankers/JoinIndexRankerTest.scala
@@ -18,14 +18,11 @@ package com.microsoft.hyperspace.index.rankers
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.actions.Constants
 import com.microsoft.hyperspace.index._
 
-@RunWith(classOf[JUnitRunner])
 class JoinIndexRankerTest extends FunSuite {
 
   val t1c1 = AttributeReference("t1c1", IntegerType)()

--- a/core/src/test/scala/com/microsoft/hyperspace/index/rules/FilterIndexRuleTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/rules/FilterIndexRuleTest.scala
@@ -23,15 +23,12 @@ import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.actions.Constants
 import com.microsoft.hyperspace.index._
 import com.microsoft.hyperspace.index.serde.LogicalPlanSerDeUtils
 import com.microsoft.hyperspace.util.FileUtils
 
-@RunWith(classOf[JUnitRunner])
 class FilterIndexRuleTest extends HyperspaceSuite {
   val originalLocation = new Path("baseTableLocation")
   val parentPath = new Path("src/test/resources/filterIndexTest")

--- a/core/src/test/scala/com/microsoft/hyperspace/index/rules/JoinIndexRuleTest.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/index/rules/JoinIndexRuleTest.scala
@@ -24,15 +24,12 @@ import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.apache.spark.sql.{Row, SparkSession}
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.actions.Constants
 import com.microsoft.hyperspace.index._
 import com.microsoft.hyperspace.index.serde.LogicalPlanSerDeUtils
 import com.microsoft.hyperspace.util.FileUtils
 
-@RunWith(classOf[JUnitRunner])
 class JoinIndexRuleTest extends HyperspaceSuite {
   val parentPath = new Path("src/test/resources/joinIndexTest")
   val systemPath = new Path(parentPath, "idroot")

--- a/core/src/test/scala/com/microsoft/hyperspace/util/HashingUtilsTests.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/util/HashingUtilsTests.scala
@@ -18,11 +18,8 @@ package com.microsoft.hyperspace.util
 
 import java.util.UUID
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class HashingUtilsTests extends FunSuite {
   test("For md5Hashing(), same input has the same output hash code.") {
     val randomUUID = UUID.randomUUID.toString

--- a/core/src/test/scala/com/microsoft/hyperspace/util/IndexNameUtilsTests.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/util/IndexNameUtilsTests.scala
@@ -16,11 +16,8 @@
 
 package com.microsoft.hyperspace.util
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class IndexNameUtilsTests extends FunSuite {
   test("Test normalizeIndexName() function.") {
     val indexName = "  my index   1     "

--- a/core/src/test/scala/com/microsoft/hyperspace/util/JsonUtilsTests.scala
+++ b/core/src/test/scala/com/microsoft/hyperspace/util/JsonUtilsTests.scala
@@ -17,14 +17,11 @@
 package com.microsoft.hyperspace.util
 
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import com.microsoft.hyperspace.actions.Constants
 import com.microsoft.hyperspace.index._
 
-@RunWith(classOf[JUnitRunner])
 class JsonUtilsTests extends FunSuite {
   test("Test for JsonUtils.") {
     val schema = StructType(


### PR DESCRIPTION
@RunWith(classOf[JUnitRunner]) tag is no longer needed after switching to `sbt`. After removing those tags, `junit` is no longer being used, thus removing it from dependency as well.