### PR TITLE
cleanup scaladoc for join rule

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -23,8 +23,8 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.CleanupAliases
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
-import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeReference, EqualTo, Expression}
-import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, AttributeReference, AttributeSet, EqualTo, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InMemoryFileIndex, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
@@ -241,11 +241,11 @@ object JoinIndexRule extends Rule[LogicalPlan] with Logging {
    *
    *
    * Background knowledge:
-   * An alias in a query plan is represented as Alias at the time of
+   * An alias in a query plan is represented as [[Alias]] at the time of
    * its creation. Unnecessary aliases get resolved and removed during query analysis phase by
-   * [[CleanupAliases]] rule. Some nodes still remain with alias definitions. E.g. Project.
+   * [[CleanupAliases]] rule. Some nodes still remain with alias definitions. E.g. [[Project]].
    *
-   * Secondly, the output of a logical plan is an AttributeSet. Alias objects get converted
+   * Secondly, the output of a logical plan is an [[AttributeSet]]. Alias objects get converted
    * to [[AttributeReference]]s at plan boundaries.
    *
    * From looking at the join condition, we can't know whether the attributes used in the


### PR DESCRIPTION
### What changes were proposed in this pull request?
Cleanup some documentation for JoinRule. 
### Why are the changes needed?
Without this, IDE highlights words within [[]], i.e. the class names not present in import statements as "missing imports"
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
not applicable