### PR TITLE
Creating index fails for csv data where data is materialized before index creation

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
 import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
+import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 
 import com.microsoft.hyperspace.HyperspaceException
@@ -225,7 +226,7 @@ object LogicalPlanSerDeUtils {
     def unapply(fileFormat: FileFormat): Option[FileFormat] = fileFormat match {
       case CSVFileFormatWrapper => Some(new CSVFileFormat)
       case JsonFileFormatWrapper => Some(new JsonFileFormat)
-      case f: ParquetFileFormat => Some(f)
+      case _: ParquetFileFormat | _: OrcFileFormat => Some(fileFormat)
       case _ => throw HyperspaceException("Unsupported File Format found.")
     }
   }
@@ -234,7 +235,7 @@ object LogicalPlanSerDeUtils {
     def unapply(fileFormat: FileFormat): Option[FileFormat] = fileFormat match {
       case _: CSVFileFormat => Some(CSVFileFormatWrapper)
       case _: JsonFileFormat => Some(JsonFileFormatWrapper)
-      case f: ParquetFileFormat => Some(f)
+      case _: ParquetFileFormat | _: OrcFileFormat => Some(fileFormat)
       case _ => throw HyperspaceException("Unsupported File Format found.")
     }
   }

--- a/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
@@ -227,7 +227,8 @@ object LogicalPlanSerDeUtils {
       case CSVFileFormatWrapper => Some(new CSVFileFormat)
       case JsonFileFormatWrapper => Some(new JsonFileFormat)
       case _: ParquetFileFormat | _: OrcFileFormat => Some(fileFormat)
-      case f => throw HyperspaceException(s"Unsupported File Format found: ${f.toString}.")
+      case other =>
+        throw HyperspaceException(s"Unsupported file format found: ${other.toString}.")
     }
   }
 
@@ -236,7 +237,8 @@ object LogicalPlanSerDeUtils {
       case _: CSVFileFormat => Some(CSVFileFormatWrapper)
       case _: JsonFileFormat => Some(JsonFileFormatWrapper)
       case _: ParquetFileFormat | _: OrcFileFormat => Some(fileFormat)
-      case f => throw HyperspaceException(s"Unsupported File Format found: ${f.toString}.")
+      case other =>
+        throw HyperspaceException(s"Unsupported file format found: ${other.toString}.")
     }
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
@@ -227,7 +227,7 @@ object LogicalPlanSerDeUtils {
       case CSVFileFormatWrapper => Some(new CSVFileFormat)
       case JsonFileFormatWrapper => Some(new JsonFileFormat)
       case _: ParquetFileFormat | _: OrcFileFormat => Some(fileFormat)
-      case _ => throw HyperspaceException("Unsupported File Format found.")
+      case f => throw HyperspaceException(s"Unsupported File Format found: ${f.toString}.")
     }
   }
 
