### PR TITLE
Add spark jar sources with sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,9 +27,9 @@ scalaVersion := scala212
 crossScalaVersions := supportedScalaVersions
 
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
-  "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
-  "org.apache.spark" %% "spark-catalyst" % sparkVersion % "provided",
+  "org.apache.spark" %% "spark-sql" % sparkVersion % "provided" withSources(),
+  "org.apache.spark" %% "spark-core" % sparkVersion % "provided" withSources(),
+  "org.apache.spark" %% "spark-catalyst" % sparkVersion % "provided" withSources(),
 
   // Test dependencies
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR addresses the issue where setting up the hyperspace project (e.g. on intellij ide) doesn't add the sources for dependencies like spark sql, spark core and spark catalyst.
### Why are the changes needed?
Update build.sbt to download dependency sources' jars
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
manually setting up intellij project when there are no pre-downloaded sources