### PR TITLE
Remove duplicate setups in tests

### DIFF
--- a/src/test/scala/com/microsoft/hyperspace/HyperspaceTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/HyperspaceTests.scala
@@ -23,10 +23,10 @@ import com.microsoft.hyperspace.index.{HyperspaceSuite, IndexConfig, IndexConsta
 import com.microsoft.hyperspace.util.FileUtils
 
 class HyperspaceTests extends HyperspaceSuite {
+  override val systemPath = new Path("src/test/resources/indexLocation")
 
   private val sampleData = SampleData.testData
   private val sampleParquetDataLocation = "src/test/resources/sampleparquet"
-  private val indexSystemPath = "src/test/resources/indexLocation"
   private val indexConfig1 = IndexConfig("index1", Seq("RGUID"), Seq("Date"))
   private val indexConfig2 = IndexConfig("index2", Seq("Query"), Seq("imprs"))
   private var df: DataFrame = _
@@ -38,14 +38,12 @@ class HyperspaceTests extends HyperspaceSuite {
     val sparkSession = spark
     import sparkSession.implicits._
     hyperspace = new Hyperspace(sparkSession)
-    FileUtils.delete(new Path(indexSystemPath))
     FileUtils.delete(new Path(sampleParquetDataLocation))
 
     val dfFromSample = sampleData.toDF("Date", "RGUID", "Query", "imprs", "clicks")
     dfFromSample.write.parquet(sampleParquetDataLocation)
 
     df = spark.read.parquet(sampleParquetDataLocation)
-    spark.conf.set(IndexConstants.INDEX_SYSTEM_PATH, indexSystemPath)
   }
 
   override def afterAll(): Unit = {
@@ -55,7 +53,7 @@ class HyperspaceTests extends HyperspaceSuite {
 
   after {
     clearCache()
-    FileUtils.delete(new Path(indexSystemPath))
+    FileUtils.delete(systemPath)
   }
 
   test(

--- a/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
@@ -26,25 +26,21 @@ import com.microsoft.hyperspace.{Hyperspace, Implicits, SampleData}
 import com.microsoft.hyperspace.index.rules.{FilterIndexRule, JoinIndexRule}
 
 class E2EHyperspaceRulesTests extends HyperspaceSuite {
-
   private val sampleData = SampleData.testData
   private val testDir = "src/test/resources/e2eTests/"
   private val sampleParquetDataLocation = testDir + "sampleparquet"
-  private val indexStorageLocation = testDir + "indexLocation"
+  override val systemPath = new Path(testDir + "indexLocation")
   private val fileSystem = new Path(sampleParquetDataLocation).getFileSystem(new Configuration)
   private var hyperspace: Hyperspace = _
 
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    val sparkSession = spark
-    spark.conf.set(IndexConstants.INDEX_SYSTEM_PATH, indexStorageLocation)
     spark.conf.set("spark.sql.autoBroadcastJoinThreshold", -1)
 
-    import sparkSession.implicits._
-    hyperspace = new Hyperspace(sparkSession)
+    import spark.implicits._
+    hyperspace = new Hyperspace(spark)
 
-    fileSystem.delete(new Path(indexStorageLocation), true)
     fileSystem.delete(new Path(sampleParquetDataLocation), true)
 
     val dfFromSample = sampleData.toDF("c1", "c2", "c3", "c4", "c5")
@@ -62,7 +58,7 @@ class E2EHyperspaceRulesTests extends HyperspaceSuite {
   }
 
   after {
-    fileSystem.delete(new Path(indexStorageLocation), true)
+    fileSystem.delete(systemPath, true)
     spark.disableHyperspace()
   }
 
@@ -311,9 +307,7 @@ class E2EHyperspaceRulesTests extends HyperspaceSuite {
   }
 
   private def getIndexFilesPath(indexName: String): Path = {
-    new Path(
-      indexStorageLocation,
-      s"$indexName/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0")
+    new Path(systemPath, s"$indexName/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0")
   }
 
   /**

--- a/src/test/scala/com/microsoft/hyperspace/index/HyperspaceSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HyperspaceSuite.scala
@@ -16,18 +16,28 @@
 
 package com.microsoft.hyperspace.index
 
+import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkFunSuite
 
 import com.microsoft.hyperspace.{Hyperspace, SparkInvolvedSuite}
+import com.microsoft.hyperspace.util.FileUtils
 
 trait HyperspaceSuite extends SparkFunSuite with SparkInvolvedSuite {
+  // This is the system path that PathResolver uses to get the root of the indexes.
+  // Each test suite that extends HyperspaceSuite should define this.
+  val systemPath: Path
+
   override def beforeAll(): Unit = {
     super.beforeAll()
+    FileUtils.delete(systemPath)
+    spark.conf.set(IndexConstants.INDEX_SYSTEM_PATH, systemPath.toUri.toString)
     clearCache()
   }
 
   override def afterAll(): Unit = {
     clearCache()
+    spark.conf.unset(IndexConstants.INDEX_SYSTEM_PATH)
+    FileUtils.delete(systemPath)
     super.afterAll()
   }
 

--- a/src/test/scala/com/microsoft/hyperspace/index/plananalysis/ExplainTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/plananalysis/ExplainTest.scala
@@ -27,7 +27,7 @@ import com.microsoft.hyperspace.index.{HyperspaceSuite, IndexConfig, IndexConsta
 
 class ExplainTest extends SparkFunSuite with HyperspaceSuite {
   private val sampleParquetDataLocation = "src/test/resources/sampleparquet"
-  private val indexStorageLocation = "src/test/resources/indexLocation"
+  override val systemPath = new Path("src/test/resources/indexLocation")
   private val fileSystem = new Path(sampleParquetDataLocation).getFileSystem(new Configuration)
   private var sampleParquetDataFullPath: String = ""
   private var hyperspace: Hyperspace = _
@@ -35,12 +35,10 @@ class ExplainTest extends SparkFunSuite with HyperspaceSuite {
   override def beforeAll(): Unit = {
     super.beforeAll()
     val sparkSession = spark
-    spark.conf.set(IndexConstants.INDEX_SYSTEM_PATH, indexStorageLocation)
     spark.conf.set("spark.sql.autoBroadcastJoinThreshold", -1)
 
     import sparkSession.implicits._
     hyperspace = new Hyperspace(sparkSession)
-    fileSystem.delete(new Path(indexStorageLocation), true)
     fileSystem.delete(new Path(sampleParquetDataLocation), true)
     val sampleData = Seq(("data1", 1), ("data2", 2), ("data3", 3))
     val dfFromSample = sampleData.toDF("Col1", "Col2")
@@ -56,7 +54,7 @@ class ExplainTest extends SparkFunSuite with HyperspaceSuite {
 
   after {
     clearCache()
-    fileSystem.delete(new Path(indexStorageLocation), true)
+    fileSystem.delete(systemPath, true)
     spark.conf.unset(IndexConstants.DISPLAY_MODE)
     spark.conf.unset(IndexConstants.HIGHLIGHT_BEGIN_TAG)
     spark.conf.unset(IndexConstants.HIGHLIGHT_END_TAG)
@@ -521,7 +519,7 @@ class ExplainTest extends SparkFunSuite with HyperspaceSuite {
   }
 
   private def getIndexFilesPath(indexName: String): Path = {
-    new Path(indexStorageLocation, s"$indexName/v__=0")
+    new Path(systemPath, s"$indexName/v__=0")
   }
 
   private def verifyExplainOutput(df: DataFrame, expected: String, verbose: Boolean)(

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/FilterIndexRuleTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/FilterIndexRuleTest.scala
@@ -30,10 +30,7 @@ import com.microsoft.hyperspace.index.serde.LogicalPlanSerDeUtils
 import com.microsoft.hyperspace.util.FileUtils
 
 class FilterIndexRuleTest extends HyperspaceSuite {
-  val originalLocation = new Path("baseTableLocation")
-  val parentPath = new Path("src/test/resources/filterIndexTest")
-  val systemPath = new Path(parentPath, "systemPath")
-
+  override val systemPath = new Path("src/test/resources/joinIndexTest")
   val indexName = "filterIxTestIndex"
 
   val c1 = AttributeReference("c1", StringType)()
@@ -46,10 +43,8 @@ class FilterIndexRuleTest extends HyperspaceSuite {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    FileUtils.delete(parentPath)
 
-    spark.conf.set(IndexConstants.INDEX_SYSTEM_PATH, systemPath.toUri.toString)
-
+    val originalLocation = new Path("baseTableLocation")
     val tableLocation =
       new InMemoryFileIndex(spark, Seq(originalLocation), Map.empty, Some(tableSchema), NoopCache)
     val relation = baseRelation(tableLocation, tableSchema)
@@ -95,13 +90,7 @@ class FilterIndexRuleTest extends HyperspaceSuite {
   }
 
   before {
-    spark.conf.set(IndexConstants.INDEX_SYSTEM_PATH, systemPath.toUri.toString)
     clearCache()
-  }
-
-  override def afterAll(): Unit = {
-    FileUtils.delete(parentPath)
-    super.afterAll()
   }
 
   test("Verify FilterIndex rule is applied correctly.") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->
While reviewing #89, I noticed that it would be helpful to move the logic to set the system path to `HyperspaceSuite` so that the test suites that extend it can just define `systemPath` and not worry about setting the spark conf or cleaning up the directory.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To clean up some duplicate logic for setting system path.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing tests.