### PR TITLE
New version of join index rule

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRuleV2.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRuleV2.scala
@@ -1,0 +1,210 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index.rules
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeReference, AttributeSet, EqualTo, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LeafNode, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InMemoryFileIndex, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.types.StructType
+
+import com.microsoft.hyperspace.Hyperspace
+import com.microsoft.hyperspace.index.IndexLogEntry
+import com.microsoft.hyperspace.index.rules.JoinIndexRule.spark
+
+/**
+ * Join Index Rule V2. This rule tries to optimizes both sides of a shuffle based join
+ * independently. The optimization works by replacing data sources with bucketed indexes which
+ * match the join predicate partitioning.
+ *
+ * Algorithm:
+ * 1. Identify whether this join node can be optimized:
+ *    a. We support only equi-joins in CNF forms. Also make sure the join columns are directly
+ *       picked from scan nodes.
+ *    b. This join is not a broadcast hash join. To check this, we independently check the left
+ *       and right sides of the join and make sure their size is less than
+ *       "spark.sql.autoBroadcastJoinThreshold"
+ * 2. Independently check left and right sides of the join for available indexes. If an index
+ *    is picked, the shuffle on that side will be eliminated.
+ */
+object JoinIndexRuleV2 extends Rule[LogicalPlan] with Logging {
+  def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
+    case join @ Join(l, r, _, Some(condition)) if eligible(l, r, condition) =>
+      updatePlan(join)
+  }
+
+  private def contains(
+      attributes: Set[AttributeReference],
+      attribute: AttributeReference): Boolean = {
+    attributes.exists(_.semanticEquals(attribute))
+  }
+
+  private def setIndexes(
+      relation: LogicalRelation,
+      joinCols: AttributeSet,
+      requiredCols: Seq[Attribute]): LogicalPlan = {
+    val indexManager = Hyperspace
+      .getContext(spark)
+      .indexCollectionManager
+
+    val availableIndexes = RuleUtils.getCandidateIndexes(indexManager, relation)
+    if (availableIndexes.isEmpty) {
+      return relation
+    }
+
+    val tempVar = (joinCols.toSet ++ requiredCols.toSet)
+      .map(_.asInstanceOf[AttributeReference])
+
+    val allReqdCols =
+      relation.outputSet
+        .filter(c => contains(tempVar, c.asInstanceOf[AttributeReference]))
+        .map(_.name)
+    val reqdIdxCols = relation.outputSet
+      .filter(
+        c =>
+          contains(
+            joinCols.toSet.map((col: Attribute) => col.asInstanceOf[AttributeReference]),
+            c.asInstanceOf[AttributeReference]))
+      .map(_.name)
+
+    val usableIndexes = availableIndexes
+      .filter { index =>
+        index.config.indexedColumns.toSet.equals(reqdIdxCols.toSet) &&
+        allReqdCols.forall(
+          c =>
+            (index.config.indexedColumns ++ index.config.includedColumns)
+              .contains(c))
+      }
+
+    usableIndexes.headOption match {
+      case None => relation
+      case Some(index) => replaceRelationWithIndex(relation, index)
+    }
+  }
+
+  private def updatePlan(join: Join): Join = {
+    val newLeft: LogicalPlan = updateIfSupported(join.left, join.condition.get)
+    val newRight: LogicalPlan =
+      updateIfSupported(join.right, join.condition.get)
+    join.copy(left = newLeft, right = newRight)
+  }
+
+  private def updateIfSupported(plan: LogicalPlan, condition: Expression): LogicalPlan = {
+    // Either left or right or both sides should contain half of references.
+    // All references for any side, either left or right, should all come from the same leaf node.
+    //
+    // e.g. if join condition refers to columns A, B, C, D, two columns should come from left, 2
+    // from right. This would be by default true. Nothing to do in this part. Let's say A,B
+    // come from left. C,D come from right. The requirement is both A and B should come from the
+    // same leaf node on left. Same for C and D. Both should come from same leaf node on right.
+
+    val joinCols =
+      condition.references.map(_.asInstanceOf[AttributeReference]).toSet
+    val eligibleBaseRelations = plan.collectLeaves().filter {
+      case relation: LogicalRelation =>
+        relation.output.toSet.exists(col => contains(joinCols, col))
+      case _ => false
+    }
+    if (eligibleBaseRelations.length != 1) {
+      return plan
+    }
+    val eligibleRelation =
+      eligibleBaseRelations.head.asInstanceOf[LogicalRelation]
+    if (eligibleRelation.output.toSet.count(c => contains(joinCols, c)) * 2 != joinCols.size) {
+      return plan
+    }
+
+    updateIndex(plan, condition.references, plan.output)
+  }
+
+  private def updateIndex(
+      plan: LogicalPlan,
+      joinCols: AttributeSet,
+      requiredCols: Seq[Attribute]): LogicalPlan =
+    plan match {
+      case p: LogicalRelation => setIndexes(p, joinCols, requiredCols)
+      case p: LeafNode => p
+      case p: LogicalPlan =>
+        p.withNewChildren {
+          p.children.map { child =>
+            updateIndex(child, joinCols, p.references.toSeq ++ requiredCols)
+          }
+        }
+    }
+
+  private def eligible(l: LogicalPlan, r: LogicalPlan, condition: Expression): Boolean = {
+    !isBroadcastJoin(l, r) && isJoinConditionSupported(condition)
+  }
+
+  private def isBroadcastJoin(l: LogicalPlan, r: LogicalPlan): Boolean = {
+    val broadcastThreshold: Long =
+      SparkSession.getActiveSession.get.conf
+        .get("spark.sql.autoBroadcastJoinThreshold")
+        .toLong
+    l.stats.sizeInBytes <= broadcastThreshold || r.stats.sizeInBytes <= broadcastThreshold
+  }
+
+  /**
+   * Check for supported Join Conditions. Equi-Joins in simple CNF form are supported.
+   *
+   * Predicates should be of the form (A = B and C = D and E = F and...). OR based conditions
+   * are not supported. E.g. (A = B OR C = D) is not supported
+   *
+   * TODO (500053): Investigate whether OR condition can use bucketing info for optimization
+   *
+   * @param condition the join condition
+   * @return true if the condition is supported. False otherwise.
+   */
+  private def isJoinConditionSupported(condition: Expression): Boolean = {
+    condition match {
+      case EqualTo(_: AttributeReference, _: AttributeReference) => true
+      case And(left, right) => isJoinConditionSupported(left) && isJoinConditionSupported(right)
+      case _ => false
+    }
+  }
+
+  private def replaceRelationWithIndex(
+    relation: LogicalRelation,
+    index: IndexLogEntry): LogicalRelation = {
+    val bucketSpec = BucketSpec(
+      numBuckets = index.numBuckets,
+      bucketColumnNames = index.config.indexedColumns,
+      sortColumnNames = index.config.indexedColumns)
+
+    val spark = SparkSession.getActiveSession.getOrElse {
+      throw new IllegalArgumentException("Could not find active SparkSession")
+    }
+
+    val location = new InMemoryFileIndex(spark, Seq(new Path(index.content.root)), Map(), None)
+    val newRelation = HadoopFsRelation(
+      location,
+      new StructType(),
+      index.schema,
+      Some(bucketSpec),
+      new ParquetFileFormat,
+      Map())(spark)
+
+    val newOutput =
+      relation.output.filter(attr => newRelation.schema.fieldNames.contains(attr.name))
+    relation.copy(relation = newRelation, output = newOutput)
+  }
+}

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/JoinIndexRuleV2Test.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/JoinIndexRuleV2Test.scala
@@ -1,0 +1,250 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index.rules
+
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.JoinType
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+import com.microsoft.hyperspace.actions.Constants
+import com.microsoft.hyperspace.index._
+import com.microsoft.hyperspace.index.serde.LogicalPlanSerDeUtils
+import com.microsoft.hyperspace.util.FileUtils
+
+class JoinIndexRuleV2Test extends HyperspaceRuleTestSuite {
+  val parentPath = new Path("src/test/resources/joinIndexTest")
+  val systemPath = new Path(parentPath, "idroot")
+
+  val t1c1 = AttributeReference("t1c1", IntegerType)()
+  val t1c2 = AttributeReference("t1c2", StringType)()
+  val t1c3 = AttributeReference("t1c3", IntegerType)()
+  val t1c4 = AttributeReference("t1c4", StringType)()
+  val t2c1 = AttributeReference("t2c1", IntegerType)()
+  val t2c2 = AttributeReference("t2c2", StringType)()
+  val t2c3 = AttributeReference("t2c3", IntegerType)()
+  val t2c4 = AttributeReference("t2c4", StringType)()
+  val t3c1 = AttributeReference("t3c1", IntegerType)()
+  val t3c2 = AttributeReference("t3c2", StringType)()
+  val t3c3 = AttributeReference("t3c3", IntegerType)()
+  val t3c4 = AttributeReference("t3c4", StringType)()
+
+  val t1Schema = schemaFromAttributes(t1c1, t1c2, t1c3, t1c4)
+  val t2Schema = schemaFromAttributes(t2c1, t2c2, t2c3, t2c4)
+  val t3Schema = schemaFromAttributes(t3c1, t3c2, t3c3, t3c4)
+
+  var t1Relation: HadoopFsRelation = _
+  var t2Relation: HadoopFsRelation = _
+  var t3Relation: HadoopFsRelation = _
+  var t1ScanNode: LogicalRelation = _
+  var t2ScanNode: LogicalRelation = _
+  var t3ScanNode: LogicalRelation = _
+  var t1FilterNode: Filter = _
+  var t2FilterNode: Filter = _
+  var t3FilterNode: Filter = _
+  var t1ProjectNode: Project = _
+  var t2ProjectNode: Project = _
+  var t3ProjectNode: Project = _
+
+  /**
+   * Test Setup:
+   *
+   * The basic scenario tested here is a [[Join]] logical plan node which consists of two children
+   * Left child is a [[Project]] -> [[Filter]] -> [[LogicalRelation]] subplan which reads data
+   * from files on disk.
+   * Right child is also a [[Project]] -> [[Filter]] -> [[LogicalRelation]] subplan same as left.
+   *
+   * If the Join node satisfies the requirements for [[JoinIndexRuleV2]], the plan must get updated
+   * to use available indexes from the system. If not, the plan should remain unaffected on
+   * application of the rule.
+   */
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    FileUtils.delete(parentPath)
+
+    spark.conf.set(IndexConstants.INDEX_SYSTEM_PATH, systemPath.toUri.toString)
+
+    val t1Location =
+      new InMemoryFileIndex(spark, Seq(new Path("t1")), Map.empty, Some(t1Schema), NoopCache) {
+        // Update allFiles() so that length of files is greater than spark's broadcast threshold
+        override def allFiles(): Seq[FileStatus] = {
+          val length = spark.conf
+            .get("spark.sql.autoBroadcastJoinThreshold")
+            .toLong * 10
+          Seq(new FileStatus(length, false, 1, 100, 100, new Path("t1")))
+        }
+      }
+
+    val t2Location =
+      new InMemoryFileIndex(spark, Seq(new Path("t2")), Map.empty, Some(t1Schema), NoopCache) {
+        // Update allFiles() so that length of files is greater than spark's broadcast threshold
+        override def allFiles(): Seq[FileStatus] = {
+          val length = spark.conf
+            .get("spark.sql.autoBroadcastJoinThreshold")
+            .toLong * 10
+          Seq(new FileStatus(length, false, 1, 100, 100, new Path("t2")))
+        }
+      }
+
+    val t3Location =
+      new InMemoryFileIndex(spark, Seq(new Path("t3")), Map.empty, Some(t1Schema), NoopCache) {
+        // Update allFiles() so that length of files is less than spark's broadcast threshold
+        override def allFiles(): Seq[FileStatus] = {
+          val length = spark.conf
+            .get("spark.sql.autoBroadcastJoinThreshold")
+            .toLong / 10
+          Seq(new FileStatus(length, false, 1, 100, 100, new Path("t3")))
+        }
+      }
+
+    t1Relation = baseRelation(t1Location, t1Schema, spark)
+    t2Relation = baseRelation(t2Location, t2Schema, spark)
+    t3Relation = baseRelation(t3Location, t3Schema, spark)
+
+    t1ScanNode = LogicalRelation(t1Relation, Seq(t1c1, t1c2, t1c3, t1c4), None, false)
+    t2ScanNode = LogicalRelation(t2Relation, Seq(t2c1, t2c2, t2c3, t2c4), None, false)
+    t3ScanNode = LogicalRelation(t3Relation, Seq(t3c1, t3c2, t3c3, t3c4), None, false)
+
+    t1FilterNode = Filter(IsNotNull(t1c1), t1ScanNode)
+    t2FilterNode = Filter(IsNotNull(t2c1), t2ScanNode)
+    t3FilterNode = Filter(IsNotNull(t3c1), t3ScanNode)
+
+    t1ProjectNode = Project(Seq(t1c1, t1c3), t1FilterNode)
+    // Project [t1c1#0, t1c3#2]
+    //  +- Filter isnotnull(t1c1#0)
+    //   +- Relation[t1c1#0,t1c2#1,t1c3#2,t1c4#3] parquet
+
+    t2ProjectNode = Project(Seq(t2c1, t2c3), t2FilterNode)
+    // Project [t2c1#4, t2c3#6]
+    //  +- Filter isnotnull(t2c1#4)
+    //   +- Relation[t2c1#4,t2c2#5,t2c3#6,t2c4#7] parquet
+
+    t3ProjectNode = Project(Seq(t3c1, t3c3), t3FilterNode)
+    // Project [t3c1#4, t3c3#6]
+    //  +- Filter isnotnull(t3c1#4)
+    //   +- Relation[t3c1#4,t3c2#5,t3c3#6,t3c4#7] parquet
+
+    createIndex("t1i1", Seq(t1c1), Seq(t1c3), t1ProjectNode)
+    createIndex("t1i2", Seq(t1c1, t1c2), Seq(t1c3), t1ProjectNode)
+    createIndex("t1i3", Seq(t1c2), Seq(t1c3), t1ProjectNode)
+    createIndex("t2i1", Seq(t2c1), Seq(t2c3), t2ProjectNode)
+    createIndex("t2i2", Seq(t2c1, t2c2), Seq(t2c3), t2ProjectNode)
+    createIndex("t3i1", Seq(t3c1), Seq(t3c3), t3ProjectNode)
+  }
+
+  before {
+    spark.conf.set(IndexConstants.INDEX_SYSTEM_PATH, systemPath.toUri.toString)
+    clearCache()
+  }
+
+  private def baseRelation(
+      location: FileIndex,
+      schema: StructType,
+      spark: SparkSession): HadoopFsRelation = {
+    HadoopFsRelation(location, new StructType(), schema, None, new ParquetFileFormat, Map.empty)(
+      spark)
+  }
+
+  override def afterAll(): Unit = {
+    FileUtils.delete(parentPath)
+    super.afterAll()
+  }
+
+  // test: does not update plan for bhj
+  test("Join rule does not update plan for Broadcast Hash Join compatible joins") {
+    val joinCondition = EqualTo(t1c1, t3c1)
+    val originalPlan =
+      Join(t1ProjectNode, t3ProjectNode, JoinType("inner"), Some(joinCondition))
+    val updatedPlan = JoinIndexRuleV2(originalPlan)
+    assert(updatedPlan.equals(originalPlan))
+  }
+
+  // test: updates plan for smj
+  test("Join rule works if indexes exist and configs are set correctly") {
+    val joinCondition = EqualTo(t1c1, t2c1)
+    val originalPlan =
+      Join(t1ProjectNode, t2ProjectNode, JoinType("inner"), Some(joinCondition))
+    val updatedPlan = JoinIndexRuleV2(originalPlan)
+    assert(!updatedPlan.equals(originalPlan))
+
+    val indexPaths =
+      Seq(getIndexDataFilesPath("t1i1"), getIndexDataFilesPath("t2i1"))
+    verifyUpdatedIndex(originalPlan, updatedPlan, indexPaths)
+  }
+
+  // test: updates plan for smj with bhj
+  test("Join rule updates sort merge join part of a plan with both smj and bhj.") {
+    val bhjCondition = EqualTo(t2c1, t3c1)
+    val bhjJoin =
+      Join(t2ProjectNode, t3ProjectNode, JoinType("inner"), Some(bhjCondition))
+
+    val smjCondition = EqualTo(t1c1, t2c1)
+    val originalPlan =
+      Join(t1ProjectNode, bhjJoin, JoinType("inner"), Some(smjCondition))
+
+    val updatedPlan = JoinIndexRuleV2(originalPlan)
+    assert(!updatedPlan.equals(originalPlan))
+
+    val indexPaths =
+      Seq(getIndexDataFilesPath("t1i1"), getIndexDataFilesPath("t2i1"))
+    verifyUpdatedIndex(originalPlan, updatedPlan, indexPaths ++ Seq(new Path("t3")))
+  }
+
+  private def verifyUpdatedIndex(
+      originalPlan: Join,
+      updatedPlan: LogicalPlan,
+      indexPaths: Seq[Path]): Unit = {
+    assert(treeStructureEquality(originalPlan, updatedPlan))
+    assert(basePaths(updatedPlan) == indexPaths)
+  }
+
+  /** method to check if tree structures of two logical plans are the same. */
+  private def treeStructureEquality(plan1: LogicalPlan, plan2: LogicalPlan): Boolean = {
+    val originalNodeCount = plan1.treeString.split("\n").length
+    val updatedNodeCount = plan2.treeString.split("\n").length
+
+    if (originalNodeCount == updatedNodeCount) {
+      (0 until originalNodeCount).forall { i =>
+        plan1(i) match {
+          // for LogicalRelation, we just check if the updated also has LogicalRelation. If the
+          // updated plan uses index, the root paths will be different here
+          case _: LogicalRelation => plan2(i).isInstanceOf[LogicalRelation]
+
+          // for other node types, we compare exact matching between original and updated plans
+          case node => node.simpleString.equals(plan2(i).simpleString)
+        }
+      }
+    } else {
+      false
+    }
+  }
+
+  /** Returns tuple of left and right base relation paths for a logical plan */
+  private def basePaths(plan: LogicalPlan): Seq[Path] = {
+    plan
+      .collectLeaves()
+      .collect {
+        case LogicalRelation(HadoopFsRelation(location, _, _, _, _, _), _, _, _) =>
+          location.rootPaths
+      }
+      .flatten
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->
```
/**
 * Join Index Rule V2. This rule tries to optimizes both sides of a shuffle based join
 * independently. The optimization works by replacing data sources with bucketed indexes which
 * match the join predicate partitioning.
 *
 * Algorithm:
 * 1. Identify whether this join node can be optimized:
 *    a. We support only equi-joins in CNF forms. Also make sure the join columns are directly
 *       picked from scan nodes.
 *    b. This join is not a broadcast hash join. To check this, we independently check the left
 *       and right sides of the join and make sure their size is less than
 *       "spark.sql.autoBroadcastJoinThreshold"
 * 2. Independently check left and right sides of the join for available indexes. If an index
 *    is picked, the shuffle on that side will be eliminated.
 */
```
Introducing the above optimizer rule for optimizing join rules. This rule is introduced to overcome the limitations of the original `JoinIndexRule`.
`JoinIndexRule`:
- works on both sides of the join at the same time. It doesn't work independently on both sides, limiting the possibility of shuffle elimination on just one side wherever possible.
- works only on the lowest level join. for broadcast joins, it doesn't improve performance much.
- cannot intelligently find a higher level shuffle based join to optimize.

`JoinIndexRuleV2`:
- works on either sides of the join independently. It can pick indexes to eliminate shuffle on just one side also.
- optimizes shuffle based joins (e.g. SortMergeJoin), disregards broadcast join.
- can work on higher level joins if one side of the join can be replaced by index and can eliminate shuffle.

To enable JoinIndexRuleV2:
set spark conf `"spark.hyperspace.enableJoinRuleV2"` to `true`.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