@@ -236,7 +236,7 @@ object LogicalPlanSerDeUtils {
       case _: CSVFileFormat => Some(CSVFileFormatWrapper)
       case _: JsonFileFormat => Some(JsonFileFormatWrapper)
       case _: ParquetFileFormat | _: OrcFileFormat => Some(fileFormat)
-      case _ => throw HyperspaceException("Unsupported File Format found.")
+      case f => throw HyperspaceException(s"Unsupported File Format found: ${f.toString}.")
     }
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.{Exists, InSubquery, ListQuery,
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
+import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 
 import com.microsoft.hyperspace.HyperspaceException
@@ -222,16 +223,18 @@ object LogicalPlanSerDeUtils {
 
   object ExtractFileFormat {
     def unapply(fileFormat: FileFormat): Option[FileFormat] = fileFormat match {
+      case CSVFileFormatWrapper => Some(new CSVFileFormat)
+      case JsonFileFormatWrapper => Some(new JsonFileFormat)
       case f: ParquetFileFormat => Some(f)
-      case _: CSVFileFormat => Some(CSVFileFormatWrapper)
       case _ => throw HyperspaceException("Unsupported File Format found.")
     }
   }
 
   object ExtractSerializableFileFormat {
     def unapply(fileFormat: FileFormat): Option[FileFormat] = fileFormat match {
+      case _: CSVFileFormat => Some(CSVFileFormatWrapper)
+      case _: JsonFileFormat => Some(JsonFileFormatWrapper)
       case f: ParquetFileFormat => Some(f)
-      case CSVFileFormatWrapper => Some(new CSVFileFormat)
       case _ => throw HyperspaceException("Unsupported File Format found.")
     }
   }

--- a/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
@@ -123,23 +123,18 @@ object LogicalPlanSerDeUtils {
             partitionSchema,
             dataSchema,
             bucketSpec,
-            fileFormat,
+            ExtractSerializableFileFormat(fileFormat),
             options),
           output,
           catalogTable,
           isStreaming) =>
-        val format = fileFormat match {
-          case f: ParquetFileFormat => f
-          case _: CSVFileFormat => CSVFileFormatWrapper
-          case _ => throw HyperspaceException("Unsupported File Format found.")
-        }
         LogicalRelationWrapper(
           HadoopFsRelationWrapper(
             InMemoryFileIndexWrapper(location.rootPaths.map(path => path.toString)),
             partitionSchema,
             dataSchema,
             bucketSpec,
-            format,
+            fileFormat,
             options),
           output,
           catalogTable,
@@ -174,16 +169,11 @@ object LogicalPlanSerDeUtils {
             partitionSchema,
             dataSchema,
             bucketSpec,
-            fileFormat,
+            ExtractFileFormat(fileFormat),
             options),
           output,
           catalogTable,
           isStreaming) =>
-        val format = fileFormat match {
-          case f: ParquetFileFormat => f
-          case CSVFileFormatWrapper => new CSVFileFormat
-          case _ => throw HyperspaceException("Unsupported File Format found.")
-        }
         LogicalRelation(
           HadoopFsRelation(
             new InMemoryFileIndex(
@@ -227,6 +217,22 @@ object LogicalPlanSerDeUtils {
             e.query.children,
             e.query.exprId,
             e.query.childOutputs))
+    }
+  }
+
+  object ExtractFileFormat {
+    def unapply(fileFormat: FileFormat): Option[FileFormat] = fileFormat match {
+      case f: ParquetFileFormat => Some(f)
+      case _: CSVFileFormat => Some(CSVFileFormatWrapper)
+      case _ => throw HyperspaceException("Unsupported File Format found.")
+    }
+  }
+
+  object ExtractSerializableFileFormat {
+    def unapply(fileFormat: FileFormat): Option[FileFormat] = fileFormat match {
+      case f: ParquetFileFormat => Some(f)
+      case CSVFileFormatWrapper => Some(new CSVFileFormat)
+      case _ => throw HyperspaceException("Unsupported File Format found.")
     }
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/serde/package.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/serde/package.scala
@@ -16,13 +16,14 @@
 
 package com.microsoft.hyperspace.index
 
-import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.SQLContext
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.hadoop.mapreduce.Job
+import org.apache.spark.sql.{SparkSession, SQLContext}
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTable}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, ExprId, Predicate, Unevaluable}
 import org.apache.spark.sql.catalyst.plans.logical.{BinaryNode, LeafNode, LogicalPlan}
 import org.apache.spark.sql.execution.FileRelation
-import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex, PartitionDirectory}
+import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex, OutputWriterFactory, PartitionDirectory}
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types.{DataType, StructType}
 
@@ -165,4 +166,17 @@ package object serde {
       override val isStreaming: Boolean)
       extends LeafNode
       with LogicalPlanWrapperWithInMemoryStates
+
+  case object CSVFileFormatWrapper extends FileFormat {
+    override def inferSchema(
+        sparkSession: SparkSession,
+        options: Map[String, String],
+        files: Seq[FileStatus]): Option[StructType] = throw new UnsupportedOperationException()
+
+    override def prepareWrite(
+        sparkSession: SparkSession,
+        job: Job,
+        options: Map[String, String],
+        dataSchema: StructType): OutputWriterFactory = throw new UnsupportedOperationException()
+  }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/serde/package.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/serde/package.scala
@@ -179,4 +179,17 @@ package object serde {
         options: Map[String, String],
         dataSchema: StructType): OutputWriterFactory = throw new UnsupportedOperationException()
   }
