### PR TITLE
Replace LogicalPlanSerDeUtils

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateAction.scala
@@ -36,7 +36,7 @@ class CreateAction(
     extends CreateActionBase(dataManager)
     with Action {
   final override lazy val logEntry: LogEntry =
-    getIndexLogEntry(spark, df, indexConfig, indexDataPath, sourceFiles(df))
+    getIndexLogEntry(spark, df, indexConfig, indexDataPath)
 
   final override val transientState: String = CREATING
 

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -57,7 +57,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
     signatureProvider.signature(df.queryExecution.optimizedPlan) match {
       case Some(s) =>
         val relations = sourceRelations(df)
-        // Currently we only support to create an index on a LogicalRelation
+        // Currently we only support to create an index on a LogicalRelation.
         assert(relations.size == 1)
 
         val sourcePlanProperties = SparkPlan.Properties(

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -16,6 +16,8 @@
 
 package com.microsoft.hyperspace.actions
 
+import java.util.Locale
+
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation, PartitioningAwareFileIndex}
@@ -91,7 +93,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
           location.rootPaths.map(_.toString),
           location.allFiles.map(_.getPath.toString),
           dataSchema.json,
-          fileFormat.toString)
+          fileFormat.toString.toLowerCase(Locale.ROOT))
     }
 
   protected def write(spark: SparkSession, df: DataFrame, indexConfig: IndexConfig): Unit = {

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -93,20 +93,20 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
   protected def sourceFiles(df: DataFrame): Seq[String] =
     df.queryExecution.optimizedPlan.collect {
       case LogicalRelation(
-      HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _),
-      _,
-      _,
-      _) =>
-      location.allFiles.map(_.getPath.toString)
+          HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _),
+          _,
+          _,
+          _) =>
+        location.allFiles.map(_.getPath.toString)
     }.flatten
 
   protected def sourceRelations(df: DataFrame): Seq[RelationMetadataEntry] =
     df.queryExecution.optimizedPlan.collect {
       case LogicalRelation(
-      HadoopFsRelation(location: PartitioningAwareFileIndex, _, dataSchema, _, fileFormat, _),
-      _,
-      _,
-      _) =>
+          HadoopFsRelation(location: PartitioningAwareFileIndex, _, dataSchema, _, fileFormat, _),
+          _,
+          _,
+          _) =>
         RelationMetadataEntry(
           location.allFiles.map(_.getPath.toString),
           dataSchema.json,

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -86,7 +86,13 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
   protected def sourceRelations(df: DataFrame): Seq[Relation] =
     df.queryExecution.optimizedPlan.collect {
       case LogicalRelation(
-          HadoopFsRelation(location: PartitioningAwareFileIndex, _, dataSchema, _, fileFormat, _),
+          HadoopFsRelation(
+            location: PartitioningAwareFileIndex,
+            _,
+            dataSchema,
+            _,
+            fileFormat,
+            options),
           _,
           _,
           _) =>
@@ -103,7 +109,8 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
           location.rootPaths.map(_.toString),
           Hdfs(sourceDataProperties),
           dataSchema.json,
-          fileFormatName)
+          fileFormatName,
+          options)
     }
 
   protected def write(spark: SparkSession, df: DataFrame, indexConfig: IndexConfig): Unit = {

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
@@ -44,9 +44,11 @@ class RefreshAction(
 
   // Reconstruct a df from schema
   private lazy val df = {
-    val rel = previousIndexLogEntry.relation
-    val dataSchema = DataType.fromJson(rel.dataSchemaJson).asInstanceOf[StructType]
-    spark.read.schema(dataSchema).format(rel.fileFormat).load(rel.rootPaths: _*)
+    val rels = previousIndexLogEntry.relations
+    // Currently we only support to create an index on a LogicalRelation
+    assert(rels.size == 1)
+    val dataSchema = DataType.fromJson(rels.head.dataSchemaJson).asInstanceOf[StructType]
+    spark.read.schema(dataSchema).format(rels.head.fileFormat).load(rels.head.rootPaths: _*)
   }
 
   private lazy val indexConfig: IndexConfig = {

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
@@ -45,10 +45,10 @@ class RefreshAction(
   // Reconstruct a df from schema
   private lazy val df = {
     val rels = previousIndexLogEntry.relations
-    // Currently we only support to create an index on a LogicalRelation
+    // Currently we only support to create an index on a LogicalRelation.
     assert(rels.size == 1)
     val dataSchema = DataType.fromJson(rels.head.dataSchemaJson).asInstanceOf[StructType]
-    // "path" key in options incurs to read data twice unexpectedly
+    // "path" key in options incurs to read data twice unexpectedly.
     val opts = rels.head.options - "path"
     spark.read
       .schema(dataSchema)

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
@@ -48,7 +48,13 @@ class RefreshAction(
     // Currently we only support to create an index on a LogicalRelation
     assert(rels.size == 1)
     val dataSchema = DataType.fromJson(rels.head.dataSchemaJson).asInstanceOf[StructType]
-    spark.read.schema(dataSchema).format(rels.head.fileFormat).load(rels.head.rootPaths: _*)
+    // "path" key in options incurs to read data twice unexpectedly
+    val opts = rels.head.options - "path"
+    spark.read
+      .schema(dataSchema)
+      .format(rels.head.fileFormat)
+      .options(opts)
+      .load(rels.head.rootPaths: _*)
   }
 
   private lazy val indexConfig: IndexConfig = {

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
@@ -46,7 +46,7 @@ class RefreshAction(
   private lazy val df = {
     val rel = previousIndexLogEntry.relation
     val dataSchema = DataType.fromJson(rel.dataSchemaJson).asInstanceOf[StructType]
-    spark.read.schema(dataSchema).load(rel.rootPaths: _*)
+    spark.read.schema(dataSchema).format(rel.fileFormat).load(rel.rootPaths: _*)
   }
 
   private lazy val indexConfig: IndexConfig = {

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
@@ -168,7 +168,7 @@ private[hyperspace] object IndexSummary {
       entry.numBuckets,
       entry.derivedDataset.properties.schemaString,
       entry.content.root,
-      entry.plan(spark).toString,
+      entry.derivedDataset.properties.schemaString, // TODO
       entry.state)
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
@@ -146,7 +146,6 @@ object IndexCollectionManager {
  * @param numBuckets number of buckets
  * @param schema index schema json
  * @param indexLocation index location
- * @param queryPlan original dataframe query plan on which this index is built
  * @param state index state
  */
 private[hyperspace] case class IndexSummary(
@@ -156,7 +155,6 @@ private[hyperspace] case class IndexSummary(
     numBuckets: Int,
     schema: String,
     indexLocation: String,
-    queryPlan: String,
     state: String)
 
 private[hyperspace] object IndexSummary {
@@ -168,7 +166,6 @@ private[hyperspace] object IndexSummary {
       entry.numBuckets,
       entry.derivedDataset.properties.schemaString,
       entry.content.root,
-      entry.derivedDataset.properties.schemaString, // TODO
       entry.state)
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -102,6 +102,8 @@ case class IndexLogEntry(
 
   def includedColumns: Seq[String] = derivedDataset.properties.columns.included
 
+  def numBuckets: Int = derivedDataset.properties.numBuckets
+
   def relation: RelationMetadataEntry = {
     source.data(0).properties.content.directories(0) match {
       case dir: Directory =>
@@ -111,8 +113,6 @@ case class IndexLogEntry(
       case _ => throw HyperspaceException("Index relation info not found")
     }
   }
-
-  def numBuckets: Int = derivedDataset.properties.numBuckets
 
   def config: IndexConfig = IndexConfig(name, indexedColumns, includedColumns)
 

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -67,7 +67,8 @@ case class Relation(
     rootPaths: Seq[String],
     data: Hdfs,
     dataSchemaJson: String,
-    fileFormat: String)
+    fileFormat: String,
+    options: Map[String, String])
 
 // IndexLogEntry-specific SparkPlan that represents the source plan.
 case class SparkPlan(properties: SparkPlan.Properties) {

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -20,7 +20,6 @@ import org.apache.spark.sql.types.{DataType, StructType}
 
 import com.microsoft.hyperspace.HyperspaceException
 import com.microsoft.hyperspace.actions.Constants
-import com.microsoft.hyperspace.index.Content.Directory
 
 // IndexLogEntry-specific fingerprint to be temporarily used where fingerprint is not defined.
 case class NoOpFingerprint() {
@@ -37,10 +36,7 @@ case class RelationMetadataEntry(
 // IndexLogEntry-specific Content that uses IndexLogEntry-specific fingerprint.
 case class Content(root: String, directories: Seq[Content.Directory])
 object Content {
-  case class Directory(
-      path: String,
-      files: Seq[String],
-      fingerprint: NoOpFingerprint)
+  case class Directory(path: String, files: Seq[String], fingerprint: NoOpFingerprint)
 }
 
 // IndexLogEntry-specific CoveringIndex that represents derived dataset.

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -101,7 +101,7 @@ case class IndexLogEntry(
   def relation: Option[RelationMetadataEntry] = {
     source.data(0).properties.content.directories(0) match {
       case dir: Directory =>
-        // Currently we only support to create an index on LogicalRelation
+        // Currently we only support to create an index on a LogicalRelation
         assert(dir.relations.size == 1)
         Some(dir.relations(0))
       case null => None

--- a/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
@@ -66,7 +66,8 @@ object LogicalPlanSerDeUtils {
 
     // Read binary data objects back and covert to logical plan.
     val bytes = Base64.getDecoder.decode(serializedPlan)
-    val deserializedPlan = KryoSerDeUtils.deserialize[LogicalPlan](kryoSerializer, bytes)
+    val deserializedPlan = KryoSerDeUtils.deserialize[LogicalRelationWrapper](
+      kryoSerializer, bytes)
 
     // Restore non-serializable operators/expressions from their corresponding wrappers.
     restore(deserializedPlan, spark)

--- a/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/serde/LogicalPlanSerDeUtils.scala
@@ -66,8 +66,7 @@ object LogicalPlanSerDeUtils {
 
     // Read binary data objects back and covert to logical plan.
     val bytes = Base64.getDecoder.decode(serializedPlan)
-    val deserializedPlan = KryoSerDeUtils.deserialize[LogicalRelationWrapper](
-      kryoSerializer, bytes)
+    val deserializedPlan = KryoSerDeUtils.deserialize[LogicalPlan](kryoSerializer, bytes)
 
     // Restore non-serializable operators/expressions from their corresponding wrappers.
     restore(deserializedPlan, spark)

--- a/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
@@ -55,10 +55,11 @@ class RefreshActionTest extends SparkFunSuite with SparkInvolvedSuite {
 
   def testEntry(df: DataFrame): IndexLogEntry = {
     val sourcePlanProperties = SparkPlan.Properties(
+      Seq(),
+      null,
+      null,
       LogicalPlanFingerprint(
         LogicalPlanFingerprint.Properties(Seq(Signature("signatureProvider", "dfSignature")))))
-    val sourceDataProperties =
-      Hdfs.Properties(Content("", Seq(Content.Directory("", Seq(), NoOpFingerprint()))))
 
     val entry = IndexLogEntry(
       "index1",
@@ -69,7 +70,7 @@ class RefreshActionTest extends SparkFunSuite with SparkInvolvedSuite {
           "schema",
           10)),
       Content("dirPath", Seq()),
-      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
+      Source(SparkPlan(sourcePlanProperties)),
       Map())
     entry.state = Constants.States.ACTIVE
     entry

--- a/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
@@ -26,7 +26,6 @@ import org.mockito.Mockito.{mock, when}
 import com.microsoft.hyperspace.{HyperspaceException, SampleData, SparkInvolvedSuite}
 import com.microsoft.hyperspace.actions.Constants.States.{ACTIVE, CREATING}
 import com.microsoft.hyperspace.index._
-import com.microsoft.hyperspace.index.serde.LogicalPlanSerDeUtils
 
 class RefreshActionTest extends SparkFunSuite with SparkInvolvedSuite {
   private val sampleParquetDataLocation = "src/test/resources/sampleparquet"
@@ -55,9 +54,7 @@ class RefreshActionTest extends SparkFunSuite with SparkInvolvedSuite {
   }
 
   def testEntry(df: DataFrame): IndexLogEntry = {
-    val serializedPlan = LogicalPlanSerDeUtils.serialize(df.queryExecution.logical, spark)
     val sourcePlanProperties = SparkPlan.Properties(
-      serializedPlan,
       LogicalPlanFingerprint(
         LogicalPlanFingerprint.Properties(Seq(Signature("signatureProvider", "dfSignature")))))
     val sourceDataProperties =

--- a/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
@@ -69,7 +69,7 @@ class RefreshActionTest extends SparkFunSuite with SparkInvolvedSuite {
           "schema",
           10)),
       Content("dirPath", Seq()),
-      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties))),
+      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
       Map())
     entry.state = Constants.States.ACTIVE
     entry

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexCacheTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexCacheTest.scala
@@ -62,7 +62,7 @@ class IndexCacheTest extends SparkFunSuite with SparkInvolvedSuite {
           IndexLogEntry.schemaString(schema),
           10)),
       Content(indexDir, Seq()),
-      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties))),
+      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
       Map())
     entry.state = Constants.States.ACTIVE
     entry

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexCacheTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexCacheTest.scala
@@ -48,10 +48,11 @@ class IndexCacheTest extends SparkFunSuite with SparkInvolvedSuite {
       schema: StructType,
       indexDir: String): IndexLogEntry = {
     val sourcePlanProperties = SparkPlan.Properties(
+      Seq(),
+      null,
+      null,
       LogicalPlanFingerprint(
         LogicalPlanFingerprint.Properties(Seq(Signature("signatureProvider", "dfSignature")))))
-    val sourceDataProperties =
-      Hdfs.Properties(Content("", Seq(Content.Directory("", Seq(), NoOpFingerprint()))))
 
     val entry = IndexLogEntry(
       "index1",
@@ -62,7 +63,7 @@ class IndexCacheTest extends SparkFunSuite with SparkInvolvedSuite {
           IndexLogEntry.schemaString(schema),
           10)),
       Content(indexDir, Seq()),
-      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
+      Source(SparkPlan(sourcePlanProperties)),
       Map())
     entry.state = Constants.States.ACTIVE
     entry

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexCacheTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexCacheTest.scala
@@ -48,7 +48,6 @@ class IndexCacheTest extends SparkFunSuite with SparkInvolvedSuite {
       schema: StructType,
       indexDir: String): IndexLogEntry = {
     val sourcePlanProperties = SparkPlan.Properties(
-      "plan",
       LogicalPlanFingerprint(
         LogicalPlanFingerprint.Properties(Seq(Signature("signatureProvider", "dfSignature")))))
     val sourceDataProperties =

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
@@ -39,9 +39,10 @@ class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
 
         private val testLogEntry: IndexLogEntry = {
           val sourcePlanProperties = SparkPlan.Properties(
+            Seq(),
+            null,
+            null,
             LogicalPlanFingerprint(LogicalPlanFingerprint.Properties(Seq(Signature("", "")))))
-          val sourceDataProperties =
-            Hdfs.Properties(Content("", Seq(Content.Directory("", Seq(), NoOpFingerprint()))))
 
           val entry = IndexLogEntry(
             indexPath.toString,
@@ -52,7 +53,7 @@ class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
                 "",
                 10)),
             Content(s"$indexPath/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0", Seq()),
-            Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
+            Source(SparkPlan(sourcePlanProperties)),
             Map())
           entry.state = Constants.States.ACTIVE
           entry
@@ -90,9 +91,10 @@ class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
 
     def toIndex(str: String): IndexLogEntry = {
       val sourcePlanProperties = SparkPlan.Properties(
+        Seq(),
+        null,
+        null,
         LogicalPlanFingerprint(LogicalPlanFingerprint.Properties(Seq(Signature("", "")))))
-      val sourceDataProperties =
-        Hdfs.Properties(Content("", Seq(Content.Directory("", Seq(), NoOpFingerprint()))))
 
       val entry = IndexLogEntry(
         str,
@@ -103,7 +105,7 @@ class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
             "",
             10)),
         Content(s"$str/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0", Seq()),
-        Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
+        Source(SparkPlan(sourcePlanProperties)),
         Map())
       entry.state = Constants.States.ACTIVE
       entry

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
@@ -53,7 +53,7 @@ class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
                 "",
                 10)),
             Content(s"$indexPath/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0", Seq()),
-            Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties))),
+            Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
             Map())
           entry.state = Constants.States.ACTIVE
           entry
@@ -104,7 +104,7 @@ class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
             "",
             10)),
         Content(s"$str/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0", Seq()),
-        Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties))),
+        Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
         Map())
       entry.state = Constants.States.ACTIVE
       entry

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
@@ -41,8 +41,7 @@ class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
           val sourcePlanProperties = SparkPlan.Properties(
             LogicalPlanFingerprint(LogicalPlanFingerprint.Properties(Seq(Signature("", "")))))
           val sourceDataProperties =
