### PR TITLE
Backward compatibility support for json and csv index creation

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
@@ -224,10 +224,11 @@ object LogicalPlanSerDeUtils {
 
   object ExtractFileFormat {
     def unapply(fileFormat: FileFormat): Option[FileFormat] = fileFormat match {
+      case CSVFileFormatWrapper => Some(new CSVFileFormat)
+      case JsonFileFormatWrapper => Some(new JsonFileFormat)
       // Add CSVFileFormat and JsonFileFormat in below checks for backward compatibility.
-      case CSVFileFormatWrapper | _: CSVFileFormat => Some(new CSVFileFormat)
-      case JsonFileFormatWrapper | _: JsonFileFormat => Some(new JsonFileFormat)
-      case _: ParquetFileFormat | _: OrcFileFormat => Some(fileFormat)
+      case _: ParquetFileFormat | _: OrcFileFormat | _: CSVFileFormat | _: JsonFileFormat =>
+        Some(fileFormat)
       case other =>
         throw HyperspaceException(s"Unsupported file format found: ${other.toString}.")
     }

--- a/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
@@ -224,8 +224,9 @@ object LogicalPlanSerDeUtils {
 
   object ExtractFileFormat {
     def unapply(fileFormat: FileFormat): Option[FileFormat] = fileFormat match {
-      case CSVFileFormatWrapper => Some(new CSVFileFormat)
-      case JsonFileFormatWrapper => Some(new JsonFileFormat)
+      // Add CSVFileFormat and JsonFileFormat in below checks for backward compatibility.
+      case CSVFileFormatWrapper | _: CSVFileFormat => Some(new CSVFileFormat)
+      case JsonFileFormatWrapper | _: JsonFileFormat => Some(new JsonFileFormat)
       case _: ParquetFileFormat | _: OrcFileFormat => Some(fileFormat)
       case other =>
         throw HyperspaceException(s"Unsupported file format found: ${other.toString}.")


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This is an extension to PR https://github.com/microsoft/hyperspace/pull/83
The previous PR broke backward compatibility such that if an index was created with hyperspace v 0.1, it could not be `refresh`ed when above mentioned PR was merged.
This PR improves on previous PR and fixes CSV bugs as well as supports backward compatibility of `refresh`ing indexes created with v0.1
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->


### Why are the changes needed?
Backward compatibility between v0.2-SNAPSHOT and v0.1 of hyperspace fails with PR https://github.com/microsoft/hyperspace/pull/83. This PR is a fix for that.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
manually tested the following
- created index with hs v0.1
- tried refreshing index with hs v0.2-snapshot >> Fails with "Unsupported file format found: CSV"
- added the fix and tried refreshing again >> refresh works as expected