+
+  case object JsonFileFormatWrapper extends FileFormat {
+    override def inferSchema(
+      sparkSession: SparkSession,
+      options: Map[String, String],
+      files: Seq[FileStatus]): Option[StructType] = throw new UnsupportedOperationException()
+
+    override def prepareWrite(
+      sparkSession: SparkSession,
+      job: Job,
+      options: Map[String, String],
+      dataSchema: StructType): OutputWriterFactory = throw new UnsupportedOperationException()
+  }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/serde/package.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/serde/package.scala
@@ -167,20 +167,7 @@ package object serde {
       extends LeafNode
       with LogicalPlanWrapperWithInMemoryStates
 
-  case object CSVFileFormatWrapper extends FileFormat {
-    override def inferSchema(
-        sparkSession: SparkSession,
-        options: Map[String, String],
-        files: Seq[FileStatus]): Option[StructType] = throw new UnsupportedOperationException()
-
-    override def prepareWrite(
-        sparkSession: SparkSession,
-        job: Job,
-        options: Map[String, String],
-        dataSchema: StructType): OutputWriterFactory = throw new UnsupportedOperationException()
-  }
-
-  case object JsonFileFormatWrapper extends FileFormat {
+  abstract class FileFormatWrapper extends FileFormat {
     override def inferSchema(
       sparkSession: SparkSession,
       options: Map[String, String],
@@ -192,4 +179,8 @@ package object serde {
       options: Map[String, String],
       dataSchema: StructType): OutputWriterFactory = throw new UnsupportedOperationException()
   }
+
+  case object CSVFileFormatWrapper extends FileFormatWrapper
+
+  case object JsonFileFormatWrapper extends FileFormatWrapper
 }

--- a/src/test/scala/com/microsoft/hyperspace/index/LogicalPlanSerDeTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/LogicalPlanSerDeTests.scala
@@ -90,7 +90,7 @@ class LogicalPlanSerDeTests extends SparkFunSuite with SparkInvolvedSuite {
     val kryoSerializer = new KryoSerializer(spark.sparkContext.getConf)
     KryoSerDeUtils.serialize(kryoSerializer, fileFormat)
 
-    // Confirm that isSplittable makes serialization fail
+    // Confirm that isSplittable makes serialization fail.
     fileFormat.isSplitable(spark, Map(), new Path("path"))
     if (expectSerializationError) {
       intercept[KryoException](KryoSerDeUtils.serialize(kryoSerializer, fileFormat))
@@ -98,32 +98,28 @@ class LogicalPlanSerDeTests extends SparkFunSuite with SparkInvolvedSuite {
       KryoSerDeUtils.serialize(kryoSerializer, fileFormat)
     }
 
-    // Now verify if Hyperspace serialization still works with this format
+    // Now verify if Hyperspace serialization still works with this format.
     verifyPlanSerde(updatedScanNode, "hadoopFsRelation.plan")
   }
 
   test("Serde query with Hadoop file system parquet relation.") {
-    val parquetFormat = new ParquetFileFormat
-    // CSVFormat is unserializable due to internal unserializable members. Verify as below.
-    verifyFileFormat(parquetFormat, false)
+    // Parquet is serializable due to no internal unserializable members. Verify as below.
+    verifyFileFormat(new ParquetFileFormat, false)
   }
 
   test("Serde query with Hadoop file system csv relation.") {
-    val csvFormat = new CSVFileFormat
     // CSVFormat is unserializable due to internal unserializable members. Verify as below.
-    verifyFileFormat(csvFormat, true)
+    verifyFileFormat(new CSVFileFormat, true)
   }
 
   test("Serde query with Hadoop file system json relation.") {
-    val jsonFormat = new JsonFileFormat
     // JsonFileFormat is unserializable due to internal unserializable members. Verify as below.
-    verifyFileFormat(jsonFormat, true)
+    verifyFileFormat(new JsonFileFormat, true)
   }
 
   test("Serde query with Hadoop file system orc relation.") {
-    val orcFormat = new OrcFileFormat
-    // OrcFileFormat is serializable due to no internal unserializable members. Verify as below.
-    verifyFileFormat(orcFormat, false)
+    // Orc is serializable due to no internal unserializable members. Verify as below.
+    verifyFileFormat(new OrcFileFormat, false)
   }
 
   test("Serde query with scalar subquery.") {

--- a/src/test/scala/com/microsoft/hyperspace/index/LogicalPlanSerDeTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/LogicalPlanSerDeTests.scala
@@ -81,7 +81,7 @@ class LogicalPlanSerDeTests extends SparkFunSuite with SparkInvolvedSuite {
   private def verifyFileFormat(
       fileFormat: FileFormat,
       expectSerializationError: Boolean): Unit = {
-    val relation: HadoopFsRelation =
+    val relation =
       scanNode.relation.asInstanceOf[HadoopFsRelation].copy(fileFormat = fileFormat)(spark)
     val updatedScanNode = scanNode.copy(relation = relation)
 

--- a/src/test/scala/com/microsoft/hyperspace/index/LogicalPlanSerDeTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/LogicalPlanSerDeTests.scala
@@ -103,7 +103,7 @@ class LogicalPlanSerDeTests extends SparkFunSuite with SparkInvolvedSuite {
     val jsonFormat = new JsonFileFormat
     val relation: HadoopFsRelation =
       scanNode.relation.asInstanceOf[HadoopFsRelation].copy(fileFormat = jsonFormat)(spark)
-    val csvScanNode = scanNode.copy(relation = relation)
+    val jsonScanNode = scanNode.copy(relation = relation)
 
     // Json file format is serializable unless isSplittable is called on it. isSplittable api
     // initializes internal objects which break serialization logic.
@@ -117,14 +117,14 @@ class LogicalPlanSerDeTests extends SparkFunSuite with SparkInvolvedSuite {
     }
 
     // Now verify if Hyperspace serialization still works with json format
-    verifyPlanSerde(csvScanNode, "hadoopFsRelation.plan")
+    verifyPlanSerde(jsonScanNode, "hadoopFsRelation.plan")
   }
 
   test("Serde query with Hadoop file system orc relation.") {
     val orcFormat = new OrcFileFormat
     val relation: HadoopFsRelation =
       scanNode.relation.asInstanceOf[HadoopFsRelation].copy(fileFormat = orcFormat)(spark)
-    val csvScanNode = scanNode.copy(relation = relation)
+    val orcScanNode = scanNode.copy(relation = relation)
 
     // Orc file format is serializable by default, so materialization should not affect.
     val kryoSerializer = new KryoSerializer(spark.sparkContext.getConf)
@@ -132,8 +132,8 @@ class LogicalPlanSerDeTests extends SparkFunSuite with SparkInvolvedSuite {
     orcFormat.isSplitable(spark, Map(), new Path("path"))
     KryoSerDeUtils.serialize(kryoSerializer, orcFormat)
 
-    // Now verify if Hyperspace serialization still works with csv format
-    verifyPlanSerde(csvScanNode, "hadoopFsRelation.plan")
+    // Now verify if Hyperspace serialization works with orc format
+    verifyPlanSerde(orcScanNode, "hadoopFsRelation.plan")
   }
 
   test("Serde query with scalar subquery.") {


### PR DESCRIPTION
Same as PR https://github.com/microsoft/hyperspace/pull/82 with cleaner commit history.
Fixes #81
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Fixes bug with creating index on csv data where data is materialized beforehand
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->


### Why are the changes needed?
bug occurs when data is materialized, it materializes some internal objects which can't be serialized. This fails during df serialization phase of index creation.
the fix uses wrappers for un-serializable objects
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
manually tested and unit tests added