-            Hdfs.Properties(
-              Content("", Seq(Content.Directory("", Seq(), NoOpFingerprint()))))
+            Hdfs.Properties(Content("", Seq(Content.Directory("", Seq(), NoOpFingerprint()))))
 
           val entry = IndexLogEntry(
             indexPath.toString,

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
@@ -39,10 +39,10 @@ class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
 
         private val testLogEntry: IndexLogEntry = {
           val sourcePlanProperties = SparkPlan.Properties(
-            "",
             LogicalPlanFingerprint(LogicalPlanFingerprint.Properties(Seq(Signature("", "")))))
           val sourceDataProperties =
-            Hdfs.Properties(Content("", Seq(Content.Directory("", Seq(), NoOpFingerprint()))))
+            Hdfs.Properties(
+              Content("", Seq(Content.Directory("", Seq(), NoOpFingerprint()))))
 
           val entry = IndexLogEntry(
             indexPath.toString,
@@ -91,7 +91,6 @@ class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
 
     def toIndex(str: String): IndexLogEntry = {
       val sourcePlanProperties = SparkPlan.Properties(
-        "",
         LogicalPlanFingerprint(LogicalPlanFingerprint.Properties(Seq(Signature("", "")))))
       val sourceDataProperties =
         Hdfs.Properties(Content("", Seq(Content.Directory("", Seq(), NoOpFingerprint()))))

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -53,7 +53,6 @@ class IndexLogEntryTest extends SparkFunSuite {
         |    "plan" : {
         |      "kind" : "Spark",
         |      "properties" : {
-        |        "rawPlan" : "planString",
         |        "fingerprint" : {
         |          "kind" : "LogicalPlan",
         |          "properties" : {
@@ -72,7 +71,12 @@ class IndexLogEntryTest extends SparkFunSuite {
         |          "root" : "",
         |          "directories" : [ {
         |            "path" : "",
-        |            "files" : [ "f1", "f2" ],
+        |            "relations" : [ {
+        |              "rootPaths" : [ "rootpath" ],
+        |              "files": [ "f1", "f2" ],
+        |              "dataSchemaJson" : "schema",
+        |              "fileFormat" : "type"
+        |             } ],
         |            "fingerprint" : {
         |              "kind" : "NoOp",
         |              "properties" : { }
@@ -96,11 +100,18 @@ class IndexLogEntryTest extends SparkFunSuite {
     val actual = JsonUtils.fromJson[IndexLogEntry](jsonString)
 
     val expectedSourcePlanProperties = SparkPlan.Properties(
-      "planString",
       LogicalPlanFingerprint(
         LogicalPlanFingerprint.Properties(Seq(Signature("provider", "signatureValue")))))
     val expectedSourceDataProperties =
-      Hdfs.Properties(Content("", Seq(Content.Directory("", Seq("f1", "f2"), NoOpFingerprint()))))
+      Hdfs.Properties(
+        Content(
+          "",
+          Seq(
+            Content.Directory(
+              "",
+              Seq(RelationMetadataEntry(Seq("rootpath"), Seq("f1", "f2"), "schema", "type")),
+              NoOpFingerprint()))))
+
     val expected = IndexLogEntry(
       "indexName",
       CoveringIndex(

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -102,13 +102,13 @@ class IndexLogEntryTest extends SparkFunSuite {
     val actual = JsonUtils.fromJson[IndexLogEntry](jsonString)
 
     val expectedSourcePlanProperties = SparkPlan.Properties(
-      Seq(Relation(
-        Seq("rootpath"),
-        Hdfs(
-          Hdfs.Properties(
+      Seq(
+        Relation(
+          Seq("rootpath"),
+          Hdfs(Hdfs.Properties(
             Content("", Seq(Content.Directory("", Seq("f1", "f2"), NoOpFingerprint()))))),
-        "schema",
-        "type")),
+          "schema",
+          "type")),
       null,
       null,
       LogicalPlanFingerprint(
@@ -123,8 +123,7 @@ class IndexLogEntryTest extends SparkFunSuite {
           schema.json,
           200)),
       Content("rootContentPath", Seq()),
-      Source(
-        SparkPlan(expectedSourcePlanProperties)),
+      Source(SparkPlan(expectedSourcePlanProperties)),
       Map())
     expected.state = "ACTIVE"
     expected.timestamp = 1578818514080L

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -53,6 +53,29 @@ class IndexLogEntryTest extends SparkFunSuite {
         |    "plan" : {
         |      "kind" : "Spark",
         |      "properties" : {
+        |        "relations" : [ {
+        |          "rootPaths" : [ "rootpath" ],
+        |          "data" : {
+        |            "kind" : "HDFS",
+        |            "properties" : {
+        |              "content" : {
+        |                "root" : "",
+        |                "directories" : [ {
+        |                  "path" : "",
+        |                  "files" : [ "f1", "f2" ],
+        |                  "fingerprint" : {
+        |                    "kind" : "NoOp",
+        |                    "properties" : { }
+        |                  }
+        |                } ]
+        |              }
+        |            }
+        |          },
+        |          "dataSchemaJson" : "schema",
+        |          "fileFormat" : "type"
+        |          } ],
+        |        "rawPlan" : null,
+        |        "sql" : null,
         |        "fingerprint" : {
         |          "kind" : "LogicalPlan",
         |          "properties" : {
@@ -63,29 +86,7 @@ class IndexLogEntryTest extends SparkFunSuite {
         |          }
         |        }
         |      }
-        |    },
-        |    "data" : [ {
-        |      "kind" : "HDFS",
-        |      "properties" : {
-        |        "content" : {
-        |          "root" : "",
-        |          "directories" : [ {
-        |            "path" : "",
-        |            "files" : [ "f1", "f2" ],
-        |            "fingerprint" : {
-        |              "kind" : "NoOp",
-        |              "properties" : { }
-        |            }
-        |          } ]
-        |        }
-        |      }
-        |    } ],
-        |    "relations" : [ {
-        |      "rootPaths" : [ "rootpath" ],
-        |      "files" : [ "f1", "f2" ],
-        |      "dataSchemaJson" : "schema",
-        |      "fileFormat" : "type"
-        |      } ]
+        |    }
         |  },
         |  "extra" : { },
         |  "version" : "0.1",
@@ -101,10 +102,17 @@ class IndexLogEntryTest extends SparkFunSuite {
     val actual = JsonUtils.fromJson[IndexLogEntry](jsonString)
 
     val expectedSourcePlanProperties = SparkPlan.Properties(
+      Seq(Relation(
+        Seq("rootpath"),
+        Hdfs(
+          Hdfs.Properties(
+            Content("", Seq(Content.Directory("", Seq("f1", "f2"), NoOpFingerprint()))))),
+        "schema",
+        "type")),
+      null,
+      null,
       LogicalPlanFingerprint(
         LogicalPlanFingerprint.Properties(Seq(Signature("provider", "signatureValue")))))
-    val expectedSourceDataProperties =
-      Hdfs.Properties(Content("", Seq(Content.Directory("", Seq("f1", "f2"), NoOpFingerprint()))))
 
     val expected = IndexLogEntry(
       "indexName",
@@ -116,9 +124,7 @@ class IndexLogEntryTest extends SparkFunSuite {
           200)),
       Content("rootContentPath", Seq()),
       Source(
-        SparkPlan(expectedSourcePlanProperties),
-        Seq(Hdfs(expectedSourceDataProperties)),
-        Seq(RelationMetadataEntry(Seq("rootpath"), Seq("f1", "f2"), "schema", "type"))),
+        SparkPlan(expectedSourcePlanProperties)),
       Map())
     expected.state = "ACTIVE"
     expected.timestamp = 1578818514080L

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -104,8 +104,7 @@ class IndexLogEntryTest extends SparkFunSuite {
       LogicalPlanFingerprint(
         LogicalPlanFingerprint.Properties(Seq(Signature("provider", "signatureValue")))))
     val expectedSourceDataProperties =
-      Hdfs.Properties(
-        Content("", Seq(Content.Directory("", Seq("f1", "f2"), NoOpFingerprint()))))
+      Hdfs.Properties(Content("", Seq(Content.Directory("", Seq("f1", "f2"), NoOpFingerprint()))))
 
     val expected = IndexLogEntry(
       "indexName",

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -71,12 +71,7 @@ class IndexLogEntryTest extends SparkFunSuite {
         |          "root" : "",
         |          "directories" : [ {
         |            "path" : "",
-        |            "relations" : [ {
-        |              "rootPaths" : [ "rootpath" ],
-        |              "files": [ "f1", "f2" ],
-        |              "dataSchemaJson" : "schema",
-        |              "fileFormat" : "type"
-        |             } ],
+        |            "files": [ "f1", "f2" ],
         |            "fingerprint" : {
         |              "kind" : "NoOp",
         |              "properties" : { }
@@ -84,7 +79,13 @@ class IndexLogEntryTest extends SparkFunSuite {
         |          } ]
         |        }
         |      }
-        |    } ]
+        |    } ],
+        |    "relations" : [ {
+        |      "rootPaths" : [ "rootpath" ],
+        |      "files": [ "f1", "f2" ],
+        |      "dataSchemaJson" : "schema",
+        |      "fileFormat" : "type"
+        |      } ]
         |  },
         |  "extra" : { },
         |  "version" : "0.1",
@@ -109,7 +110,7 @@ class IndexLogEntryTest extends SparkFunSuite {
           Seq(
             Content.Directory(
               "",
-              Seq(RelationMetadataEntry(Seq("rootpath"), Seq("f1", "f2"), "schema", "type")),
+              Seq("f1", "f2"),
               NoOpFingerprint()))))
 
     val expected = IndexLogEntry(
@@ -121,7 +122,10 @@ class IndexLogEntryTest extends SparkFunSuite {
           schema.json,
           200)),
       Content("rootContentPath", Seq()),
-      Source(SparkPlan(expectedSourcePlanProperties), Seq(Hdfs(expectedSourceDataProperties))),
+      Source(
+        SparkPlan(expectedSourcePlanProperties),
+        Seq(Hdfs(expectedSourceDataProperties)),
+        Seq(RelationMetadataEntry(Seq("rootpath"), Seq("f1", "f2"), "schema", "type"))),
       Map())
     expected.state = "ACTIVE"
     expected.timestamp = 1578818514080L

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -55,6 +55,7 @@ class IndexLogEntryTest extends SparkFunSuite {
         |      "properties" : {
         |        "relations" : [ {
         |          "rootPaths" : [ "rootpath" ],
+        |          "options" : { },
         |          "data" : {
         |            "kind" : "HDFS",
         |            "properties" : {
@@ -108,7 +109,8 @@ class IndexLogEntryTest extends SparkFunSuite {
           Hdfs(Hdfs.Properties(
             Content("", Seq(Content.Directory("", Seq("f1", "f2"), NoOpFingerprint()))))),
           "schema",
-          "type")),
+          "type",
+          Map())),
       null,
       null,
       LogicalPlanFingerprint(

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -71,7 +71,7 @@ class IndexLogEntryTest extends SparkFunSuite {
         |          "root" : "",
         |          "directories" : [ {
         |            "path" : "",
-        |            "files": [ "f1", "f2" ],
+        |            "files" : [ "f1", "f2" ],
         |            "fingerprint" : {
         |              "kind" : "NoOp",
         |              "properties" : { }
@@ -82,7 +82,7 @@ class IndexLogEntryTest extends SparkFunSuite {
         |    } ],
         |    "relations" : [ {
         |      "rootPaths" : [ "rootpath" ],
-        |      "files": [ "f1", "f2" ],
+        |      "files" : [ "f1", "f2" ],
         |      "dataSchemaJson" : "schema",
         |      "fileFormat" : "type"
         |      } ]
@@ -105,13 +105,7 @@ class IndexLogEntryTest extends SparkFunSuite {
         LogicalPlanFingerprint.Properties(Seq(Signature("provider", "signatureValue")))))
     val expectedSourceDataProperties =
       Hdfs.Properties(
-        Content(
-          "",
-          Seq(
-            Content.Directory(
-              "",
-              Seq("f1", "f2"),
-              NoOpFingerprint()))))
+        Content("", Seq(Content.Directory("", Seq("f1", "f2"), NoOpFingerprint()))))
 
     val expected = IndexLogEntry(
       "indexName",

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
@@ -29,10 +29,6 @@ import com.microsoft.hyperspace.util.{FileUtils, JsonUtils}
 
 class IndexLogManagerImplTest extends SparkFunSuite with SparkInvolvedSuite with BeforeAndAfterAll {
 
-  def getRelMetaEntry(files: Seq[String]): RelationMetadataEntry = {
-    RelationMetadataEntry(Seq("rootpath"), files, "schema", "type")
-  }
-
   val testRoot = "src/test/resources/indexLogManagerTests"
   val sampleIndexLogEntry: IndexLogEntry = IndexLogEntry(
     "entityName",
@@ -44,10 +40,8 @@ class IndexLogManagerImplTest extends SparkFunSuite with SparkInvolvedSuite with
     Content(
       "/root/log",
       Seq(
-        Content.Directory(
-          "dir1", Seq(getRelMetaEntry(Seq("1.json", "2.json"))), NoOpFingerprint()),
-        Content.Directory(
-          "dir2", Seq(getRelMetaEntry(Seq("1.json", "2.json"))), NoOpFingerprint()))),
+        Content.Directory("dir1", Seq("1.json", "2.json"), NoOpFingerprint()),
+        Content.Directory("dir2", Seq("1.json", "2.json"), NoOpFingerprint()))),
     Source(
       SparkPlan(
         SparkPlan.Properties(
@@ -57,10 +51,10 @@ class IndexLogManagerImplTest extends SparkFunSuite with SparkInvolvedSuite with
         Hdfs(properties = Hdfs.Properties(content = Content(
           "/root/data",
           Seq(
-            Content.Directory(
-              "dir1", Seq(getRelMetaEntry(Seq("1.json", "2.json"))), NoOpFingerprint()),
-            Content.Directory(
-              "dir2", Seq(getRelMetaEntry(Seq("1.json", "2.json"))), NoOpFingerprint()))))))),
+            Content.Directory("dir1", Seq("1.json", "2.json"), NoOpFingerprint()),
+            Content.Directory("dir2", Seq("1.json", "2.json"), NoOpFingerprint())))))),
+      Seq(RelationMetadataEntry(Seq("rootpath"), Seq("1.json", "2.json"), "schema", "type"))
+    ),
     Map())
 
   private def getEntry(state: String): LogEntry = {

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
@@ -27,7 +27,10 @@ import com.microsoft.hyperspace.{SparkInvolvedSuite, TestUtils}
 import com.microsoft.hyperspace.index.IndexConstants.HYPERSPACE_LOG
 import com.microsoft.hyperspace.util.{FileUtils, JsonUtils}
 
-class IndexLogManagerImplTest extends SparkFunSuite with SparkInvolvedSuite with BeforeAndAfterAll {
+class IndexLogManagerImplTest
+    extends SparkFunSuite
+    with SparkInvolvedSuite
+    with BeforeAndAfterAll {
   val testRoot = "src/test/resources/indexLogManagerTests"
   val sampleIndexLogEntry: IndexLogEntry = IndexLogEntry(
     "entityName",
@@ -42,19 +45,20 @@ class IndexLogManagerImplTest extends SparkFunSuite with SparkInvolvedSuite with
         Content.Directory("dir1", Seq("1.json", "2.json"), NoOpFingerprint()),
         Content.Directory("dir2", Seq("1.json", "2.json"), NoOpFingerprint()))),
     Source(
-      SparkPlan(
-        SparkPlan.Properties(
-          Seq(Relation(Seq("rootpath"), Hdfs(properties = Hdfs.Properties(content = Content(
+      SparkPlan(SparkPlan.Properties(
+        Seq(Relation(
+          Seq("rootpath"),
+          Hdfs(properties = Hdfs.Properties(content = Content(
             "/root/data",
             Seq(
               Content.Directory("dir1", Seq("1.json", "2.json"), NoOpFingerprint()),
               Content.Directory("dir2", Seq("1.json", "2.json"), NoOpFingerprint()))))),
-            "schema",
-            "type")),
-          null,
-          null,
-          LogicalPlanFingerprint(
-            LogicalPlanFingerprint.Properties(Seq(Signature("provider", "signature"))))))),
+          "schema",
+          "type")),
+        null,
+        null,
+        LogicalPlanFingerprint(
+          LogicalPlanFingerprint.Properties(Seq(Signature("provider", "signature"))))))),
     Map())
 
   private def getEntry(state: String): LogEntry = {
@@ -147,7 +151,9 @@ class IndexLogManagerImplTest extends SparkFunSuite with SparkInvolvedSuite with
     val path = new Path(testRoot, UUID.randomUUID().toString)
     val fs = path.getFileSystem(new Configuration)
     FileUtils.createFile(
-      fs, new Path(path, s"$HYPERSPACE_LOG/0"), JsonUtils.toJson(getEntry("ACTIVE")))
+      fs,
+      new Path(path, s"$HYPERSPACE_LOG/0"),
+      JsonUtils.toJson(getEntry("ACTIVE")))
     val result = new IndexLogManagerImpl(path).createLatestStableLog(0)
     assert(result === true)
     assert(fs.exists(new Path(path, s"$HYPERSPACE_LOG/latestStable")))
@@ -157,7 +163,9 @@ class IndexLogManagerImplTest extends SparkFunSuite with SparkInvolvedSuite with
     val path = new Path(testRoot, UUID.randomUUID().toString)
     val fs = path.getFileSystem(new Configuration)
     FileUtils.createFile(
-      fs, new Path(path, s"$HYPERSPACE_LOG/0"), JsonUtils.toJson(getEntry("CANCELLING")))
+      fs,
+      new Path(path, s"$HYPERSPACE_LOG/0"),
+      JsonUtils.toJson(getEntry("CANCELLING")))
     val result = new IndexLogManagerImpl(path).createLatestStableLog(0)
     assert(result === false)
     assert(!fs.exists(new Path(path, s"$HYPERSPACE_LOG/latestStable")))
@@ -166,8 +174,7 @@ class IndexLogManagerImplTest extends SparkFunSuite with SparkInvolvedSuite with
   test("testUpdateLatestStableLog fails with exception if unable to find a valid log entry") {
     val path = new Path(testRoot, UUID.randomUUID().toString)
     val fs = path.getFileSystem(new Configuration)
-    FileUtils.createFile(
-      fs, new Path(path, s"$HYPERSPACE_LOG/0"), "Invalid Log Entry")
+    FileUtils.createFile(fs, new Path(path, s"$HYPERSPACE_LOG/0"), "Invalid Log Entry")
     assertThrows[com.fasterxml.jackson.core.JsonParseException](
       new IndexLogManagerImpl(path).createLatestStableLog(0))
   }

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
@@ -54,7 +54,8 @@ class IndexLogManagerImplTest
               Content.Directory("dir1", Seq("1.json", "2.json"), NoOpFingerprint()),
               Content.Directory("dir2", Seq("1.json", "2.json"), NoOpFingerprint()))))),
           "schema",
-          "type")),
+          "type",
+          Map())),
         null,
         null,
         LogicalPlanFingerprint(

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
@@ -28,7 +28,6 @@ import com.microsoft.hyperspace.index.IndexConstants.HYPERSPACE_LOG
 import com.microsoft.hyperspace.util.{FileUtils, JsonUtils}
 
 class IndexLogManagerImplTest extends SparkFunSuite with SparkInvolvedSuite with BeforeAndAfterAll {
-
   val testRoot = "src/test/resources/indexLogManagerTests"
   val sampleIndexLogEntry: IndexLogEntry = IndexLogEntry(
     "entityName",

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
@@ -28,6 +28,11 @@ import com.microsoft.hyperspace.index.IndexConstants.HYPERSPACE_LOG
 import com.microsoft.hyperspace.util.{FileUtils, JsonUtils}
 
 class IndexLogManagerImplTest extends SparkFunSuite with SparkInvolvedSuite with BeforeAndAfterAll {
+
+  def getRelMetaEntry(files: Seq[String]): RelationMetadataEntry = {
+    RelationMetadataEntry(Seq("rootpath"), files, "schema", "type")
+  }
+
   val testRoot = "src/test/resources/indexLogManagerTests"
   val sampleIndexLogEntry: IndexLogEntry = IndexLogEntry(
     "entityName",
@@ -39,20 +44,23 @@ class IndexLogManagerImplTest extends SparkFunSuite with SparkInvolvedSuite with
     Content(
       "/root/log",
       Seq(
-        Content.Directory("dir1", Seq("1.json", "2.json"), NoOpFingerprint()),
-        Content.Directory("dir2", Seq("1.json", "2.json"), NoOpFingerprint()))),
+        Content.Directory(
+          "dir1", Seq(getRelMetaEntry(Seq("1.json", "2.json"))), NoOpFingerprint()),
+        Content.Directory(
+          "dir2", Seq(getRelMetaEntry(Seq("1.json", "2.json"))), NoOpFingerprint()))),
     Source(
       SparkPlan(
         SparkPlan.Properties(
-          rawPlan = "spark plan",
           LogicalPlanFingerprint(
             LogicalPlanFingerprint.Properties(Seq(Signature("provider", "signature")))))),
       Seq(
         Hdfs(properties = Hdfs.Properties(content = Content(
           "/root/data",
           Seq(
-            Content.Directory("dir1", Seq("1.json", "2.json"), NoOpFingerprint()),
-            Content.Directory("dir2", Seq("1.json", "2.json"), NoOpFingerprint()))))))),
+            Content.Directory(
+              "dir1", Seq(getRelMetaEntry(Seq("1.json", "2.json"))), NoOpFingerprint()),
+            Content.Directory(
+              "dir2", Seq(getRelMetaEntry(Seq("1.json", "2.json"))), NoOpFingerprint()))))))),
     Map())
 
   private def getEntry(state: String): LogEntry = {

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
@@ -44,16 +44,17 @@ class IndexLogManagerImplTest extends SparkFunSuite with SparkInvolvedSuite with
     Source(
       SparkPlan(
         SparkPlan.Properties(
+          Seq(Relation(Seq("rootpath"), Hdfs(properties = Hdfs.Properties(content = Content(
+            "/root/data",
+            Seq(
+              Content.Directory("dir1", Seq("1.json", "2.json"), NoOpFingerprint()),
+              Content.Directory("dir2", Seq("1.json", "2.json"), NoOpFingerprint()))))),
+            "schema",
+            "type")),
+          null,
+          null,
           LogicalPlanFingerprint(
-            LogicalPlanFingerprint.Properties(Seq(Signature("provider", "signature")))))),
-      Seq(
-        Hdfs(properties = Hdfs.Properties(content = Content(
-          "/root/data",
-          Seq(
-            Content.Directory("dir1", Seq("1.json", "2.json"), NoOpFingerprint()),
-            Content.Directory("dir2", Seq("1.json", "2.json"), NoOpFingerprint())))))),
-      Seq(RelationMetadataEntry(Seq("rootpath"), Seq("1.json", "2.json"), "schema", "type"))
-    ),
+            LogicalPlanFingerprint.Properties(Seq(Signature("provider", "signature"))))))),
     Map())
 
   private def getEntry(state: String): LogEntry = {

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -249,7 +249,7 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
                 dataSchema,
                 _,
                 fileFormat,
-                _),
+                options),
               _,
               _,
               _) =>
