### PR TITLE
Remove "path" key in DF read options

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -105,12 +105,14 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
           case d: DataSourceRegister => d.shortName
           case other => throw HyperspaceException(s"Unsupported file format: $other")
         }
+        // "path" key in options can incur multiple data read unexpectedly.
+        val opts = options - "path"
         Relation(
           location.rootPaths.map(_.toString),
           Hdfs(sourceDataProperties),
           dataSchema.json,
           fileFormatName,
-          options)
+          opts)
     }
 
   protected def write(spark: SparkSession, df: DataFrame, indexConfig: IndexConfig): Unit = {

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
@@ -48,12 +48,10 @@ class RefreshAction(
     // Currently we only support to create an index on a LogicalRelation.
     assert(rels.size == 1)
     val dataSchema = DataType.fromJson(rels.head.dataSchemaJson).asInstanceOf[StructType]
-    // "path" key in options incurs to read data twice unexpectedly.
-    val opts = rels.head.options - "path"
     spark.read
       .schema(dataSchema)
       .format(rels.head.fileFormat)
-      .options(opts)
+      .options(rels.head.options)
       .load(rels.head.rootPaths: _*)
   }
 

--- a/src/test/scala/com/microsoft/hyperspace/actions/CreateActionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/actions/CreateActionTest.scala
@@ -36,7 +36,7 @@ class CreateActionTest extends SparkFunSuite with SparkInvolvedSuite {
   private val mockLogManager: IndexLogManager = mock(classOf[IndexLogManager])
   private val mockDataManager: IndexDataManager = mock(classOf[IndexDataManager])
 
-  object CreateActionBaseMock extends CreateActionBase(mockDataManager) {
+  object CreateActionBaseWrapper extends CreateActionBase(mockDataManager) {
     def getSourceRelations(df: DataFrame): Seq[Relation] = sourceRelations(df)
   }
 
@@ -147,14 +147,14 @@ class CreateActionTest extends SparkFunSuite with SparkInvolvedSuite {
       (spark.read.option("path", path1).parquet(path1, path2), Seq(path1, path1, path2), 7))
       .foreach {
         case (df, expectedRootPaths, expectedCount) =>
-          val relation = CreateActionBaseMock.getSourceRelations(df)(0)
+          val relation = CreateActionBaseWrapper.getSourceRelations(df)(0)
           val rootPaths = relation.rootPaths.map {
             case path if path.startsWith(workDir) => path.drop(workDir.size + 1) // slash
             case path => path
           }
           assert(rootPaths == expectedRootPaths)
           assert(df.count == expectedCount)
-          assert(relation.options.isDefinedAt("path") == false)
+          assert(!relation.options.isDefinedAt("path"))
         case _ => fail("invalid test")
       }
 

--- a/src/test/scala/com/microsoft/hyperspace/actions/CreateActionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/actions/CreateActionTest.scala
@@ -115,9 +115,6 @@ class CreateActionTest extends SparkFunSuite with SparkInvolvedSuite with SQLHel
       val path1 = p + "table1"
       val path2 = p + "table2"
 
-      FileUtils.delete(new Path(path1))
-      FileUtils.delete(new Path(path2))
-
       import spark.implicits._
       SampleData.testData
         .toDF("Date", "RGUID", "Query", "imprs", "clicks")
@@ -155,9 +152,6 @@ class CreateActionTest extends SparkFunSuite with SparkInvolvedSuite with SQLHel
             assert(df.count == expectedCount)
             assert(!relation.options.isDefinedAt("path"))
         }
-
-      FileUtils.delete(new Path(path1))
-      FileUtils.delete(new Path(path2))
     }
   }
 }

--- a/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
@@ -96,43 +96,4 @@ class RefreshActionTest extends SparkFunSuite with SparkInvolvedSuite {
     val ex = intercept[HyperspaceException](action.validate())
     assert(ex.getMessage.contains("Refresh is only supported in ACTIVE state"))
   }
-
-  test("Verify reconstruct df with path key in options") {
-    val path1 = sampleParquetDataLocation + "table1"
-    val path2 = sampleParquetDataLocation + "table2"
-    FileUtils.delete(new Path(path1))
-    FileUtils.delete(new Path(path2))
-
-    import spark.implicits._
-    SampleData.testData
-      .toDF("Date", "RGUID", "Query", "imprs", "clicks")
-      .limit(2)
-      .write
-      .parquet(path1)
-
-    SampleData.testData
-      .toDF("Date", "RGUID", "Query", "imprs", "clicks")
-      .limit(3)
-      .write
-      .parquet(path2)
-
-    assert(spark.read.format("parquet").load(path1).count == 2)
-    assert(spark.read.format("parquet").load(path1, path2).count == 5)
-    assert(spark.read.parquet(path1).count == 2)
-    assert(spark.read.parquet(path1, path2).count == 5)
-
-    // path option ignored
-    assert(spark.read.format("parquet").option("path", path1).load(path1).count == 2)
-    assert(spark.read.format("parquet").option("path", path1).load(path2).count == 3)
-
-    // path option is not ignored
-    assert(spark.read.option("path", path1).parquet(path1).count == 4)
-    assert(spark.read.option("path", path1).parquet(path2).count == 5)
-
-    assert(spark.read.format("parquet").option("path", path1).load(path1, path2).count == 7)
-    assert(spark.read.option("path", path1).parquet(path1, path2).count == 7)
-
-    FileUtils.delete(new Path(path1))
-    FileUtils.delete(new Path(path2))
-  }
 }

