### PR TITLE
Updating version dependency in python tests run script

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -83,7 +83,12 @@ def prepare(root_dir):
     delete_if_exists(os.path.expanduser("~/.ivy2/cache/com/microsoft/hyperspace"))
     delete_if_exists(os.path.expanduser("~/.m2/repository/com/microsoft/hyperspace"))
     run_cmd([sbt_path, "clean", "publishM2"], stream_output=True)
-    package = "com.microsoft.hyperspace:hyperspace-core_2.12:0.2.0-SNAPSHOT"
+    
+    # Get current release which is required to be loaded
+    version = '0.0.0'
+    with open(os.path.join(root_dir, "version.sbt")) as fd:
+        version = fd.readline().split('"')[1]
+    package = "com.microsoft.hyperspace:hyperspace-core_2.12:" + version
     return package
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
python tests run script uses hardcoded version currently. Instead this will fetch version from version.sbt. So for new releases this will not require manual update after this PR.

### Why are the changes needed?
python tests run currently depends on hardcoded version when run from azure pipeline and it fails if new version is released.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
To be tested in azure pipeline run.