@@ -264,7 +264,8 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
               location.rootPaths.map(_.toString),
               Hdfs(sourceDataProperties),
               dataSchema.json,
-              fileFormatName)
+              fileFormatName,
+              options)
         }
         val sourcePlanProperties = SparkPlan.Properties(
           relations,

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -286,9 +286,10 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
                   dataSchema.json,
                   fileFormat.toString.toLowerCase(Locale.ROOT))
         }
+        val files = relations.map (_.files).flatten
         val sourceDataProperties =
           Hdfs.Properties(
-            Content("", Seq(Content.Directory("", relations, NoOpFingerprint()))))
+            Content("", Seq(Content.Directory("", files, NoOpFingerprint()))))
 
         val entry = IndexLogEntry(
           indexConfig.indexName,
@@ -302,7 +303,7 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
             s"$indexStorageLocation/${indexConfig.indexName}" +
               s"/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0",
             Seq()),
-          Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties))),
+          Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), relations),
           Map())
         entry.state = state
         entry

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -188,7 +188,6 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
   }
 
   test("Verify refresh-full rebuild of index.") {
-
     Seq(("csv", Map("header" -> "true")), ("parquet", Map()), ("json", Map())).foreach {
       case (format, option: Map[String, String]) =>
         val refreshTestLocation = sampleParquetDataLocation + "refresh_" + format

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -71,7 +71,6 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
       200,
       StructType(Seq(StructField("RGUID", StringType), StructField("Date", StringType))).json,
       s"$indexStorageLocation/index1/v__=0",
-      StructType(Seq(StructField("RGUID", StringType), StructField("Date", StringType))).json,
       Constants.States.ACTIVE)
     assert(actual.equals(expected))
   }

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -288,8 +288,7 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
         }
         val files = relations.map (_.files).flatten
         val sourceDataProperties =