--- a/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
@@ -97,7 +97,6 @@ class RefreshActionTest extends SparkFunSuite with SparkInvolvedSuite {
   }
 
   test("Verify reconstruct df with path key in options") {
-
     val path1 = sampleParquetDataLocation + "table1"
     val path2 = sampleParquetDataLocation + "table2"
     FileUtils.delete(new Path(path1))

--- a/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
@@ -26,7 +26,6 @@ import org.mockito.Mockito.{mock, when}
 import com.microsoft.hyperspace.{HyperspaceException, SampleData, SparkInvolvedSuite}
 import com.microsoft.hyperspace.actions.Constants.States.{ACTIVE, CREATING}
 import com.microsoft.hyperspace.index._
-import com.microsoft.hyperspace.util.FileUtils
 
 class RefreshActionTest extends SparkFunSuite with SparkInvolvedSuite {
   private val sampleParquetDataLocation = "src/test/resources/sampleparquet"

--- a/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
@@ -22,6 +22,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.DataFrame
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mockito.{mock, when}
+
 import com.microsoft.hyperspace.{HyperspaceException, SampleData, SparkInvolvedSuite}
 import com.microsoft.hyperspace.actions.Constants.States.{ACTIVE, CREATING}
 import com.microsoft.hyperspace.index._

--- a/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
@@ -22,10 +22,10 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.DataFrame
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mockito.{mock, when}
-
 import com.microsoft.hyperspace.{HyperspaceException, SampleData, SparkInvolvedSuite}
 import com.microsoft.hyperspace.actions.Constants.States.{ACTIVE, CREATING}
 import com.microsoft.hyperspace.index._
+import com.microsoft.hyperspace.util.FileUtils
 
 class RefreshActionTest extends SparkFunSuite with SparkInvolvedSuite {
   private val sampleParquetDataLocation = "src/test/resources/sampleparquet"
@@ -94,5 +94,45 @@ class RefreshActionTest extends SparkFunSuite with SparkInvolvedSuite {
     val action = new RefreshAction(spark, mockLogManager, mockDataManager)
     val ex = intercept[HyperspaceException](action.validate())
     assert(ex.getMessage.contains("Refresh is only supported in ACTIVE state"))
+  }
+
+  test("Verify reconstruct df with path key in options") {
+
+    val path1 = sampleParquetDataLocation + "table1"
+    val path2 = sampleParquetDataLocation + "table2"
+    FileUtils.delete(new Path(path1))
+    FileUtils.delete(new Path(path2))
+
+    import spark.implicits._
+    SampleData.testData
+      .toDF("Date", "RGUID", "Query", "imprs", "clicks")
+      .limit(2)
+      .write
+      .parquet(path1)
+
+    SampleData.testData
+      .toDF("Date", "RGUID", "Query", "imprs", "clicks")
+      .limit(3)
+      .write
+      .parquet(path2)
+
+    assert(spark.read.format("parquet").load(path1).count == 2)
+    assert(spark.read.format("parquet").load(path1, path2).count == 5)
+    assert(spark.read.parquet(path1).count == 2)
+    assert(spark.read.parquet(path1, path2).count == 5)
+
+    // path option ignored
+    assert(spark.read.format("parquet").option("path", path1).load(path1).count == 2)
+    assert(spark.read.format("parquet").option("path", path1).load(path2).count == 3)
+
+    // path option is not ignored
+    assert(spark.read.option("path", path1).parquet(path1).count == 4)
+    assert(spark.read.option("path", path1).parquet(path2).count == 5)
+
+    assert(spark.read.format("parquet").option("path", path1).load(path1, path2).count == 7)
+    assert(spark.read.option("path", path1).parquet(path1, path2).count == 7)
+
+    FileUtils.delete(new Path(path1))
+    FileUtils.delete(new Path(path2))
   }
 }

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -229,6 +229,7 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
         assert(indexCount == 3)
 
         FileUtils.delete(new Path(refreshTestLocation))
+      case _ => assert(false, "invalid test")
     }
   }
 

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -16,8 +16,6 @@
 
 package com.microsoft.hyperspace.index
 
-import java.util.Locale
-
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.DataFrame
@@ -51,7 +49,7 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
       .write
       .parquet(sampleParquetDataLocation)
 
-    df = spark.read.option("path", sampleParquetDataLocation).parquet(sampleParquetDataLocation)
+    df = spark.read.parquet(sampleParquetDataLocation)
   }
 
   after {
@@ -229,7 +227,7 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
         assert(indexCount == 3)
 
         FileUtils.delete(new Path(refreshTestLocation))
-      case _ => assert(false, "invalid test")
+      case _ => fail("invalid test")
     }
   }
 

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -51,7 +51,7 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
       .write
       .parquet(sampleParquetDataLocation)
 
-    df = spark.read.parquet(sampleParquetDataLocation)
+    df = spark.read.option("path", sampleParquetDataLocation).parquet(sampleParquetDataLocation)
   }
 
   after {
@@ -265,7 +265,7 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
               Hdfs(sourceDataProperties),
               dataSchema.json,
               fileFormatName,
-              options)
+              options - "path")
         }
         val sourcePlanProperties = SparkPlan.Properties(
           relations,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->
The follow up PR to address https://github.com/microsoft/hyperspace/pull/99#discussion_r464098937
- Remove "path" key in IndexLogEntry
- Tests for "path" key in options for spark.read

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- "path" key in options can be added by "Spark", not only by the user and it might cause confusion. Therefore, it's better not to write it at creation.
- Test enhancement

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
- "path" key is not included in "options" field in IndexLogEntry

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
IndexManagerTest , CreateActionTest
