### PR TITLE
Fix CreateAction test where path comparison fails on Windows

### DIFF
--- a/src/test/scala/com/microsoft/hyperspace/actions/CreateActionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/actions/CreateActionTest.scala
@@ -123,8 +123,8 @@ class CreateActionTest extends SparkFunSuite with SparkInvolvedSuite with SQLHel
 
   test("Verify rootPaths for given LogicalRelations") {
     withTempPath { p =>
-      val path1 = p + "table1"
-      val path2 = p + "table2"
+      val path1 = new Path(p.getCanonicalPath, "t1").toString
+      val path2 = new Path(p.getCanonicalPath, "t2").toString
 
       import spark.implicits._
       SampleData.testData
@@ -157,9 +157,10 @@ class CreateActionTest extends SparkFunSuite with SparkInvolvedSuite with SQLHel
         .foreach {
           case (df, expectedPaths, expectedCount) =>
             val relation = CreateActionBaseWrapper.getSourceRelations(df).head
-            val expectedRootPaths = expectedPaths.map("file:" + _)
-
-            assert(relation.rootPaths == expectedRootPaths)
+            def normalize(path: String): String = {
+              new Path(path).toUri.getPath
+            }
+            assert(relation.rootPaths.map(normalize) == expectedPaths.map(normalize))
             assert(df.count == expectedCount)
             assert(!relation.options.isDefinedAt("path"))
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->

This PR fixes `CreateAction` test where paths comparison causes a failure on Windows.

This PR addresses the issue where temp path is not cleaned up correctly.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To fix a test that fails on Windows.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Updated existing test.