-          Hdfs.Properties(
-            Content("", Seq(Content.Directory("", files, NoOpFingerprint()))))
+          Hdfs.Properties(Content("", Seq(Content.Directory("", files, NoOpFingerprint()))))
 
         val entry = IndexLogEntry(
           indexConfig.indexName,

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexTests.scala
@@ -31,7 +31,6 @@ class IndexTests extends SparkFunSuite {
       schema: StructType,
       numBuckets: Int): IndexLogEntry = {
     val sourcePlanProperties = SparkPlan.Properties(
-      "plan",
       LogicalPlanFingerprint(
         LogicalPlanFingerprint.Properties(Seq(Signature("signatureProvider", "dfSignature")))))
     val sourceDataProperties =

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexTests.scala
@@ -45,7 +45,7 @@ class IndexTests extends SparkFunSuite {
           IndexLogEntry.schemaString(schema),
           10)),
       Content(path, Seq()),
-      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties))),
+      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
       Map())
     entry.state = Constants.States.ACTIVE
     entry

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexTests.scala
@@ -31,10 +31,11 @@ class IndexTests extends SparkFunSuite {
       schema: StructType,
       numBuckets: Int): IndexLogEntry = {
     val sourcePlanProperties = SparkPlan.Properties(
+      Seq(),
+      null,
+      null,
       LogicalPlanFingerprint(
         LogicalPlanFingerprint.Properties(Seq(Signature("signatureProvider", "dfSignature")))))
-    val sourceDataProperties =
-      Hdfs.Properties(Content("", Seq(Content.Directory("", Seq(), NoOpFingerprint()))))
 
     val entry = IndexLogEntry(
       config.indexName,
@@ -45,7 +46,7 @@ class IndexTests extends SparkFunSuite {
           IndexLogEntry.schemaString(schema),
           10)),
       Content(path, Seq()),
-      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
+      Source(SparkPlan(sourcePlanProperties)),
       Map())
     entry.state = Constants.States.ACTIVE
     entry

