### PR TITLE
e2e tests showing aliases not supported in join rule

### DIFF
--- a/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
@@ -127,6 +127,40 @@ class E2EHyperspaceRulesTests extends HyperspaceSuite {
         getIndexFilesPath(rightDfIndexConfig.indexName)))
   }
 
+  test("E2E test for join query with alias columns is not supported.") {
+    def verifyNoChange(f: () => DataFrame): Unit = {
+      spark.disableHyperspace()
+      val originalPlan = f().queryExecution.optimizedPlan
+      val updatedPlan = JoinIndexRule(originalPlan)
+      assert(originalPlan.equals(updatedPlan))
+    }
+
+    withView("t1", "t2") {
+      val leftDf = spark.read.parquet(sampleParquetDataLocation)
+      val leftDfIndexConfig = IndexConfig("leftIndex", Seq("c3"), Seq("c1"))
+      hyperspace.createIndex(leftDf, leftDfIndexConfig)
+
+      val rightDf = spark.read.parquet(sampleParquetDataLocation)
+      val rightDfIndexConfig = IndexConfig("rightIndex", Seq("c3"), Seq("c4"))
+      hyperspace.createIndex(rightDf, rightDfIndexConfig)
+
+      leftDf.createOrReplaceTempView("t1")
+      rightDf.createOrReplaceTempView("t2")
+
+      // Test: join query with alias columns in join condition is not optimized.
+      def query1(): DataFrame = spark.sql("""SELECT alias, c4
+          |from t2, (select c3 as alias, c1 from t1)
+          |where t2.c3 = alias""".stripMargin)
+      verifyNoChange(query1)
+
+      // Test: join query with alias columns in project columns is not optimized.
+      def query2(): DataFrame = spark.sql("""SELECT alias, c4
+          |from t2, (select c3, c1 as alias from t1) as newt
+          |where t2.c3 = newt.c3""".stripMargin)
+      verifyNoChange(query2)
+    }
+  }
+
   test("E2E test for join query on catalog temp tables/views") {
     withView("t1", "t2") {
       val leftDf = spark.read.parquet(sampleParquetDataLocation)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Join Index Rule doesn't support alias in join condition columns as well as project columns. Added tests to capture this behavior.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->


### Why are the changes needed?
A future PR will remove some alias related code from Join Index Rule. To make sure we are not changing any expected behavior in that PR #78 , it's better to add these tests before that PR is merged
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
no
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
unit tests
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
