### PR TITLE
[WIP] Deduplicate metadata path structure to use file path  = "root/directory/file"

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -87,7 +87,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
           Content(
             root = absolutePath.getParent.toString,
             directories = Seq(
-              Directory("", indexFilesInfo(absolutePath), NoOpFingerprint()))),
+              Directory(absolutePath.getName, indexFilesInfo(absolutePath), NoOpFingerprint()))),
           Source(SparkPlan(sourcePlanProperties)),
           Map())
 

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -83,7 +83,8 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
                 .Columns(resolvedIndexedColumns, resolvedIncludedColumns),
               IndexLogEntry.schemaString(schema),
               numBuckets)),
-          Content(path.toString, Seq(Directory("", indexFilesInfo(path), NoOpFingerprint()))),
+          Content(root = path.getParent.toString,
+            directories = Seq(Directory(path.getName, indexFilesInfo(path), NoOpFingerprint()))),
           Source(SparkPlan(sourcePlanProperties)),
           Map())
 

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -87,7 +87,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
           Content(
             root = absolutePath.getParent.toString,
             directories = Seq(
-              Directory(absolutePath.getName, indexFilesInfo(absolutePath), NoOpFingerprint()))),
+              Directory("", indexFilesInfo(absolutePath), NoOpFingerprint()))),
           Source(SparkPlan(sourcePlanProperties)),
           Map())
 

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -37,7 +37,7 @@ object Content {
     case class FileInfo(name: String, size: Long, modifiedTime: Long)
     object FileInfo {
       def apply(s: FileStatus): FileInfo =
-        FileInfo(s.getPath.toString, s.getLen, s.getModificationTime)
+        FileInfo(s.getPath.getName, s.getLen, s.getModificationTime)
     }
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -16,7 +16,7 @@
 
 package com.microsoft.hyperspace.index
 
-import org.apache.hadoop.fs.FileStatus
+import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.sql.types.{DataType, StructType}
 
 import com.microsoft.hyperspace.actions.Constants
@@ -29,7 +29,10 @@ case class NoOpFingerprint() {
 }
 
 // IndexLogEntry-specific Content that uses IndexLogEntry-specific fingerprint.
-case class Content(root: String, directories: Seq[Content.Directory])
+case class Content(root: String, directories: Seq[Content.Directory]) {
+  def rootDirs: Seq[Path] = directories.map(d => new Path(root + Path.SEPARATOR + d.path))
+}
+
 object Content {
   case class Directory(path: String, files: Seq[FileInfo], fingerprint: NoOpFingerprint)
   object Directory {

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -30,7 +30,14 @@ case class NoOpFingerprint() {
 
 // IndexLogEntry-specific Content that uses IndexLogEntry-specific fingerprint.
 case class Content(root: String, directories: Seq[Content.Directory]) {
-  def rootDirs: Seq[Path] = directories.map(d => new Path(root + Path.SEPARATOR + d.path))
+  def files: Seq[Path] =
+    directories.flatMap { d =>
+      if (d.path.equals("")) {
+        d.files.map(f => new Path(root + Path.SEPARATOR + d.path + Path.SEPARATOR + f.name))
+      } else {
+        Seq(new Path(root + Path.SEPARATOR + d.path))
+      }
+    }
 }
 
 object Content {
@@ -39,8 +46,11 @@ object Content {
     // modifiedTime is an Epoch time in milliseconds. (ms since 1970-01-01T00:00:00.000 UTC).
     case class FileInfo(name: String, size: Long, modifiedTime: Long)
     object FileInfo {
-      def apply(s: FileStatus): FileInfo =
-        FileInfo(s.getPath.getName, s.getLen, s.getModificationTime)
+      def apply(s: FileStatus): FileInfo = {
+        val path = s.getPath
+        val name = Path.SEPARATOR + path.getParent.getName + Path.SEPARATOR + path.getName
+        FileInfo(name, s.getLen, s.getModificationTime)
+      }
     }
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -32,11 +32,7 @@ case class NoOpFingerprint() {
 case class Content(root: String, directories: Seq[Content.Directory]) {
   def files: Seq[Path] =
     directories.flatMap { d =>
-      if (d.path.equals("")) {
-        d.files.map(f => new Path(root + Path.SEPARATOR + d.path + Path.SEPARATOR + f.name))
-      } else {
-        Seq(new Path(root + Path.SEPARATOR + d.path))
-      }
+      d.files.map(f => new Path(root + Path.SEPARATOR + d.path + Path.SEPARATOR + f.name))
     }
 }
 
@@ -47,9 +43,7 @@ object Content {
     case class FileInfo(name: String, size: Long, modifiedTime: Long)
     object FileInfo {
       def apply(s: FileStatus): FileInfo = {
-        val path = s.getPath
-        val name = Path.SEPARATOR + path.getParent.getName + Path.SEPARATOR + path.getName
-        FileInfo(name, s.getLen, s.getModificationTime)
+        FileInfo(s.getPath.getName, s.getLen, s.getModificationTime)
       }
     }
   }

--- a/src/main/scala/com/microsoft/hyperspace/index/plananalysis/PlanAnalyzer.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/plananalysis/PlanAnalyzer.scala
@@ -142,7 +142,7 @@ object PlanAnalyzer {
           _,
           _,
           _) =>
-        usedPaths += location.rootPaths.map(_.getParent).head.toString
+        usedPaths += location.rootPaths.map(_.getParent.getParent).head.toString
       case other =>
         other.subqueries.foreach { subQuery =>
           getPaths(subQuery).flatMap(path => usedPaths += path)

--- a/src/main/scala/com/microsoft/hyperspace/index/plananalysis/PlanAnalyzer.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/plananalysis/PlanAnalyzer.scala
@@ -142,7 +142,7 @@ object PlanAnalyzer {
           _,
           _,
           _) =>
-        usedPaths += location.rootPaths.head.toString
+        usedPaths += location.rootPaths.map(_.getParent).head.toString
       case other =>
         other.subqueries.foreach { subQuery =>
           getPaths(subQuery).flatMap(path => usedPaths += path)

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -104,7 +104,7 @@ object FilterIndexRule
       case Some(index) =>
         val spark = fsRelation.sparkSession
         val newLocation =
-          new InMemoryFileIndex(spark, Seq(new Path(index.content.root)), Map(), None)
+          new InMemoryFileIndex(spark, index.content.rootDirs, Map(), None)
 
         val newRelation = HadoopFsRelation(
           newLocation,

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -103,8 +103,7 @@ object FilterIndexRule
     rank(candidateIndexes) match {
       case Some(index) =>
         val spark = fsRelation.sparkSession
-        val newLocation =
-          new InMemoryFileIndex(spark, index.content.files, Map(), None)
+        val newLocation = new InMemoryFileIndex(spark, index.content.files, Map(), None)
 
         val newRelation = HadoopFsRelation(
           newLocation,

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -104,7 +104,7 @@ object FilterIndexRule
       case Some(index) =>
         val spark = fsRelation.sparkSession
         val newLocation =
-          new InMemoryFileIndex(spark, index.content.rootDirs, Map(), None)
+          new InMemoryFileIndex(spark, index.content.files, Map(), None)
 
         val newRelation = HadoopFsRelation(
           newLocation,

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -141,7 +141,7 @@ object JoinIndexRule
       bucketColumnNames = index.indexedColumns,
       sortColumnNames = index.indexedColumns)
 
-    val location = new InMemoryFileIndex(spark, Seq(new Path(index.content.root)), Map(), None)
+    val location = new InMemoryFileIndex(spark, index.content.rootDirs, Map(), None)
     val relation = HadoopFsRelation(
       location,
       new StructType(),

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -141,7 +141,7 @@ object JoinIndexRule
       bucketColumnNames = index.indexedColumns,
       sortColumnNames = index.indexedColumns)
 
-    val location = new InMemoryFileIndex(spark, index.content.rootDirs, Map(), None)
+    val location = new InMemoryFileIndex(spark, index.content.files, Map(), None)
     val relation = HadoopFsRelation(
       location,
       new StructType(),

--- a/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
@@ -387,7 +387,9 @@ class E2EHyperspaceRulesTests extends HyperspaceSuite with SQLHelper {
   private def queryPlanHasExpectedRootPaths(
       optimizedPlan: LogicalPlan,
       expectedPaths: Seq[Path]): Boolean = {
-    getAllRootPaths(optimizedPlan).equals(expectedPaths)
+    getAllRootPaths(optimizedPlan).zip(expectedPaths).forall {
+      case (a, b) => a.toString.startsWith(b.toString)
+    }
   }
 
   /**

--- a/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
@@ -409,9 +409,7 @@ class E2EHyperspaceRulesTests extends HyperspaceSuite with SQLHelper {
     }
   }
 
-  private def getIndexFilesPath(indexName: String): Path = {
-    new Path(systemPath, s"$indexName/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0")
-  }
+  private def getIndexFilesPath(indexName: String): Path = new Path(systemPath, s"$indexName")
 
   /**
    * Gets the sorted rows from the given dataframe to make it easy to compare with

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -73,7 +73,7 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
       indexConfig1.includedColumns,
       200,
       StructType(Seq(StructField("RGUID", StringType), StructField("Date", StringType))).json,
-      s"$indexStorageLocation/index1/v__=0",
+      s"$indexStorageLocation/index1",
       Constants.States.ACTIVE)
     assert(actual.equals(expected))
   }
@@ -284,9 +284,12 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
               IndexLogEntry.schemaString(schema),
               IndexConstants.INDEX_NUM_BUCKETS_DEFAULT)),
           Content(
-            s"$indexStorageLocation/${indexConfig.indexName}" +
-              s"/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0",
-            Seq()),
+            s"$indexStorageLocation/${indexConfig.indexName}",
+            Seq(
+              Content.Directory(
+                s"${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0",
+                Seq(),
+                NoOpFingerprint()))),
           Source(SparkPlan(sourcePlanProperties)),
           Map())
         entry.state = state

--- a/src/test/scala/com/microsoft/hyperspace/index/plananalysis/ExplainTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/plananalysis/ExplainTest.scala
@@ -121,7 +121,9 @@ class ExplainTest extends SparkFunSuite with HyperspaceSuite {
      */
     // scalastyle:on filelinelengthchecker
 
-    val joinIndexPath = getIndexFilesPath("joinIndex")
+    val joinIndexFilePath = getIndexFilesPath("joinIndex")
+
+    val joinIndexPath = getIndexRootPath("joinIndex")
 
     // scalastyle:off filelinelengthchecker
     expectedOutput
@@ -138,7 +140,7 @@ class ExplainTest extends SparkFunSuite with HyperspaceSuite {
       .append("<----:  +- *(1) Filter isnotnull(Col1#11)---->")
       .append(defaultDisplayMode.newLine)
       .append(s"<----:     +- *(1) FileScan parquet [Col1#11,Col2#12] Batched: true, Format: Parquet, Location: " +
-        truncate(s"InMemoryFileIndex[$joinIndexPath]") +
+        truncate(s"InMemoryFileIndex[$joinIndexFilePath]") +
         ", PartitionFilters: [], PushedFilters: [IsNotNull(Col1)], ReadSchema: struct<Col1:string,Col2:int>, SelectedBucketsCount: 200 out of 200---->")
       .append(defaultDisplayMode.newLine)
       .append("<----+- *(2) Project [Col1#21, Col2#22]---->")
@@ -146,7 +148,7 @@ class ExplainTest extends SparkFunSuite with HyperspaceSuite {
       .append("   <----+- *(2) Filter isnotnull(Col1#21)---->")
       .append(defaultDisplayMode.newLine)
       .append(s"      <----+- *(2) FileScan parquet [Col1#21,Col2#22] Batched: true, Format: Parquet, Location: " +
-        truncate(s"InMemoryFileIndex[$joinIndexPath]") +
+        truncate(s"InMemoryFileIndex[$joinIndexFilePath]") +
         ", PartitionFilters: [], PushedFilters: [IsNotNull(Col1)], ReadSchema: struct<Col1:string,Col2:int>, SelectedBucketsCount: 200 out of 200---->")
       .append(defaultDisplayMode.newLine)
       .append(defaultDisplayMode.newLine)
@@ -229,6 +231,9 @@ class ExplainTest extends SparkFunSuite with HyperspaceSuite {
     val df = spark.read.parquet(sampleParquetDataLocation)
     val indexConfig =
       IndexConfig("filterIndex", Seq("Col2"), Seq("Col1"))
+    df.createOrReplaceTempView("query")
+    hyperspace.createIndex(df, indexConfig)
+
     val displayMode = new PlainTextMode(getHighlightConf("<----", "---->"))
     // Constructing expected output for given query from explain API
     val expectedOutput = new StringBuilder
@@ -372,7 +377,7 @@ class ExplainTest extends SparkFunSuite with HyperspaceSuite {
       .append(displayMode.newLine)
       .append("=============================================================")
       .append(displayMode.newLine)
-      .append("filterIndex:" + getIndexFilesPath("filterIndex"))
+      .append("filterIndex:" + getIndexRootPath("filterIndex"))
       .append(displayMode.newLine)
       .append(displayMode.newLine)
       .append("=============================================================")
@@ -400,8 +405,6 @@ class ExplainTest extends SparkFunSuite with HyperspaceSuite {
       .append(displayMode.newLine)
     // scalastyle:on filelinelengthchecker
 
-    df.createOrReplaceTempView("query")
-    hyperspace.createIndex(df, indexConfig)
     val dfSubquery =
       spark.sql("""select Col1 from query where
           |Col1 == (select Col1 from query where Col2==1)""".stripMargin)
@@ -507,7 +510,7 @@ class ExplainTest extends SparkFunSuite with HyperspaceSuite {
       .append("=============================================================")
       .append(displayMode.newLine)
       .append("filterIndex:")
-      .append(getIndexFilesPath("filterIndex"))
+      .append(getIndexRootPath("filterIndex"))
       .append(displayMode.newLine)
       .append(displayMode.newLine)
       .append(displayMode.beginEndTag.close)
@@ -518,7 +521,13 @@ class ExplainTest extends SparkFunSuite with HyperspaceSuite {
     verifyExplainOutput(df, expectedOutput.toString, verbose = false) { filterQuery }
   }
 
-  private def getIndexFilesPath(indexName: String): Path = new Path(systemPath, indexName)
+  private def getIndexRootPath(indexName: String): Path = new Path(systemPath, indexName)
+
+  private def getIndexFilesPath(indexName: String): Path = {
+    val path = new Path(getIndexRootPath(indexName), "v__=0")
+    val fs = path.getFileSystem(new Configuration)
+    fs.listStatus(path).head.getPath
+  }
 
   private def verifyExplainOutput(df: DataFrame, expected: String, verbose: Boolean)(
       query: DataFrame => DataFrame) {

--- a/src/test/scala/com/microsoft/hyperspace/index/plananalysis/ExplainTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/plananalysis/ExplainTest.scala
@@ -518,9 +518,7 @@ class ExplainTest extends SparkFunSuite with HyperspaceSuite {
     verifyExplainOutput(df, expectedOutput.toString, verbose = false) { filterQuery }
   }
 
-  private def getIndexFilesPath(indexName: String): Path = {
-    new Path(systemPath, s"$indexName/v__=0")
-  }
+  private def getIndexFilesPath(indexName: String): Path = new Path(systemPath, indexName)
 
   private def verifyExplainOutput(df: DataFrame, expected: String, verbose: Boolean)(
       query: DataFrame => DataFrame) {

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/FilterIndexRuleTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/FilterIndexRuleTest.scala
@@ -157,7 +157,7 @@ class FilterIndexRuleTest extends HyperspaceRuleTestSuite {
       bucketSpec: Option[BucketSpec]): Unit = {
     val allIndexes = IndexCollectionManager(spark).getIndexes(Seq(Constants.States.ACTIVE))
     val expectedLocation = getIndexDataFilesPath(indexName)
-    assert(location.rootPaths.head.equals(expectedLocation))
+    assert(location.rootPaths.head.toString.startsWith(expectedLocation.toString))
     assert(partitionSchema.equals(new StructType()))
     assert(dataSchema.equals(allIndexes.filter(_.name.equals(indexName)).head.schema))
     assert(bucketSpec.isEmpty)

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.types.{StructField, StructType}
 
 import com.microsoft.hyperspace.HyperspaceException
 import com.microsoft.hyperspace.actions.Constants
-import com.microsoft.hyperspace.index.{Content, CoveringIndex, Hdfs, HyperspaceSuite, IndexConstants, IndexLogEntry, IndexLogManagerImpl, LogicalPlanFingerprint, LogicalPlanSignatureProvider, NoOpFingerprint, Signature, Source, SparkPlan}
+import com.microsoft.hyperspace.index._
 
 trait HyperspaceRuleTestSuite extends HyperspaceSuite {
   def createIndex(
@@ -51,7 +51,9 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
                 .Columns(indexCols.map(_.name), includedCols.map(_.name)),
               IndexLogEntry.schemaString(schemaFromAttributes(indexCols ++ includedCols: _*)),
               10)),
-          Content(getIndexDataFilesPath(name).toUri.toString, Seq()),
+          Content(
+            getIndexDataFilesPath(name).toUri.toString,
+            Seq(Content.Directory("", Seq(), NoOpFingerprint()))),
           Source(SparkPlan(sourcePlanProperties)),
           Map())
 

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.types.{StructField, StructType}
 import com.microsoft.hyperspace.HyperspaceException
 import com.microsoft.hyperspace.actions.Constants
 import com.microsoft.hyperspace.index._
+import com.microsoft.hyperspace.index.Content.Directory.FileInfo
 
 trait HyperspaceRuleTestSuite extends HyperspaceSuite {
   def createIndex(
@@ -53,7 +54,9 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
               10)),
           Content(
             getIndexDataFilesPath(name).toUri.toString,
-            Seq(Content.Directory("", Seq(), NoOpFingerprint()))),
+            Seq(
+              Content
+                .Directory("", Seq(FileInfo("v__=0/f1.parquet", 10, 10)), NoOpFingerprint()))),
           Source(SparkPlan(sourcePlanProperties)),
           Map())
 
@@ -78,6 +81,5 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
     HadoopFsRelation(location, new StructType(), schema, None, new ParquetFileFormat, Map.empty)(
       spark)
 
-  def getIndexRootPath(indexName: String): Path =
-    new Path(systemPath, indexName)
+  def getIndexRootPath(indexName: String): Path = new Path(systemPath, indexName)
 }

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/JoinIndexRuleTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/JoinIndexRuleTest.scala
@@ -332,8 +332,9 @@ class JoinIndexRuleTest extends HyperspaceRuleTestSuite with SQLHelper {
     }
   }
 
-  test("Join rule updates plan if columns have one-to-one mapping with repeated " +
-    "case-insensitive predicates") {
+  test(
+    "Join rule updates plan if columns have one-to-one mapping with repeated " +
+      "case-insensitive predicates") {
     val t1ProjectNode = Project(Seq(t1c1, t1c3), t1FilterNode)
     val t2ProjectNode = Project(Seq(t2c1, t2c3), t2FilterNode)
 
@@ -401,7 +402,12 @@ class JoinIndexRuleTest extends HyperspaceRuleTestSuite with SQLHelper {
       updatedPlan: LogicalPlan,
       indexPaths: Seq[Path]): Unit = {
     assert(treeStructureEquality(originalPlan, updatedPlan))
-    assert(basePaths(updatedPlan) == indexPaths)
+    val bP = basePaths(updatedPlan)
+    assert(bP.length == indexPaths.length)
+    assert(bP.zip(indexPaths).forall {
+      case (a, b) =>
+        a.toString.startsWith(b.toString)
+    })
   }
 
   /** method to check if tree structures of two logical plans are the same. */


### PR DESCRIPTION
### What changes were proposed in this pull request?
Changes in this PR:
- Index metadata will store index file contents as below (note the `<root>/<directory>/<file>` structure:
```
  "content" : {
    "root" : "file:/C:/Users/apdave/github/hyperspace-1/src/test/resources/indexLocation/index1",
    "directories" : [ {
      "path" : "v__=0",
      "files" : [ {
        "name" : "part-00007-ec24eb01-d061-4cd7-b10f-9ba9c3fdc972_00007.c000.snappy.parquet",
        "size" : 926,
        "modifiedTime" : 1597960540839
      }, {
        "name" : "part-00011-ec24eb01-d061-4cd7-b10f-9ba9c3fdc972_00011.c000.snappy.parquet",
        "size" : 926,
        "modifiedTime" : 1597960540730
      }, ...
```
- JoinIndexRule, FilterIndexRule (and future rules) will read from a list of index **files** which comprise of the latest snapshot of the index. This was not true in previous versions. Earlier, the index was represented by just its root directory.

### Why are the changes needed?
For support of future features like #110 and #60 , it's now required to read a subset of index files from a list of index directories. For this, we are updating the metadata to store a complete list of files which represent the current state of the index.

### Does this PR introduce _any_ user-facing change?
yes, the metadata layout is changed. Previously created indexes will be unreadable.

### How was this patch tested?
unit tests 