--- a/src/test/scala/com/microsoft/hyperspace/index/rankers/JoinIndexRankerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rankers/JoinIndexRankerTest.scala
@@ -61,7 +61,6 @@ class JoinIndexRankerTest extends SparkFunSuite {
       includedCols: Seq[AttributeReference],
       numBuckets: Int): IndexLogEntry = {
     val sourcePlanProperties = SparkPlan.Properties(
-      "serializedPlan",
       LogicalPlanFingerprint(
         LogicalPlanFingerprint.Properties(Seq(Signature("signClass", "sign(plan)")))))
     val sourceDataProperties =

--- a/src/test/scala/com/microsoft/hyperspace/index/rankers/JoinIndexRankerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rankers/JoinIndexRankerTest.scala
@@ -75,7 +75,7 @@ class JoinIndexRankerTest extends SparkFunSuite {
           IndexLogEntry.schemaString(schemaFromAttributes(indexCols ++ includedCols: _*)),
           numBuckets)),
       Content(name, Seq()),
-      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties))),
+      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
       Map())
     entry.state = Constants.States.ACTIVE
     entry

--- a/src/test/scala/com/microsoft/hyperspace/index/rankers/JoinIndexRankerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rankers/JoinIndexRankerTest.scala
@@ -61,10 +61,11 @@ class JoinIndexRankerTest extends SparkFunSuite {
       includedCols: Seq[AttributeReference],
       numBuckets: Int): IndexLogEntry = {
     val sourcePlanProperties = SparkPlan.Properties(
+      Seq(),
+      null,
+      null,
       LogicalPlanFingerprint(
         LogicalPlanFingerprint.Properties(Seq(Signature("signClass", "sign(plan)")))))
-    val sourceDataProperties =
-      Hdfs.Properties(Content("", Seq(Content.Directory("", Seq(), NoOpFingerprint()))))
 
     val entry = IndexLogEntry(
       name,
@@ -75,7 +76,7 @@ class JoinIndexRankerTest extends SparkFunSuite {
           IndexLogEntry.schemaString(schemaFromAttributes(indexCols ++ includedCols: _*)),
           numBuckets)),
       Content(name, Seq()),
-      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
+      Source(SparkPlan(sourcePlanProperties)),
       Map())
     entry.state = Constants.States.ACTIVE
     entry

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.types.{StructField, StructType}
 import com.microsoft.hyperspace.HyperspaceException
 import com.microsoft.hyperspace.actions.Constants
 import com.microsoft.hyperspace.index.{Content, CoveringIndex, Hdfs, HyperspaceSuite, IndexConstants, IndexLogEntry, IndexLogManagerImpl, LogicalPlanFingerprint, LogicalPlanSignatureProvider, NoOpFingerprint, Signature, Source, SparkPlan}
