### PR TITLE
Replace printStackTrace with Logging

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogManager.scala
@@ -116,7 +116,7 @@ class IndexLogManagerImpl(indexPath: Path) extends IndexLogManager with Logging 
       FileUtil.copy(fs, pathFromId(id), fs, latestStablePath, false, new Configuration)
     } catch {
       case ex: Exception =>
-        logError("", ex)
+        logError(s"Failed to create the latest stable log with id = '$id'", ex)
         false
     }
   }
@@ -130,7 +130,7 @@ class IndexLogManagerImpl(indexPath: Path) extends IndexLogManager with Logging 
       }
     } catch {
       case ex: Exception =>
-        logError("", ex)
+        logError("Failed to delete the latest stable log", ex)
         false
     }
   }
@@ -147,7 +147,7 @@ class IndexLogManagerImpl(indexPath: Path) extends IndexLogManager with Logging 
         fs.rename(tempPath, pathFromId(id))
       } catch {
         case ex: Exception =>
-          logError("", ex)
+          logError(s"Failed to write log with id = '$id'", ex)
           false
       }
     }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogManager.scala
@@ -22,6 +22,7 @@ import scala.util.Try
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, FileUtil, Path}
+import org.apache.spark.internal.Logging
 
 import com.microsoft.hyperspace.actions.Constants
 import com.microsoft.hyperspace.util.{FileUtils, JsonUtils}
@@ -53,7 +54,7 @@ trait IndexLogManager {
   def writeLog(id: Int, log: LogEntry): Boolean
 }
 
-class IndexLogManagerImpl(indexPath: Path) extends IndexLogManager {
+class IndexLogManagerImpl(indexPath: Path) extends IndexLogManager with Logging {
   // Use FileContext instead of FileSystem for atomic renames?
   private lazy val fs: FileSystem = indexPath.getFileSystem(new Configuration)
 
@@ -115,8 +116,7 @@ class IndexLogManagerImpl(indexPath: Path) extends IndexLogManager {
       FileUtil.copy(fs, pathFromId(id), fs, latestStablePath, false, new Configuration)
     } catch {
       case ex: Exception =>
-        // TODO: replace printStackTrace with Logging.
-        ex.printStackTrace()
+        logError("", ex)
         false
     }
   }
@@ -130,8 +130,7 @@ class IndexLogManagerImpl(indexPath: Path) extends IndexLogManager {
       }
     } catch {
       case ex: Exception =>
-        // TODO: replace printStackTrace with Logging.
-        ex.printStackTrace()
+        logError("", ex)
         false
     }
   }
@@ -148,8 +147,7 @@ class IndexLogManagerImpl(indexPath: Path) extends IndexLogManager {
         fs.rename(tempPath, pathFromId(id))
       } catch {
         case ex: Exception =>
-          // TODO: replace printStackTrace with Logging.
-          ex.printStackTrace()
+          logError("", ex)
           false
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->
Replacement of printStackTrace with Logging. Fixes #53.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
printStackTrace() outputs to only stderr

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes

Previous behavior
(a test exception from writeLog())
```
java.lang.Exception: test
        at com.microsoft.hyperspace.index.IndexLogManagerImpl.writeLog(IndexLogManager.scala:143)
        at com.microsoft.hyperspace.actions.Action$class.saveEntry(Action.scala:77)
        at com.microsoft.hyperspace.actions.Action$class.begin(Action.scala:52)
        at com.microsoft.hyperspace.actions.Action$class.run(Action.scala:86)
        at com.microsoft.hyperspace.actions.CreateAction.run(CreateAction.scala:27)
        at com.microsoft.hyperspace.index.IndexCollectionManager.create(IndexCollectionManager.scala:42)
        at com.microsoft.hyperspace.index.CachingIndexCollectionManager.create(CachingIndexCollectionManager.scala:77)
        at com.microsoft.hyperspace.Hyperspace.createIndex(Hyperspace.scala:41)
        at $line24.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:40)
        at $line24.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:45)
        at $line24.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:47)
        at $line24.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:49)
        at $line24.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:51)
        at $line24.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:53)
        at $line24.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:55)
        at $line24.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:57)
        at $line24.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:59)
        at $line24.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:61)
        at $line24.$read$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:63)
        at $line24.$read$$iw$$iw$$iw$$iw$$iw.<init>(<console>:65)
        at $line24.$read$$iw$$iw$$iw$$iw.<init>(<console>:67)
        at $line24.$read$$iw$$iw$$iw.<init>(<console>:69)
        at $line24.$read$$iw$$iw.<init>(<console>:71)
        at $line24.$read$$iw.<init>(<console>:73)
        at $line24.$read.<init>(<console>:75)
        at $line24.$read$.<init>(<console>:79)
        at $line24.$read$.<clinit>(<console>)
        at $line24.$eval$.$print$lzycompute(<console>:7)
        at $line24.$eval$.$print(<console>:6)
        at $line24.$eval.$print(<console>)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.call(IMain.scala:793)
        at scala.tools.nsc.interpreter.IMain$Request.loadAndRun(IMain.scala:1054)
        at scala.tools.nsc.interpreter.IMain$WrappedRequest$$anonfun$loadAndRunReq$1.apply(IMain.scala:645)
        at scala.tools.nsc.interpreter.IMain$WrappedRequest$$anonfun$loadAndRunReq$1.apply(IMain.scala:644)
        at scala.reflect.internal.util.ScalaClassLoader$class.asContext(ScalaClassLoader.scala:31)
        at scala.reflect.internal.util.AbstractFileClassLoader.asContext(AbstractFileClassLoader.scala:19)
        at scala.tools.nsc.interpreter.IMain$WrappedRequest.loadAndRunReq(IMain.scala:644)
        at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:576)
        at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:572)
        at scala.tools.nsc.interpreter.ILoop.interpretStartingWith(ILoop.scala:819)
        at scala.tools.nsc.interpreter.ILoop.command(ILoop.scala:691)
        at scala.tools.nsc.interpreter.ILoop.processLine(ILoop.scala:404)
        at scala.tools.nsc.interpreter.ILoop.loop(ILoop.scala:425)
        at org.apache.spark.repl.SparkILoop$$anonfun$process$1.apply$mcZ$sp(SparkILoop.scala:285)
        at org.apache.spark.repl.SparkILoop.runClosure(SparkILoop.scala:159)
        at org.apache.spark.repl.SparkILoop.process(SparkILoop.scala:182)
        at org.apache.spark.repl.Main$.doMain(Main.scala:78)
        at org.apache.spark.repl.Main$.main(Main.scala:58)
        at org.apache.spark.repl.Main.main(Main.scala)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
        at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:845)
        at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:161)
        at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:184)
        at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:86)
        at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:920)
        at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:929)
        at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)

```

With fix
```
20/07/14 09:05:01 ERROR IndexLogManagerImpl: 
java.lang.Exception: test
        at com.microsoft.hyperspace.index.IndexLogManagerImpl.writeLog(IndexLogManager.scala:143)
        at com.microsoft.hyperspace.actions.Action$class.saveEntry(Action.scala:77)
        at com.microsoft.hyperspace.actions.Action$class.begin(Action.scala:52)
        at com.microsoft.hyperspace.actions.Action$class.run(Action.scala:86)
<same stack>
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
with a test exception as above