### PR TITLE
fixed typo in the notebook - accroding --> according

### DIFF
--- a/notebooks/scala/Hitchhikers Guide to Hyperspace.ipynb
+++ b/notebooks/scala/Hitchhikers Guide to Hyperspace.ipynb
@@ -1,12 +1,4 @@
 {
-  "metadata": {
-    "saveOutput": true,
-    "language_info": {
-      "name": "scala"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 2,
   "cells": [
     {
       "cell_type": "markdown",
@@ -715,7 +707,7 @@
       "metadata": {},
       "source": [
         "## Refresh Indexes\n",
-        "If the original data on which an index was created changes, then the index will no longer capture the latest state of data. The user can refresh such a stale index using \"refreshIndex\" command. This causes the index to be fully rebuilt and updates it accroding to the latest data records (don't worry, we will show you how to *incrementally refresh* your index in other notebooks).\n",
+        "If the original data on which an index was created changes, then the index will no longer capture the latest state of data. The user can refresh such a stale index using \"refreshIndex\" command. This causes the index to be fully rebuilt and updates it according to the latest data records (don't worry, we will show you how to *incrementally refresh* your index in other notebooks).\n",
         "\n",
         "The two cells below show an example for this scenario:\n",
         "- First cell adds two more departments to the original departments data. It reads and prints list of departments to verify new departments are added correctly. The output shows 6 departments in total: four old ones and two new. Invoking \"refreshIndex\" updates \"deptIndex1\" so index captures new departments.\n",
@@ -775,5 +767,13 @@
       ],
       "attachments": {}
     }
-  ]
+  ],
+  "metadata": {
+    "saveOutput": true,
+    "language_info": {
+      "name": "scala"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
 }


### PR DESCRIPTION


### What changes were proposed in this pull request?
I just fixed a typo in the notebook: accroding  --> according 

### Why are the changes needed?
Because typos are bad! :-)


### Does this PR introduce _any_ user-facing change?
This is just a documentation style fix.


### How was this patch tested?
None needed as it is just text within the notebook