-import com.microsoft.hyperspace.index.serde.LogicalPlanSerDeUtils
 
 trait HyperspaceRuleTestSuite extends HyperspaceSuite {
   def createIndex(
@@ -39,7 +38,6 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
     LogicalPlanSignatureProvider.create(signClass).signature(plan) match {
       case Some(s) =>
         val sourcePlanProperties = SparkPlan.Properties(
-          LogicalPlanSerDeUtils.serialize(plan, spark),
           LogicalPlanFingerprint(LogicalPlanFingerprint.Properties(Seq(Signature(signClass, s)))))
         val sourceDataProperties =
           Hdfs.Properties(Content("", Seq(Content.Directory("", Seq(), NoOpFingerprint()))))

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
@@ -51,7 +51,7 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
               IndexLogEntry.schemaString(schemaFromAttributes(indexCols ++ includedCols: _*)),
               10)),
           Content(getIndexDataFilesPath(name).toUri.toString, Seq()),
-          Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties))),
+          Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
           Map())
 
         val logManager = new IndexLogManagerImpl(getIndexRootPath(name))

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
@@ -38,9 +38,10 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
     LogicalPlanSignatureProvider.create(signClass).signature(plan) match {
       case Some(s) =>
         val sourcePlanProperties = SparkPlan.Properties(
+          Seq(),
+          null,
+          null,
           LogicalPlanFingerprint(LogicalPlanFingerprint.Properties(Seq(Signature(signClass, s)))))
-        val sourceDataProperties =
-          Hdfs.Properties(Content("", Seq(Content.Directory("", Seq(), NoOpFingerprint()))))
 
         val indexLogEntry = IndexLogEntry(
           name,
@@ -51,7 +52,7 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
               IndexLogEntry.schemaString(schemaFromAttributes(indexCols ++ includedCols: _*)),
               10)),
           Content(getIndexDataFilesPath(name).toUri.toString, Seq()),
-          Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
+          Source(SparkPlan(sourcePlanProperties)),
           Map())
 
         val logManager = new IndexLogManagerImpl(getIndexRootPath(name))

--- a/src/test/scala/com/microsoft/hyperspace/util/JsonUtilsTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/util/JsonUtilsTests.scala
@@ -44,7 +44,7 @@ class JsonUtilsTests extends SparkFunSuite {
           IndexLogEntry.schemaString(schema),
           10)),
       Content("path", Seq()),
-      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties))),
+      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
       Map())
     index.state = Constants.States.ACTIVE
 

--- a/src/test/scala/com/microsoft/hyperspace/util/JsonUtilsTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/util/JsonUtilsTests.scala
@@ -31,7 +31,6 @@ class JsonUtilsTests extends SparkFunSuite {
         StructField("school", StringType)))
 
     val sourcePlanProperties = SparkPlan.Properties(
-      "plan",
       LogicalPlanFingerprint(
         LogicalPlanFingerprint.Properties(Seq(Signature("signatureProvider", "dfSignature")))))
     val sourceDataProperties =

--- a/src/test/scala/com/microsoft/hyperspace/util/JsonUtilsTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/util/JsonUtilsTests.scala
@@ -31,10 +31,11 @@ class JsonUtilsTests extends SparkFunSuite {
         StructField("school", StringType)))
 
     val sourcePlanProperties = SparkPlan.Properties(
+      Seq(),
+      null,
+      null,
       LogicalPlanFingerprint(
         LogicalPlanFingerprint.Properties(Seq(Signature("signatureProvider", "dfSignature")))))
-    val sourceDataProperties =
-      Hdfs.Properties(Content("", Seq(Content.Directory("", Seq(), NoOpFingerprint()))))
 
     val index = IndexLogEntry(
       "myIndex",
@@ -44,7 +45,7 @@ class JsonUtilsTests extends SparkFunSuite {
           IndexLogEntry.schemaString(schema),
           10)),
       Content("path", Seq()),
-      Source(SparkPlan(sourcePlanProperties), Seq(Hdfs(sourceDataProperties)), Seq()),
+      Source(SparkPlan(sourcePlanProperties)),
       Map())
     index.state = Constants.States.ACTIVE
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->

Instead of using KryoSerializer, reconstruct a DataFrame with {`rootPaths`, `dataSchema`}. In order to do this, we need to keep the necessary info in IndexLogEntry

Note that this approach can only be applied to Covering Index & HadoopFsRelation; limitations of the current version of Hyperspace.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
KryoSerializer is not compatible with the different versions of Spark; so refreshing an index built with another spark version would fail.

Fixes #98 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, indexes created before this change should be removed & recreated. 
IndexLogEntry (metadata) will be changed; new `"relations"` field:
```
...
"source" : {
    "plan" : {
      "properties" : {
        "relations" : [ {
          "rootPaths" : [ "file:/<>/table2" ],
          "data" : {
            "properties" : {
              "content" : {
                "root" : "",
                "directories" : [ {
                  "path" : "",
                  "files" : [ "file:/<>/table2/part-00000-2547e7e7-2577-4e07-b796-0a36e3e5444e-c000.snappy.parquet", "file:/<>/table2/part-00001-2547e7e7-2577-4e07-b796-0a36e3e5444d-c000.snappy.parquet" ],
                  "fingerprint" : {
                    "kind" : "NoOp",
                    "properties" : { }
                  }
                } ]
              }
            },
            "kind" : "HDFS"
          },
          "dataSchemaJson" : "{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"name\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"age\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}",
          "fileFormat" : "parquet"
        } ],
        "rawPlan" : null,
        "sql" : null,
        "fingerprint" : {
          "properties" : {
            "signatures" : [ {
              "provider" : "com.microsoft.hyperspace.index.IndexSignatureProvider",
              "value" : "921391350ed46e5ac8761bc4fc5a466a"
            } ]
          },
          "kind" : "LogicalPlan"
        }
      },
      "kind" : "Spark"
    }
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
refreshIndex tested both spark 2.4.6 + scala 2.11 <=> spark 3.0.0 + scala 2.12 locally
