### PR TITLE
New Tree based Structure for index metadata

### DIFF
--- a/notebooks/python/Hitchhikers Guide to Hyperspace.ipynb
+++ b/notebooks/python/Hitchhikers Guide to Hyperspace.ipynb
@@ -1,0 +1,749 @@
+{
+  "metadata": {
+    "saveOutput": true,
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2,
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Hitchhiker's Guide to Hyperspace - An Indexing Subsystem for Apache Spark™\n",
+        "Hyperspace introduces the ability for Apache Spark™ users to create indexes on their datasets (e.g., CSV, JSON, Parquet etc.) and leverage them for potential query and workload acceleration.\n",
+        "\n",
+        "In this notebook, we highlight the basics of Hyperspace, emphasizing on its simplicity and shows how it can be used by just anyone.\n",
+        "\n",
+        "**Disclaimer**: Hyperspace helps accelerate your workloads/queries under two circumstances:\n",
+        "\n",
+        "  1. Queries contain filters on predicates with high selectivity (e.g., you want to select 100 matching rows from a million candidate rows)\n",
+        "  2. Queries contain a join that requires heavy-shuffles (e.g., you want to join a 100 GB dataset with a 10 GB dataset)\n",
+        "\n",
+        "You may want to carefully monitor your workloads and determine whether indexing is helping you on a case-by-case basis."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Setup\n",
+        "To begin with, let's start a new Spark™ session. Since this notebook is a tutorial merely to illustrate what Hyperspace can offer, we will make a configuration change that allow us to highlight what Hyperspace is doing on small datasets. By default, Spark™ uses *broadcast join* to optimize join queries when the data size for one side of join is small (which is the case for the sample data we use in this tutorial). Therefore, we disable broadcast joins so that later when we run join queries, Spark™ uses *sort-merge* join. This is mainly to show how Hyperspace indexes would be used at scale for accelerating join queries.\n",
+        "\n",
+        "The output of running the cell below shows a reference to the successfully created Spark™ session and prints out '-1' as the value for the modified join config which indicates that broadcast join is successfully disabled."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 16,
+          "data": {
+            "text/plain": "-1"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "# Start your Spark session\n",
+        "spark\n",
+        "\n",
+        "# Disable BroadcastHashJoin, so Spark will use standard SortMergeJoin. Currently Hyperspace indexes utilize SortMergeJoin to speed up query.\n",
+        "spark.conf.set(\"spark.sql.autoBroadcastJoinThreshold\", -1)\n",
+        "\n",
+        "# Verify that BroadcastHashJoin is set correctly \n",
+        "print(spark.conf.get(\"spark.sql.autoBroadcastJoinThreshold\"))"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Data Preparation\n",
+        "\n",
+        "To prepare our environment, we will create sample data records and save them as parquet data files. While we use Parquet for illustration, you can use other formats such as CSV. In the subsequent cells, we will also demonstrate how you can create several Hyperspace indexes on this sample dataset and how one can make Spark™ use them when running queries. \n",
+        "\n",
+        "Our example records correspond to two datasets: *department* and *employee*. You should configure \"empLocation\" and \"deptLocation\" paths so that on the storage account they point to your desired location to save generated data files. \n",
+        "\n",
+        "The output of running below cell shows contents of our datasets as lists of triplets followed by references to dataFrames created to save the content of each dataset in our preferred location."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "outputs": [],
+      "metadata": {},
+      "source": [
+        "from pyspark.sql.types import StructField, StructType, StringType, IntegerType\n",
+        "\n",
+        "# Sample department records\n",
+        "departments = [(10, \"Accounting\", \"New York\"), (20, \"Research\", \"Dallas\"), (30, \"Sales\", \"Chicago\"), (40, \"Operations\", \"Boston\")]\n",
+        "\n",
+        "# Sample employee records\n",
+        "employees = [(7369, \"SMITH\", 20), (7499, \"ALLEN\", 30), (7521, \"WARD\", 30), (7566, \"JONES\", 20), (7698, \"BLAKE\", 30)]\n",
+        "\n",
+        "# Create a schema for the dataframe\n",
+        "dept_schema = StructType([StructField('deptId', IntegerType(), True), StructField('deptName', StringType(), True), StructField('location', StringType(), True)])\n",
+        "emp_schema = StructType([StructField('empId', IntegerType(), True), StructField('empName', StringType(), True), StructField('deptId', IntegerType(), True)])\n",
+        "\n",
+        "departments_df = spark.createDataFrame(departments, dept_schema)\n",
+        "employees_df = spark.createDataFrame(employees, emp_schema)\n",
+        "\n",
+        "#TODO ** customize this location path **\n",
+        "emp_Location = \"/<yourpath>/employees.parquet\"\n",
+        "dept_Location = \"/<yourpath>/departments.parquet\"\n",
+        "\n",
+        "employees_df.write.mode(\"overwrite\").parquet(emp_Location)\n",
+        "departments_df.write.mode(\"overwrite\").parquet(dept_Location)"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Let's verify the contents of parquet files we created above to make sure they contain expected records in correct format. We later use these data files to create Hyperspace indexes and run sample queries.\n",
+        "\n",
+        "Running below cell, the output displays the rows in employee and department dataFrames in a tabular form. There should be 14 employees and 4 departments, each matching with one of triplets we created in the previous cell."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 18,
+          "data": {
+            "text/plain": "+-----+-------+------+\n|empId|empName|deptId|\n+-----+-------+------+\n| 7369|  SMITH|    20|\n| 7499|  ALLEN|    30|\n| 7566|  JONES|    20|\n| 7698|  BLAKE|    30|\n| 7521|   WARD|    30|\n+-----+-------+------+\n\n+------+----------+--------+\n|deptId|  deptName|location|\n+------+----------+--------+\n|    10|Accounting|New York|\n|    40|Operations|  Boston|\n|    20|  Research|  Dallas|\n|    30|     Sales| Chicago|\n+------+----------+--------+"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "# emp_Location and dept_Location are the user defined locations above to save parquet files\n",
+        "emp_DF = spark.read.parquet(emp_Location)\n",
+        "dept_DF = spark.read.parquet(dept_Location)\n",
+        "\n",
+        "# Verify the data is available and correct\n",
+        "emp_DF.show()\n",
+        "dept_DF.show()"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Hello Hyperspace Index!\n",
+        "Hyperspace lets users create indexes on records scanned from persisted data files. Once successfully created, an entry corresponding to the index is added to the Hyperspace's metadata. This metadata is later used by Apache Spark™'s optimizer (with our extensions) during query processing to find and use proper indexes. \n",
+        "\n",
+        "Once indexes are created, users can perform several actions:\n",
+        "  - **Refresh** If the underlying data changes, users can refresh an existing index to capture that. \n",
+        "  - **Delete** If the index is not needed, users can perform a soft-delete i.e., index is not physically deleted but is marked as 'deleted' so it is no longer used in your workloads.\n",
+        "  - **Vacuum** If an index is no longer required, users can vacuum it which forces a physical deletion of the index contents and associated metadata completely from Hyperspace's metadata.\n",
+        "\n",
+        "Below sections show how such index management operations can be done in Hyperspace.\n",
+        "\n",
+        "First, we need to import the required libraries and create an instance of Hyperspace. We later use this instance to invoke different Hyperspace APIs to create indexes on our sample data and modify those indexes.\n",
+        "\n",
+        "Output of running below cell shows a reference to the created instance of Hyperspace."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "outputs": [],
+      "metadata": {},
+      "source": [
+        "from hyperspace import *\n",
+        "\n",
+        "# Create an instance of Hyperspace\n",
+        "hyperspace = Hyperspace(spark)"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Create Indexes\n",
+        "To create a Hyperspace index, the user needs to provide 2 pieces of information:\n",
+        "* An Apache Spark™ DataFrame which references the data to be indexed.\n",
+        "* An index configuration object: IndexConfig, which specifies the *index name*, *indexed* and *included* columns of the index. \n",
+        "\n",
+        "We start by creating three Hyperspace indexes on our sample data: two indexes on the department dataset named \"deptIndex1\" and \"deptIndex2\", and one index on the employee dataset named 'empIndex'. \n",
+        "For each index, we need a corresponding IndexConfig to capture the name along with columns lists for the indexed and included columns. Running below cell creates these indexConfigs and its output lists them.\n",
+        "\n",
+        "**Note**: An *index column* is a column that appears in your filters or join conditions. An *included column* is a column that appears in your select/project.\n",
+        "\n",
+        "For instance, in the following query:\n",
+        "```sql\n",
+        "SELECT X\n",
+        "FROM Table\n",
+        "WHERE Y = 2\n",
+        "```\n",
+        "X can be an *index column* and Y can be an *included column*."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "outputs": [],
+      "metadata": {},
+      "source": [
+        "# Create index configurations\n",
+        "\n",
+        "emp_IndexConfig = IndexConfig(\"empIndex1\", [\"deptId\"], [\"empName\"])\n",
+        "dept_IndexConfig1 = IndexConfig(\"deptIndex1\", [\"deptId\"], [\"deptName\"])\n",
+        "dept_IndexConfig2 = IndexConfig(\"deptIndex2\", [\"location\"], [\"deptName\"])"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Now, we create three indexes using our index configurations. For this purpose, we invoke \"createIndex\" command on our Hyperspace instance. This command requires an index configuration and the dataFrame containing rows to be indexed.\n",
+        "Running below cell creates three indexes.\n",
+        ""
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "outputs": [],
+      "metadata": {},
+      "source": [
+        "# Create indexes from configurations\n",
+        "\n",
+        "hyperspace.createIndex(emp_DF, emp_IndexConfig)\n",
+        "hyperspace.createIndex(dept_DF, dept_IndexConfig1)\n",
+        "hyperspace.createIndex(dept_DF, dept_IndexConfig2)"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### List Indexes\n",
+        "\n",
+        "Below code shows how a user can list all available indexes in a Hyperspace instance. It uses \"indexes\" API which returns information about existing indexes as a Spark™'s DataFrame so you can perform additional operations. For instance, you can invoke valid operations on this DataFrame for checking its content or analyzing it further (for example filtering specific indexes or grouping them according to some desired property). \n",
+        "\n",
+        "Below cell uses DataFrame's 'show' action to fully print the rows and show details of our indexes in a tabular form. For each index, we can see all information Hyperspace has stored about it in the metadata. You will immediately notice the following:\n",
+        "  - \"config.indexName\", \"config.indexedColumns\", \"config.includedColumns\" and \"status.status\" are the fields that a user normally refers to. \n",
+        "  - \"dfSignature\" is automatically generated by Hyperspace and is unique for each index. Hyperspace uses this signature internally to maintain the index and exploit it at query time. \n",
+        "  \n",
+        "In the output below, all three indexes should have \"ACTIVE\" as status and their name, indexed columns, and included columns should match with what we defined in index configurations above.\n",
+        ""
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 23,
+          "data": {
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation| state|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...|ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...|ACTIVE|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|/location/...|ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "hyperspace.indexes().show()"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Delete Indexes\n",
+        "A user can drop an existing index by using the \"deleteIndex\" API and providing the index name. Index deletion does a soft delete: It mainly updates index's status in the Hyperspace metadata from \"ACTIVE\" to \"DELETED\". This will exclude the dropped index from any future query optimization and Hyperspace no longer picks that index for any query. However, index files for a deleted index still remain available (since it is a soft-delete), so that the index could be restored if user asks for.\n",
+        "\n",
+        "Below cell deletes index with name \"deptIndex2\" and lists Hyperspace metadata after that. The output should be similar to above cell for \"List Indexes\" except for \"deptIndex2\" which now should have its status changed into \"DELETED\"."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 24,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 24,
+          "data": {
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...| ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...|DELETED|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|/location/...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "hyperspace.deleteIndex(\"deptIndex2\")\n",
+        "\n",
+        "hyperspace.indexes().show()"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Restore Indexes\n",
+        "A user can use the \"restoreIndex\" API to restore a deleted index. This will bring back the latest version of index into ACTIVE status and makes it usable again for queries. Below cell shows an example of \"restoreIndex\" usage. We delete \"deptIndex1\" and restore it. The output shows \"deptIndex1\" first went into the \"DELETED\" status after invoking \"deleteIndex\" command and came back to the \"ACTIVE\" status after calling \"restoreIndex\".\n",
+        ""
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 25,
+          "data": {
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...|DELETED|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...|DELETED|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|/location/...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...| ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...|DELETED|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|/location/...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "hyperspace.deleteIndex(\"deptIndex1\")\n",
+        "\n",
+        "hyperspace.indexes().show()\n",
+        "\n",
+        "hyperspace.restoreIndex(\"deptIndex1\")\n",
+        "\n",
+        "hyperspace.indexes().show()"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Vacuum Indexes\n",
+        "The user can perform a hard-delete i.e., fully remove files and the metadata entry for a deleted index using \"vacuumIndex\" command. Once done, this action is irreversible as it physically deletes all the index files (which is why it is a hard-delete).\n",
+        " \n",
+        "The cell below vacuums the \"deptIndex2\" index and shows Hyperspace metadata after vaccuming. You should see metadata entries for two indexes \"deptIndex1\" and \"empIndex\" both with \"ACTIVE\" status and no entry for \"deptIndex2\"."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 72,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+--------------------+------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|           queryPlan| state|\n+----------+--------------+---------------+----------+--------------------+--------------------+--------------------+------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|/datasets/idx...|Relation[deptId#1...|ACTIVE|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|/datasets/idx...|Relation[empId#19...|ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+--------------------+------+"
+          },
+          "execution_count": 72,
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "hyperspace.vacuumIndex(\"deptIndex2\")\n",
+        "hyperspace.indexes().show()"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Enable/Disable Hyperspace\n",
+        "\n",
+        "Hyperspace provides APIs to enable or disable index usage with Spark™.\n",
+        "\n",
+        "  - By using \"enable\" command, Hyperspace optimization rules become visible to the Apache Spark™ optimizer and they will exploit existing Hyperspace indexes to optimize user queries.\n",
+        "  - By using \"disable' command, Hyperspace rules no longer apply during query optimization. You should note that disabling Hyperspace has no impact on created indexes as they remain intact.\n",
+        "\n",
+        "Below cell shows how you can use these commands to enable or disable Hyperspace. The output simply shows a reference to the existing Spark™ session whose configuration is updated."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 26,
+          "data": {
+            "text/plain": "<pyspark.sql.session.SparkSession object at 0x7f30d4c90dd8>"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "# Enable Hyperspace\n",
+        "Hyperspace.enable(spark)\n",
+        "\n",
+        "# Disable Hyperspace\n",
+        "Hyperspace.disable(spark)"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Index Usage\n",
+        "In order to make Spark use Hyperspace indexes during query processing, the user needs to make sure that Hyperspace is enabled. \n",
+        "\n",
+        "The cell below enables Hyperspace and creates two DataFrames containing our sample data records which we use for running example queries. For each DataFrame, a few sample rows are printed."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 27,
+          "data": {
+            "text/plain": "+-----+-------+------+\n|empId|empName|deptId|\n+-----+-------+------+\n| 7369|  SMITH|    20|\n| 7499|  ALLEN|    30|\n| 7566|  JONES|    20|\n| 7698|  BLAKE|    30|\n| 7521|   WARD|    30|\n+-----+-------+------+\n\n+------+----------+--------+\n|deptId|  deptName|location|\n+------+----------+--------+\n|    10|Accounting|New York|\n|    40|Operations|  Boston|\n|    20|  Research|  Dallas|\n|    30|     Sales| Chicago|\n+------+----------+--------+"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "# Enable Hyperspace\n",
+        "Hyperspace.enable(spark)\n",
+        "\n",
+        "emp_DF = spark.read.parquet(emp_Location)\n",
+        "dept_DF = spark.read.parquet(dept_Location)\n",
+        "\n",
+        "emp_DF.show(5)\n",
+        "dept_DF.show(5)"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Hyperspace's Index Types\n",
+        "\n",
+        "Currently, Hyperspace has rules to exploit indexes for two groups of queries: \n",
+        "* Selection queries with lookup or range selection filtering predicates.\n",
+        "* Join queries with an equality join predicate (i.e. Equi-joins).\n",
+        ""
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Indexes for Accelerating Filters\n",
+        "\n",
+        "Our first example query does a lookup on department records (see below cell). In SQL, this query looks as follows:\n",
+        "\n",
+        "```sql\n",
+        "SELECT deptName \n",
+        "FROM departments\n",
+        "WHERE deptId = 20\n",
+        "```\n",
+        "\n",
+        "The output of running the cell below shows: \n",
+        "- query result, which is a single department name.\n",
+        "- query plan that Spark™ used to run the query. \n",
+        "\n",
+        "In the query plan, the \"FileScan\" operator at the bottom of the plan shows the datasource where the records were read from. The location of this file indicates the path to the latest version of the \"deptIndex1\" index. This shows  that according to the query and using Hyperspace optimization rules, Spark™ decided to exploit the proper index at runtime.\n",
+        ""
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 28,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 28,
+          "data": {
+            "text/plain": "+--------+\n|deptName|\n+--------+\n|Research|\n+--------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#492 = 20)\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#493]\n+- Filter (deptId#492 = 20)\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#493]\n+- Filter (isnotnull(deptId#492) && (deptId#492 = 20))\n   +- Relation[deptId#492,deptName#493] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#493]\n+- *(1) Filter (isnotnull(deptId#492) && (deptId#492 = 20))\n   +- *(1) FileScan parquet [deptId#492,deptName#493] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/deptIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId), EqualTo(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "# Filter with equality predicate\n",
+        "\n",
+        "eqFilter = dept_DF.filter(\"\"\"deptId = 20\"\"\").select(\"\"\"deptName\"\"\")\n",
+        "eqFilter.show()\n",
+        "\n",
+        "eqFilter.explain(True)"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Our second example is a range selection query on department records. In SQL, this query looks as follows:\n",
+        "\n",
+        "```sql\n",
+        "SELECT deptName \n",
+        "FROM departments\n",
+        "WHERE deptId > 20\"\n",
+        "```\n",
+        "Similar to our first example, the output of the cell below shows the query results (names of two departments) and the query plan. The location of data file in the FileScan operator shows that 'deptIndex1\" was used to run the query.   \n",
+        ""
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 29,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 29,
+          "data": {
+            "text/plain": "+----------+\n|  deptName|\n+----------+\n|Operations|\n|     Sales|\n+----------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#492 > 20)\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#493]\n+- Filter (deptId#492 > 20)\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#493]\n+- Filter (isnotnull(deptId#492) && (deptId#492 > 20))\n   +- Relation[deptId#492,deptName#493] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#493]\n+- *(1) Filter (isnotnull(deptId#492) && (deptId#492 > 20))\n   +- *(1) FileScan parquet [deptId#492,deptName#493] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/deptIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "# Filter with range selection predicate\n",
+        "\n",
+        "rangeFilter = dept_DF.filter(\"\"\"deptId > 20\"\"\").select(\"deptName\")\n",
+        "rangeFilter.show()\n",
+        "\n",
+        "rangeFilter.explain(True)"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Our third example is a query joining department and employee records on the department id. The equivalent SQL statement is shown below:\n",
+        "\n",
+        "```sql\n",
+        "SELECT employees.deptId, empName, departments.deptId, deptName\n",
+        "FROM   employees, departments \n",
+        "WHERE  employees.deptId = departments.deptId\"\n",
+        "```\n",
+        "\n",
+        "The output of running the cell below shows the query results which are the names of 14 employees and the name of department each employee works in. The query plan is also included in the output. Notice how the file locations for two FileScan operators shows that Spark used \"empIndex\" and \"deptIndex1\" indexes to run the query.   \n",
+        ""
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 30,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 30,
+          "data": {
+            "text/plain": "+-------+--------+\n|empName|deptName|\n+-------+--------+\n|  SMITH|Research|\n|  JONES|Research|\n|  ALLEN|   Sales|\n|  BLAKE|   Sales|\n|   WARD|   Sales|\n+-------+--------+\n\n== Parsed Logical Plan ==\nProject [empName#487, deptName#493]\n+- Join Inner, (deptId#488 = deptId#492)\n   :- Relation[empId#486,empName#487,deptId#488] parquet\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#487, deptName#493]\n+- Join Inner, (deptId#488 = deptId#492)\n   :- Relation[empId#486,empName#487,deptId#488] parquet\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Optimized Logical Plan ==\nProject [empName#487, deptName#493]\n+- Join Inner, (deptId#488 = deptId#492)\n   :- Project [empName#487, deptId#488]\n   :  +- Filter isnotnull(deptId#488)\n   :     +- Relation[empName#487,deptId#488] parquet\n   +- Project [deptId#492, deptName#493]\n      +- Filter isnotnull(deptId#492)\n         +- Relation[deptId#492,deptName#493] parquet\n\n== Physical Plan ==\n*(3) Project [empName#487, deptName#493]\n+- *(3) SortMergeJoin [deptId#488], [deptId#492], Inner\n   :- *(1) Project [empName#487, deptId#488]\n   :  +- *(1) Filter isnotnull(deptId#488)\n   :     +- *(1) FileScan parquet [deptId#488,empName#487] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/empIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#492, deptName#493]\n      +- *(2) Filter isnotnull(deptId#492)\n         +- *(2) FileScan parquet [deptId#492,deptName#493] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/deptIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "# Join\n",
+        "\n",
+        "eqJoin = emp_DF.join(dept_DF, emp_DF.deptId == dept_DF.deptId).select(emp_DF.empName, dept_DF.deptName)\n",
+        "\n",
+        "eqJoin.show()\n",
+        "\n",
+        "eqJoin.explain(True)"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 31,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 31,
+          "data": {
+            "text/plain": "+-------+--------+\n|empName|deptName|\n+-------+--------+\n|  SMITH|Research|\n|  JONES|Research|\n|  ALLEN|   Sales|\n|  BLAKE|   Sales|\n|   WARD|   Sales|\n+-------+--------+\n\n== Parsed Logical Plan ==\nProject [empName#487, deptName#493]\n+- Join Inner, (deptId#488 = deptId#492)\n   :- Relation[empId#486,empName#487,deptId#488] parquet\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#487, deptName#493]\n+- Join Inner, (deptId#488 = deptId#492)\n   :- Relation[empId#486,empName#487,deptId#488] parquet\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Optimized Logical Plan ==\nProject [empName#487, deptName#493]\n+- Join Inner, (deptId#488 = deptId#492)\n   :- Project [empName#487, deptId#488]\n   :  +- Filter isnotnull(deptId#488)\n   :     +- Relation[empName#487,deptId#488] parquet\n   +- Project [deptId#492, deptName#493]\n      +- Filter isnotnull(deptId#492)\n         +- Relation[deptId#492,deptName#493] parquet\n\n== Physical Plan ==\n*(3) Project [empName#487, deptName#493]\n+- *(3) SortMergeJoin [deptId#488], [deptId#492], Inner\n   :- *(1) Project [empName#487, deptId#488]\n   :  +- *(1) Filter isnotnull(deptId#488)\n   :     +- *(1) FileScan parquet [deptId#488,empName#487] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/empIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#492, deptName#493]\n      +- *(2) Filter isnotnull(deptId#492)\n         +- *(2) FileScan parquet [deptId#492,deptName#493] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/deptIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "# Join\n",
+        "\n",
+        "eqJoin = emp_DF.join(dept_DF, emp_DF.deptId == dept_DF.deptId).select(emp_DF.empName, dept_DF.deptName)\n",
+        "\n",
+        "eqJoin.show()\n",
+        "\n",
+        "eqJoin.explain(True)"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Support for SQL Semantics\n",
+        "\n",
+        "The index usage is transparent to whether the user uses DataFrame API or Spark™ SQL. The following example shows the same join example as before, in sql form, showing the use of indexes if applicable."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 32,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 32,
+          "data": {
+            "text/plain": "+-------+--------+\n|empName|deptName|\n+-------+--------+\n|  SMITH|Research|\n|  JONES|Research|\n|  ALLEN|   Sales|\n|  BLAKE|   Sales|\n|   WARD|   Sales|\n+-------+--------+\n\n== Parsed Logical Plan ==\n'Project ['EMP.empName, 'DEPT.deptName]\n+- 'Filter ('EMP.deptId = 'DEPT.deptId)\n   +- 'Join Inner\n      :- 'UnresolvedRelation `EMP`\n      +- 'UnresolvedRelation `DEPT`\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#487, deptName#493]\n+- Filter (deptId#488 = deptId#492)\n   +- Join Inner\n      :- SubqueryAlias `emp`\n      :  +- Relation[empId#486,empName#487,deptId#488] parquet\n      +- SubqueryAlias `dept`\n         +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Optimized Logical Plan ==\nProject [empName#487, deptName#493]\n+- Join Inner, (deptId#488 = deptId#492)\n   :- Project [empName#487, deptId#488]\n   :  +- Filter isnotnull(deptId#488)\n   :     +- Relation[empName#487,deptId#488] parquet\n   +- Project [deptId#492, deptName#493]\n      +- Filter isnotnull(deptId#492)\n         +- Relation[deptId#492,deptName#493] parquet\n\n== Physical Plan ==\n*(3) Project [empName#487, deptName#493]\n+- *(3) SortMergeJoin [deptId#488], [deptId#492], Inner\n   :- *(1) Project [empName#487, deptId#488]\n   :  +- *(1) Filter isnotnull(deptId#488)\n   :     +- *(1) FileScan parquet [deptId#488,empName#487] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/empIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#492, deptName#493]\n      +- *(2) Filter isnotnull(deptId#492)\n         +- *(2) FileScan parquet [deptId#492,deptName#493] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/deptIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "from pyspark.sql import SparkSession\n",
+        "\n",
+        "emp_DF.createOrReplaceTempView(\"EMP\")\n",
+        "dept_DF.createOrReplaceTempView(\"DEPT\")\n",
+        "\n",
+        "joinQuery = spark.sql(\"SELECT EMP.empName, DEPT.deptName FROM EMP, DEPT WHERE EMP.deptId = DEPT.deptId\")\n",
+        "\n",
+        "joinQuery.show()\n",
+        "joinQuery.explain(True)"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Explain API\n",
+        "Indexes are great but how do you know if they are being used? Hyperspace allows users to compare their original plan vs the updated index-dependent plan before running their query. You have an option to choose from html/plaintext/console mode to display the command output. \n",
+        "\n",
+        "The following cell shows an example with HTML. The highlighted section represents the difference between original and updated plans along with the indexes being used."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 42,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 42,
+          "data": {
+            "text/html": "<pre>=============================================================<br>Plan with indexes:<br>=============================================================<br>Project [empName#487, deptName#493]<br>+- SortMergeJoin [deptId#488], [deptId#492], Inner<br>   <b style=\"background:LightGreen\">:- *(1) Project [empName#487, deptId#488]</b><br>   <b style=\"background:LightGreen\">:  +- *(1) Filter isnotnull(deptId#488)</b><br>   <b style=\"background:LightGreen\">:     +- *(1) FileScan parquet [deptId#488,empName#487] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/empIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200</b><br>   <b style=\"background:LightGreen\">+- *(2) Project [deptId#492, deptName#493]</b><br>      <b style=\"background:LightGreen\">+- *(2) Filter isnotnull(deptId#492)</b><br>         <b style=\"background:LightGreen\">+- *(2) FileScan parquet [deptId#492,deptName#493] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/deptIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200</b><br><br>=============================================================<br>Plan without indexes:<br>=============================================================<br>Project [empName#487, deptName#493]<br>+- SortMergeJoin [deptId#488], [deptId#492], Inner<br>   <b style=\"background:LightGreen\">:- *(2) Sort [deptId#488 ASC NULLS FIRST], false, 0</b><br>   <b style=\"background:LightGreen\">:  +- Exchange hashpartitioning(deptId#488, 200), [id=#353]</b><br>   <b style=\"background:LightGreen\">:     +- *(1) Project [empName#487, deptId#488]</b><br>   <b style=\"background:LightGreen\">:        +- *(1) Filter isnotnull(deptId#488)</b><br>   <b style=\"background:LightGreen\">:           +- *(1) FileScan parquet [empName#487,deptId#488] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@location../employees.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<empName:string,deptId:int></b><br>   <b style=\"background:LightGreen\">+- *(4) Sort [deptId#492 ASC NULLS FIRST], false, 0</b><br>      <b style=\"background:LightGreen\">+- Exchange hashpartitioning(deptId#492, 200), [id=#359]</b><br>         <b style=\"background:LightGreen\">+- *(3) Project [deptId#492, deptName#493]</b><br>            <b style=\"background:LightGreen\">+- *(3) Filter isnotnull(deptId#492)</b><br>               <b style=\"background:LightGreen\">+- *(3) FileScan parquet [deptId#492,deptName#493] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@location../departments.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string></b><br><br>=============================================================<br>Indexes used:<br>=============================================================<br>deptIndex1:/location/deptIndex1/v__=0<br>empIndex1:/location/empIndex1/v__=0<br><br>=============================================================<br>Physical operator stats:<br>=============================================================<br>+------------------+-------------------+------------------+----------+<br>| Physical Operator|Hyperspace Disabled|Hyperspace Enabled|Difference|<br>+------------------+-------------------+------------------+----------+<br>|     *InputAdapter|                  4|                 2|        -2|<br>|  *ShuffleExchange|                  2|                 0|        -2|<br>|             *Sort|                  2|                 0|        -2|<br>|*WholeStageCodegen|                  5|                 3|        -2|<br>|            Filter|                  2|                 2|         0|<br>|           Project|                  3|                 3|         0|<br>|      Scan parquet|                  2|                 2|         0|<br>|     SortMergeJoin|                  1|                 1|         0|<br>+------------------+-------------------+------------------+----------+<br><br></pre>"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "eqJoin = emp_DF.join(dept_DF, emp_DF.deptId == dept_DF.deptId).select(emp_DF.empName, dept_DF.deptName)\n",
+        "\n",
+        "spark.conf.set(\"spark.hyperspace.explain.displayMode\", \"html\")\n",
+        "hyperspace.explain(eqJoin, True, displayHTML)"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Refresh Indexes\n",
+        "If the original data on which an index was created changes, then the index will no longer capture the latest state of data. The user can refresh such a stale index using \"refreshIndex\" command. This causes the index to be fully rebuilt and updates it accroding to the latest data records (don't worry, we will show you how to *incrementally refresh* your index in other notebooks).\n",
+        "\n",
+        "The two cells below show an example for this scenario:\n",
+        "- First cell adds two more departments to the original departments data. It reads and prints list of departments to verify new departments are added correctly. The output shows 6 departments in total: four old ones and two new. Invoking \"refreshIndex\" updates \"deptIndex1\" so index captures new departments.\n",
+        "- Second cell runs our range selection query example. The results should now contain four departments: two are the ones, seen before when we ran the query above, and two are the new departments we just added."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 43,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 43,
+          "data": {
+            "text/plain": "+------+---------------+-------------+\n|deptId|       deptName|     location|\n+------+---------------+-------------+\n|    60|Human Resources|San Francisco|\n|    60|Human Resources|San Francisco|\n|    10|     Accounting|     New York|\n|    50|      Inovation|      Seattle|\n|    50|      Inovation|      Seattle|\n|    40|     Operations|       Boston|\n|    20|       Research|       Dallas|\n|    30|          Sales|      Chicago|\n+------+---------------+-------------+"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "extra_Departments = [(50, \"Inovation\", \"Seattle\"), (60, \"Human Resources\", \"San Francisco\")]\n",
+        "\n",
+        "extra_departments_df = spark.createDataFrame(extra_Departments, dept_schema)\n",
+        "extra_departments_df.write.mode(\"Append\").parquet(dept_Location)\n",
+        "\n",
+        "\n",
+        "dept_DFrame_Updated = spark.read.parquet(dept_Location)\n",
+        "\n",
+        "dept_DFrame_Updated.show(10)"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 45,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 45,
+          "data": {
+            "text/plain": "+---------------+\n|       deptName|\n+---------------+\n|Human Resources|\n|Human Resources|\n|      Inovation|\n|      Inovation|\n|     Operations|\n|          Sales|\n+---------------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#905 > 20)\n   +- Relation[deptId#905,deptName#906,location#907] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#906]\n+- Filter (deptId#905 > 20)\n   +- Relation[deptId#905,deptName#906,location#907] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#906]\n+- Filter (isnotnull(deptId#905) && (deptId#905 > 20))\n   +- Relation[deptId#905,deptName#906,location#907] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#906]\n+- *(1) Filter (isnotnull(deptId#905) && (deptId#905 > 20))\n   +- *(1) FileScan parquet [deptId#905,deptName#906] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@location../departments.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "newRangeFilter = dept_DFrame_Updated.filter(\"deptId > 20\").select(\"deptName\")\n",
+        "newRangeFilter.show()\n",
+        "\n",
+        "newRangeFilter.explain(True)"
+      ],
+      "attachments": {}
+    }
+  ]
+}

--- a/src/main/scala/com/microsoft/hyperspace/index/ExperimentalStructure.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/ExperimentalStructure.scala
@@ -74,7 +74,7 @@ object Directory {
     val files: Seq[FileInfo1] = {
       try {
         val fs = path.getFileSystem(new Configuration)
-        val statuses = fs.listStatus(path)
+        val statuses = fs.listStatus(path).filter(status => isDataPath(status.getPath))
 
         // Assuming index directories don't contain nested directories. Only Leaf files.
         assert(statuses.forall(!_.isDirectory))
@@ -91,6 +91,12 @@ object Directory {
     } else {
       Directory(path.getParent, Directory(path.getName, files, Seq()))
     }
+  }
+
+  /* from PartitionAwareFileIndex */
+  private def isDataPath(path: Path): Boolean = {
+    val name = path.getName
+    !((name.startsWith("_") && !name.contains("=")) || name.startsWith("."))
   }
 
   def apply(path: Path, child: Directory): Directory = {

--- a/src/main/scala/com/microsoft/hyperspace/index/ExperimentalStructure.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/ExperimentalStructure.scala
@@ -1,0 +1,83 @@
+package com.microsoft.hyperspace.index
+
+import java.io.FileNotFoundException
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, Path}
+
+import com.microsoft.hyperspace.index.Content1.Directory
+import com.microsoft.hyperspace.util.{JsonUtils, PathUtils}
+// scalastyle:off
+case class Content1(directory: Content1.Directory) {
+  def files: Seq[Path] = rec(new Path(directory.name), directory)
+
+  private def rec(prefixPath: Path, directory: Directory): Seq[Path] = {
+    val files = directory.files.map(f => new Path(prefixPath, f.name))
+    files ++ directory.dirs.flatMap {
+      dir => rec(new Path(prefixPath, dir.name), dir)
+    }
+  }
+}
+object Content1 {
+
+  case class Directory(
+    name: String,
+    files: Seq[Directory.FileInfo] = Seq(),
+    dirs: Seq[Directory] = Seq())
+
+  object Directory {
+
+    case class FileInfo(name: String, size: Long, modifiedTime: Long)
+
+    object FileInfo {
+      def apply(s: FileStatus): FileInfo =
+        FileInfo(s.getPath.getName, s.getLen, s.getModificationTime)
+    }
+
+    def apply(path: Path): Directory = {
+      val files: Seq[FileInfo] = {
+        try {
+          val fs = path.getFileSystem(new Configuration)
+          val statuses = fs.listStatus(path)
+
+          // Assuming index directories don't contain nested directories. Only Leaf files.
+          assert(statuses.forall(!_.isDirectory))
+
+          statuses.map(FileInfo(_)).toSeq
+        } catch {
+          // FileNotFoundException is an expected exception before index gets created.
+          case _: FileNotFoundException => Seq()
+          case e: Throwable => throw e
+        }
+      }
+      if (path.isRoot) {
+        Directory(path.toString, files, Seq())
+      } else {
+        Directory(path.getParent, Directory(path.getName, files, Seq()))
+      }
+    }
+
+    def apply(path: Path, child: Directory): Directory = {
+      if (path.isRoot) {
+        Directory(path.toString, Seq(), Seq(child))
+      } else {
+        Directory(path.getParent, Directory(path.getName, Seq(), Seq(child)))
+      }
+    }
+  }
+
+  def apply(path: Path): Content1 = Content1(Directory(path))
+}
+
+object Main extends App {
+  //val path = PathUtils.makeAbsolute(new Path("C:\\Users\\apdave\\github\\hyperspace-1\\src\\main\\scala\\com\\microsoft\\hyperspace\\index\\rules"))
+  val path = new Path("C:\\Users\\apdave\\repo2\\testdata\\sampleparquet")
+  val content = Content1(path)
+  println(content)
+  val str = JsonUtils.toJson(content)
+  println(str)
+  val content2 = JsonUtils.fromJson[Content1](str)
+  println(content2)
+  println(content == content2)
+  for (file <- content2.files) println(file)
+}

--- a/src/main/scala/com/microsoft/hyperspace/index/ExperimentalStructure.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/ExperimentalStructure.scala
@@ -8,12 +8,12 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import com.microsoft.hyperspace.index.Content1.Directory
 import com.microsoft.hyperspace.util.{JsonUtils, PathUtils}
 // scalastyle:off
-case class Content1(directory: Content1.Directory) {
-  def files: Seq[Path] = rec(new Path(directory.name), directory)
+case class Content1(root: Content1.Directory) {
+  def files: Seq[Path] = rec(new Path(root.name), root)
 
   private def rec(prefixPath: Path, directory: Directory): Seq[Path] = {
     val files = directory.files.map(f => new Path(prefixPath, f.name))
-    files ++ directory.dirs.flatMap {
+    files ++ directory.subDirs.flatMap {
       dir => rec(new Path(prefixPath, dir.name), dir)
     }
   }
@@ -23,7 +23,7 @@ object Content1 {
   case class Directory(
     name: String,
     files: Seq[Directory.FileInfo] = Seq(),
-    dirs: Seq[Directory] = Seq())
+    subDirs: Seq[Directory] = Seq())
 
   object Directory {
 

--- a/src/main/scala/com/microsoft/hyperspace/index/ExperimentalStructure.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/ExperimentalStructure.scala
@@ -2,14 +2,15 @@ package com.microsoft.hyperspace.index
 
 import java.io.FileNotFoundException
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
-import com.microsoft.hyperspace.index.Content1.Directory
 import com.microsoft.hyperspace.util.{JsonUtils, PathUtils}
 // scalastyle:off
-case class Content1(root: Content1.Directory) {
-  def files: Seq[Path] = rec(new Path(root.name), root)
+case class Content1(root: Directory) {
+  @JsonIgnore
+  lazy val files: Seq[Path] = rec(new Path(root.name), root)
 
   private def rec(prefixPath: Path, directory: Directory): Seq[Path] = {
     val files = directory.files.map(f => new Path(prefixPath, f.name))
@@ -19,59 +20,58 @@ case class Content1(root: Content1.Directory) {
   }
 }
 object Content1 {
-
-  case class Directory(
-    name: String,
-    files: Seq[Directory.FileInfo] = Seq(),
-    subDirs: Seq[Directory] = Seq())
-
-  object Directory {
-
-    case class FileInfo(name: String, size: Long, modifiedTime: Long)
-
-    object FileInfo {
-      def apply(s: FileStatus): FileInfo =
-        FileInfo(s.getPath.getName, s.getLen, s.getModificationTime)
-    }
-
-    def apply(path: Path): Directory = {
-      val files: Seq[FileInfo] = {
-        try {
-          val fs = path.getFileSystem(new Configuration)
-          val statuses = fs.listStatus(path)
-
-          // Assuming index directories don't contain nested directories. Only Leaf files.
-          assert(statuses.forall(!_.isDirectory))
-
-          statuses.map(FileInfo(_)).toSeq
-        } catch {
-          // FileNotFoundException is an expected exception before index gets created.
-          case _: FileNotFoundException => Seq()
-          case e: Throwable => throw e
-        }
-      }
-      if (path.isRoot) {
-        Directory(path.toString, files, Seq())
-      } else {
-        Directory(path.getParent, Directory(path.getName, files, Seq()))
-      }
-    }
-
-    def apply(path: Path, child: Directory): Directory = {
-      if (path.isRoot) {
-        Directory(path.toString, Seq(), Seq(child))
-      } else {
-        Directory(path.getParent, Directory(path.getName, Seq(), Seq(child)))
-      }
-    }
-  }
-
   def apply(path: Path): Content1 = Content1(Directory(path))
 }
 
+case class Directory(
+  name: String,
+  files: Seq[FileInfo] = Seq(),
+  subDirs: Seq[Directory] = Seq())
+
+object Directory {
+  def apply(path: Path): Directory = {
+    val files: Seq[FileInfo] = {
+      try {
+        val fs = path.getFileSystem(new Configuration)
+        val statuses = fs.listStatus(path)
+
+        // Assuming index directories don't contain nested directories. Only Leaf files.
+        assert(statuses.forall(!_.isDirectory))
+
+        statuses.map(FileInfo(_)).toSeq
+      } catch {
+        // FileNotFoundException is an expected exception before index gets created.
+        case _: FileNotFoundException => Seq()
+        case e: Throwable => throw e
+      }
+    }
+    if (path.isRoot) {
+      Directory(path.toString, files, Seq())
+    } else {
+      Directory(path.getParent, Directory(path.getName, files, Seq()))
+    }
+  }
+
+  def apply(path: Path, child: Directory): Directory = {
+    if (path.isRoot) {
+      Directory(path.toString, Seq(), Seq(child))
+    } else {
+      Directory(path.getParent, Directory(path.getName, Seq(), Seq(child)))
+    }
+  }
+}
+
+case class FileInfo(name: String, size: Long, modifiedTime: Long)
+
+object FileInfo {
+  def apply(s: FileStatus): FileInfo =
+    FileInfo(s.getPath.getName, s.getLen, s.getModificationTime)
+}
+
+
 object Main extends App {
   //val path = PathUtils.makeAbsolute(new Path("C:\\Users\\apdave\\github\\hyperspace-1\\src\\main\\scala\\com\\microsoft\\hyperspace\\index\\rules"))
-  val path = new Path("C:\\Users\\apdave\\repo2\\testdata\\sampleparquet")
+  val path = PathUtils.makeAbsolute(new Path("C:\\Users\\apdave\\repo2\\testdata\\sampleparquet"))
   val content = Content1(path)
   println(content)
   val str = JsonUtils.toJson(content)

--- a/src/main/scala/com/microsoft/hyperspace/index/ExperimentalStructure.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/ExperimentalStructure.scala
@@ -8,29 +8,70 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 
 import com.microsoft.hyperspace.util.{JsonUtils, PathUtils}
 // scalastyle:off
-case class Content1(root: Directory) {
+case class NewContent(root: Directory) {
   @JsonIgnore
   lazy val files: Seq[Path] = rec(new Path(root.name), root)
 
   private def rec(prefixPath: Path, directory: Directory): Seq[Path] = {
     val files = directory.files.map(f => new Path(prefixPath, f.name))
-    files ++ directory.subDirs.flatMap {
-      dir => rec(new Path(prefixPath, dir.name), dir)
+    files ++ directory.subDirs.flatMap { dir =>
+      rec(new Path(prefixPath, dir.name), dir)
     }
   }
 }
-object Content1 {
-  def apply(path: Path): Content1 = Content1(Directory(path))
+object NewContent {
+  def apply(path: Path): NewContent = NewContent(Directory(path))
+
+  def fromLeafFiles(files: Seq[FileStatus]): NewContent = {
+    val leafDirToChildrenFiles: Map[Path, Array[FileStatus]] =
+      files.toArray.groupBy(_.getPath.getParent)
+    val rootPath = getRoot(leafDirToChildrenFiles.head._1)
+
+    val subDirs = leafDirToChildrenFiles
+      .filterNot(_._1.isRoot)
+      .map {
+        case (dir, statuses) =>
+          createDirectoryTreeWithoutRoot(dir, statuses)
+      }
+      .toSeq
+
+    val rootFiles: Seq[FileInfo1] =
+      leafDirToChildrenFiles.getOrElse(rootPath, Array()).map(FileInfo1(_))
+    NewContent(Directory(rootPath.toString, rootFiles, subDirs))
+  }
+
+  private def getRoot(path: Path): Path = {
+    if (path.isRoot) path else getRoot(path.getParent)
+  }
+
+  private def createDirectoryTreeWithoutRoot(
+      dirPath: Path,
+      statuses: Array[FileStatus]): Directory = {
+    if (dirPath.getParent.isRoot) {
+      Directory(dirPath.getName, files = statuses.map(FileInfo1(_)))
+    } else {
+      createTopLevelNonRootDirectory(
+        dirPath.getParent,
+        Directory(dirPath.getName, files = statuses.map(FileInfo1(_))))
+    }
+  }
+
+  private def createTopLevelNonRootDirectory(dirPath: Path, child: Directory): Directory = {
+    if (dirPath.getParent.isRoot) {
+      Directory(dirPath.getName, files = Seq(), subDirs = Seq(child))
+    } else {
+      createTopLevelNonRootDirectory(
+        dirPath.getParent,
+        Directory(dirPath.getName, files = Seq(), subDirs = Seq(child)))
+    }
+  }
 }
 
-case class Directory(
-  name: String,
-  files: Seq[FileInfo] = Seq(),
-  subDirs: Seq[Directory] = Seq())
+case class Directory(name: String, files: Seq[FileInfo1] = Seq(), subDirs: Seq[Directory] = Seq())
 
 object Directory {
   def apply(path: Path): Directory = {
-    val files: Seq[FileInfo] = {
+    val files: Seq[FileInfo1] = {
       try {
         val fs = path.getFileSystem(new Configuration)
         val statuses = fs.listStatus(path)
@@ -38,7 +79,7 @@ object Directory {
         // Assuming index directories don't contain nested directories. Only Leaf files.
         assert(statuses.forall(!_.isDirectory))
 
-        statuses.map(FileInfo(_)).toSeq
+        statuses.map(FileInfo1(_)).toSeq
       } catch {
         // FileNotFoundException is an expected exception before index gets created.
         case _: FileNotFoundException => Seq()
@@ -61,23 +102,41 @@ object Directory {
   }
 }
 
-case class FileInfo(name: String, size: Long, modifiedTime: Long)
+case class FileInfo1(name: String, size: Long, modifiedTime: Long)
 
-object FileInfo {
-  def apply(s: FileStatus): FileInfo =
-    FileInfo(s.getPath.getName, s.getLen, s.getModificationTime)
+object FileInfo1 {
+  def apply(s: FileStatus): FileInfo1 =
+    FileInfo1(s.getPath.getName, s.getLen, s.getModificationTime)
 }
-
 
 object Main extends App {
   //val path = PathUtils.makeAbsolute(new Path("C:\\Users\\apdave\\github\\hyperspace-1\\src\\main\\scala\\com\\microsoft\\hyperspace\\index\\rules"))
   val path = PathUtils.makeAbsolute(new Path("C:\\Users\\apdave\\repo2\\testdata\\sampleparquet"))
-  val content = Content1(path)
+  val content = NewContent(path)
   println(content)
   val str = JsonUtils.toJson(content)
   println(str)
-  val content2 = JsonUtils.fromJson[Content1](str)
+  val content2 = JsonUtils.fromJson[NewContent](str)
   println(content2)
   println(content == content2)
   for (file <- content2.files) println(file)
+  val fs = content2.files.head.getFileSystem(new Configuration)
+  var newContent = NewContent.fromLeafFiles(content2.files.map(fs.getFileStatus))
+  println(JsonUtils.toJson(newContent))
+
+  val paths: Seq[FileStatus] = (content2.files ++ Seq(
+    "file:/C:/Users/apdave/repo2/testdata/sampleparquet/part-00000-5782bdd3-4729-44e6-b54b-51b557f66792-c000.snappy.parquet",
+    "file:/C:/Users/apdave/repo2/testdata/sampleparquet/part-00000-e8c8821f-a1b2-4b3b-be9e-687b6fa6d057-c000.snappy.parquet",
+    "file:/C:/Users/apdave/repo2/testdata/sampleparquet/_SUCCESS",
+    "file:/C:/ApoorveLaptop-{3D0D96FA-6031-4AEC-A22C-D55D24797ACB}.txt",
+    "file:/C:/spark/README.md",
+    "file:/C:/spark/RELEASE",
+    "file:/C:/spark/NOTICE",
+    "file:/C:/spark/LICENSE")
+    .map(new Path(_)))
+    .map(fs.getFileStatus)
+
+  val newContent2 = NewContent.fromLeafFiles(paths)
+  println(JsonUtils.toJson(newContent2))
+  for (file <- newContent2.files) println(file)
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
@@ -159,13 +159,19 @@ private[hyperspace] case class IndexSummary(
 
 private[hyperspace] object IndexSummary {
   def apply(spark: SparkSession, entry: IndexLogEntry): IndexSummary = {
+    var root = entry.content.root
+    var indexDirPath = entry.content.root.name
+    while (root.files.isEmpty) {
+      root = root.subDirs.head
+      indexDirPath += Path.SEPARATOR + root.name
+    }
     IndexSummary(
       entry.name,
       entry.derivedDataset.properties.columns.indexed,
       entry.derivedDataset.properties.columns.included,
       entry.numBuckets,
       entry.derivedDataset.properties.schemaString,
-      entry.content.root,
+      indexDirPath,
       entry.state)
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
@@ -171,7 +171,7 @@ private[hyperspace] object IndexSummary {
       entry.derivedDataset.properties.columns.included,
       entry.numBuckets,
       entry.derivedDataset.properties.schemaString,
-      indexDirPath,
+      new Path(indexDirPath).toUri.toString,
       entry.state)
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
@@ -163,7 +163,7 @@ private[hyperspace] object IndexSummary {
     var indexDirPath = entry.content.root.name
     while (root.files.isEmpty) {
       root = root.subDirs.head
-      indexDirPath += Path.SEPARATOR + root.name
+      indexDirPath += root.name + Path.SEPARATOR
     }
     IndexSummary(
       entry.name,

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -69,7 +69,7 @@ case class Hdfs(properties: Hdfs.Properties) {
   val kind = "HDFS"
 }
 object Hdfs {
-  case class Properties(content: Content)
+  case class Properties(content: NewContent)
 }
 
 // IndexLogEntry-specific Relation that represents the source relation.
@@ -100,7 +100,7 @@ case class Source(plan: SparkPlan)
 case class IndexLogEntry(
     name: String,
     derivedDataset: CoveringIndex,
-    content: Content,
+    content: NewContent,
     source: Source,
     extra: Map[String, String])
     extends LogEntry(IndexLogEntry.VERSION) {

--- a/src/main/scala/com/microsoft/hyperspace/index/plananalysis/PlanAnalyzer.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/plananalysis/PlanAnalyzer.scala
@@ -142,7 +142,7 @@ object PlanAnalyzer {
           _,
           _,
           _) =>
-        usedPaths += location.rootPaths.head.toString
+        usedPaths += location.rootPaths.head.getParent.toString
       case other =>
         other.subqueries.foreach { subQuery =>
           getPaths(subQuery).flatMap(path => usedPaths += path)

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -103,8 +103,7 @@ object FilterIndexRule
     rank(candidateIndexes) match {
       case Some(index) =>
         val spark = fsRelation.sparkSession
-        val newLocation =
-          new InMemoryFileIndex(spark, Seq(new Path(index.content.root)), Map(), None)
+        val newLocation = new InMemoryFileIndex(spark, index.content.files, Map(), None)
 
         val newRelation = HadoopFsRelation(
           newLocation,

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -141,7 +141,7 @@ object JoinIndexRule
       bucketColumnNames = index.indexedColumns,
       sortColumnNames = index.indexedColumns)
 
-    val location = new InMemoryFileIndex(spark, Seq(new Path(index.content.root)), Map(), None)
+    val location = new InMemoryFileIndex(spark, index.content.files, Map(), None)
     val relation = HadoopFsRelation(
       location,
       new StructType(),

--- a/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
@@ -69,7 +69,7 @@ class RefreshActionTest extends SparkFunSuite with SparkInvolvedSuite {
             .Columns(Seq("clicks"), Seq()),
           "schema",
           10)),
-      Content("dirPath", Seq()),
+      NewContent(Directory("dirPath")),
       Source(SparkPlan(sourcePlanProperties)),
       Map())
     entry.state = Constants.States.ACTIVE

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexCacheTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexCacheTest.scala
@@ -62,7 +62,7 @@ class IndexCacheTest extends SparkFunSuite with SparkInvolvedSuite {
             .Columns(Seq("RGUID"), Seq("Date")),
           IndexLogEntry.schemaString(schema),
           10)),
-      Content(indexDir, Seq()),
+      NewContent(Directory(indexDir)),
       Source(SparkPlan(sourcePlanProperties)),
       Map())
     entry.state = Constants.States.ACTIVE

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
@@ -52,7 +52,8 @@ class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
                   .Columns(Seq("RGUID"), Seq("Date")),
                 "",
                 10)),
-            Content(s"$indexPath/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0", Seq()),
+            NewContent(
+              Directory(s"$indexPath/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0")),
             Source(SparkPlan(sourcePlanProperties)),
             Map())
           entry.state = Constants.States.ACTIVE
@@ -104,7 +105,7 @@ class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
               .Columns(Seq("RGUID"), Seq("Date")),
             "",
             10)),
-        Content(s"$str/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0", Seq()),
+        NewContent(Directory(s"$str/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0")),
         Source(SparkPlan(sourcePlanProperties)),
         Map())
       entry.state = Constants.States.ACTIVE

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -19,7 +19,6 @@ package com.microsoft.hyperspace.index
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 
-import com.microsoft.hyperspace.index.Content.Directory.FileInfo
 import com.microsoft.hyperspace.util.JsonUtils
 
 class IndexLogEntryTest extends SparkFunSuite {
@@ -112,20 +111,13 @@ class IndexLogEntryTest extends SparkFunSuite {
     val actual = JsonUtils.fromJson[IndexLogEntry](jsonString)
 
     val expectedSourcePlanProperties = SparkPlan.Properties(
-      Seq(
-        Relation(
-          Seq("rootpath"),
-          Hdfs(
-            Hdfs.Properties(
-              Content(
-                "",
-                Seq(Content.Directory(
-                  "",
-                  Seq(FileInfo("f1", 100L, 100L), FileInfo("f2", 200L, 200L)),
-                  NoOpFingerprint()))))),
-          "schema",
-          "type",
-          Map())),
+      Seq(Relation(
+        Seq("rootpath"),
+        Hdfs(Hdfs.Properties(NewContent(
+          Directory("", Seq(FileInfo1("f1", 100L, 100L), FileInfo1("f2", 200L, 200L)), Seq())))),
+        "schema",
+        "type",
+        Map())),
       null,
       null,
       LogicalPlanFingerprint(
@@ -139,7 +131,7 @@ class IndexLogEntryTest extends SparkFunSuite {
             .Columns(Seq("col1"), Seq("col2", "col3")),
           schema.json,
           200)),
-      Content("rootContentPath", Seq()),
+      NewContent(Directory("rootContentPath")),
       Source(SparkPlan(expectedSourcePlanProperties)),
       Map())
     expected.state = "ACTIVE"

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -35,7 +35,6 @@ class IndexLogEntryTest extends SparkFunSuite {
         |{
         |  "name" : "indexName",
         |  "derivedDataset" : {
-        |    "kind" : "CoveringIndex",
         |    "properties" : {
         |      "columns" : {
         |        "indexed" : [ "col1" ],
@@ -43,26 +42,26 @@ class IndexLogEntryTest extends SparkFunSuite {
         |      },
         |      "schemaString" : "$schemaString",
         |      "numBuckets" : 200
-        |    }
+        |    },
+        |    "kind" : "CoveringIndex"
         |  },
         |  "content" : {
-        |    "root" : "rootContentPath",
-        |    "directories" : [ ]
+        |    "root" : {
+        |      "name" : "rootContentPath",
+        |      "files" : [ ],
+        |      "subDirs" : [ ]
+        |    }
         |  },
         |  "source" : {
         |    "plan" : {
-        |      "kind" : "Spark",
         |      "properties" : {
         |        "relations" : [ {
         |          "rootPaths" : [ "rootpath" ],
-        |          "options" : { },
         |          "data" : {
-        |            "kind" : "HDFS",
         |            "properties" : {
         |              "content" : {
-        |                "root" : "",
-        |                "directories" : [ {
-        |                  "path" : "",
+        |                "root" : {
+        |                  "name" : "",
         |                  "files" : [ {
         |                    "name" : "f1",
         |                    "size" : 100,
@@ -72,29 +71,29 @@ class IndexLogEntryTest extends SparkFunSuite {
         |                    "size" : 200,
         |                    "modifiedTime" : 200
         |                  } ],
-        |                  "fingerprint" : {
-        |                    "kind" : "NoOp",
-        |                    "properties" : { }
-        |                  }
-        |                } ]
+        |                  "subDirs" : [ ]
+        |                }
         |              }
-        |            }
+        |            },
+        |            "kind" : "HDFS"
         |          },
         |          "dataSchemaJson" : "schema",
-        |          "fileFormat" : "type"
-        |          } ],
+        |          "fileFormat" : "type",
+        |          "options" : { }
+        |        } ],
         |        "rawPlan" : null,
         |        "sql" : null,
         |        "fingerprint" : {
-        |          "kind" : "LogicalPlan",
         |          "properties" : {
         |            "signatures" : [ {
         |              "provider" : "provider",
         |              "value" : "signatureValue"
         |            } ]
-        |          }
+        |          },
+        |          "kind" : "LogicalPlan"
         |        }
-        |      }
+        |      },
+        |      "kind" : "Spark"
         |    }
         |  },
         |  "extra" : { },
@@ -107,8 +106,6 @@ class IndexLogEntryTest extends SparkFunSuite {
 
     val schema =
       StructType(Array(StructField("RGUID", StringType), StructField("Date", StringType)))
-
-    val actual = JsonUtils.fromJson[IndexLogEntry](jsonString)
 
     val expectedSourcePlanProperties = SparkPlan.Properties(
       Seq(Relation(
@@ -137,6 +134,7 @@ class IndexLogEntryTest extends SparkFunSuite {
     expected.state = "ACTIVE"
     expected.timestamp = 1578818514080L
 
+    val actual = JsonUtils.fromJson[IndexLogEntry](jsonString)
     assert(actual.equals(expected))
   }
 }

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
@@ -24,7 +24,6 @@ import org.apache.spark.SparkFunSuite
 import org.scalatest.BeforeAndAfterAll
 
 import com.microsoft.hyperspace.{SparkInvolvedSuite, TestUtils}
-import com.microsoft.hyperspace.index.Content.Directory.FileInfo
 import com.microsoft.hyperspace.index.IndexConstants.HYPERSPACE_LOG
 import com.microsoft.hyperspace.util.{FileUtils, JsonUtils}
 
@@ -40,33 +39,31 @@ class IndexLogManagerImplTest
         CoveringIndex.Properties.Columns(Seq("id"), Seq("name", "school")),
         "id INT name STRING school STRING",
         100)),
-    Content(
-      "/root/log",
-      Seq(
-        Content.Directory(
-          "dir1",
-          Seq(FileInfo("1.json", 100L, 200L), FileInfo("2.json", 100L, 200L)),
-          NoOpFingerprint()),
-        Content.Directory(
-          "dir2",
-          Seq(FileInfo("1.json", 100L, 200L), FileInfo("2.json", 100L, 200L)),
-          NoOpFingerprint()))),
+    NewContent(
+      Directory(
+        "/root/log",
+        files = Seq(),
+        subDirs = Seq(
+          Directory(
+            "dir1",
+            Seq(FileInfo1("1.json", 100L, 200L), FileInfo1("2.json", 100L, 200L))),
+          Directory(
+            "dir2",
+            Seq(FileInfo1("1.json", 100L, 200L), FileInfo1("2.json", 100L, 200L)))))),
     Source(
       SparkPlan(SparkPlan.Properties(
         Seq(Relation(
           Seq("rootpath"),
-          Hdfs(properties = Hdfs.Properties(content = Content(
+          Hdfs(properties = Hdfs.Properties(content = NewContent(Directory(
             "/root/data",
-            Seq(
-              Content
-                .Directory(
-                  "dir1",
-                  Seq(FileInfo("1.json", 100L, 200L), FileInfo("2.json", 100L, 200L)),
-                  NoOpFingerprint()),
-              Content.Directory(
+            files = Seq(),
+            subDirs = Seq(
+              Directory(
+                "dir1",
+                Seq(FileInfo1("1.json", 100L, 200L), FileInfo1("2.json", 100L, 200L))),
+              Directory(
                 "dir2",
-                Seq(FileInfo("1.json", 100L, 200L), FileInfo("2.json", 100L, 200L)),
-                NoOpFingerprint()))))),
+                Seq(FileInfo1("1.json", 100L, 200L), FileInfo1("2.json", 100L, 200L)))))))),
           "schema",
           "type",
           Map())),

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -78,6 +78,16 @@ class IndexManagerTests extends HyperspaceSuite with SQLHelper {
             s"$systemPath/${indexConfig1.indexName}" +
               s"/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0",
             Constants.States.ACTIVE)
+          // scalastyle:off
+          println("actual  : ", actual)
+          println("expected: ", expected)
+          println("actual == expected? ", actual == expected)
+          println("enableLineage :", enableLineage)
+          logError(s"actual  : $actual")
+          logError(s"expected: $expected")
+          logError(s"actual == expected? ${actual == expected}")
+          logError(s"enableLineage : $enableLineage")
+          // scalastyle:on
           assert(actual.equals(expected))
         }
       }

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -282,8 +282,8 @@ class IndexManagerTests extends SparkFunSuite with SparkInvolvedSuite {
               IndexLogEntry.schemaString(schema),
               IndexConstants.INDEX_NUM_BUCKETS_DEFAULT)),
           NewContent(
-            Directory(s"$indexStorageLocation/${indexConfig.indexName}" +
-              s"/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0")),
+            PathUtils.makeAbsolute(new Path(s"$indexStorageLocation/${indexConfig.indexName}" +
+              s"/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0"))),
           Source(SparkPlan(sourcePlanProperties)),
           Map())
         entry.state = state

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexTests.scala
@@ -45,7 +45,7 @@ class IndexTests extends SparkFunSuite {
             .Columns(config.indexedColumns, config.includedColumns),
           IndexLogEntry.schemaString(schema),
           10)),
-      Content(path, Seq()),
+      NewContent(Directory(path)),
       Source(SparkPlan(sourcePlanProperties)),
       Map())
     entry.state = Constants.States.ACTIVE

--- a/src/test/scala/com/microsoft/hyperspace/index/plananalysis/ExplainTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/plananalysis/ExplainTest.scala
@@ -527,7 +527,8 @@ class ExplainTest extends SparkFunSuite with HyperspaceSuite {
   private def getIndexFilesPath(indexName: String): Path = {
     val path = getIndexRootPath(indexName)
     val fs = path.getFileSystem(new Configuration)
-    fs.listStatus(path).head.getPath
+    // Pick any files path but remove the _SUCCESS file.
+    fs.listStatus(path).filterNot(_.getPath.getName.startsWith("_")).head.getPath
   }
 
   private def verifyExplainOutput(df: DataFrame, expected: String, verbose: Boolean)(

--- a/src/test/scala/com/microsoft/hyperspace/index/rankers/JoinIndexRankerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rankers/JoinIndexRankerTest.scala
@@ -75,7 +75,7 @@ class JoinIndexRankerTest extends SparkFunSuite {
             .Columns(indexCols.map(_.name), includedCols.map(_.name)),
           IndexLogEntry.schemaString(schemaFromAttributes(indexCols ++ includedCols: _*)),
           numBuckets)),
-      Content(name, Seq()),
+      NewContent(Directory(name)),
       Source(SparkPlan(sourcePlanProperties)),
       Map())
     entry.state = Constants.States.ACTIVE

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/FilterIndexRuleTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/FilterIndexRuleTest.scala
@@ -157,7 +157,7 @@ class FilterIndexRuleTest extends HyperspaceRuleTestSuite {
       bucketSpec: Option[BucketSpec]): Unit = {
     val allIndexes = IndexCollectionManager(spark).getIndexes(Seq(Constants.States.ACTIVE))
     val expectedLocation = getIndexDataFilesPath(indexName)
-    assert(location.rootPaths.head.equals(expectedLocation))
+    assert(location.rootPaths.head.toString.startsWith(expectedLocation.toString))
     assert(partitionSchema.equals(new StructType()))
     assert(dataSchema.equals(allIndexes.filter(_.name.equals(indexName)).head.schema))
     assert(bucketSpec.isEmpty)

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.types.{StructField, StructType}
 
 import com.microsoft.hyperspace.HyperspaceException
 import com.microsoft.hyperspace.actions.Constants
-import com.microsoft.hyperspace.index.{Content, CoveringIndex, Hdfs, HyperspaceSuite, IndexConstants, IndexLogEntry, IndexLogManagerImpl, LogicalPlanFingerprint, LogicalPlanSignatureProvider, NoOpFingerprint, Signature, Source, SparkPlan}
+import com.microsoft.hyperspace.index.{CoveringIndex, Directory, HyperspaceSuite, IndexConstants, IndexLogEntry, IndexLogManagerImpl, LogicalPlanFingerprint, LogicalPlanSignatureProvider, NewContent, NoOpFingerprint, Signature, Source, SparkPlan}
 
 trait HyperspaceRuleTestSuite extends HyperspaceSuite {
   def createIndex(
@@ -51,7 +51,7 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
                 .Columns(indexCols.map(_.name), includedCols.map(_.name)),
               IndexLogEntry.schemaString(schemaFromAttributes(indexCols ++ includedCols: _*)),
               10)),
-          Content(getIndexDataFilesPath(name).toUri.toString, Seq()),
+          NewContent(Directory(getIndexDataFilesPath(name).toUri.toString)),
           Source(SparkPlan(sourcePlanProperties)),
           Map())
 

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.types.{StructField, StructType}
 
 import com.microsoft.hyperspace.HyperspaceException
 import com.microsoft.hyperspace.actions.Constants
-import com.microsoft.hyperspace.index.{CoveringIndex, Directory, HyperspaceSuite, IndexConstants, IndexLogEntry, IndexLogManagerImpl, LogicalPlanFingerprint, LogicalPlanSignatureProvider, NewContent, NoOpFingerprint, Signature, Source, SparkPlan}
+import com.microsoft.hyperspace.index._
 
 trait HyperspaceRuleTestSuite extends HyperspaceSuite {
   def createIndex(
@@ -51,7 +51,10 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
                 .Columns(indexCols.map(_.name), includedCols.map(_.name)),
               IndexLogEntry.schemaString(schemaFromAttributes(indexCols ++ includedCols: _*)),
               10)),
-          NewContent(Directory(getIndexDataFilesPath(name).toUri.toString)),
+          NewContent(
+            Directory(
+              getIndexDataFilesPath(name).toUri.toString,
+              Seq(FileInfo1("v__=0/f1.parquet", 10, 10)))),
           Source(SparkPlan(sourcePlanProperties)),
           Map())
 

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/JoinIndexRuleTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/JoinIndexRuleTest.scala
@@ -401,7 +401,12 @@ class JoinIndexRuleTest extends HyperspaceRuleTestSuite with SQLHelper {
       updatedPlan: LogicalPlan,
       indexPaths: Seq[Path]): Unit = {
     assert(treeStructureEquality(originalPlan, updatedPlan))
-    assert(basePaths(updatedPlan) == indexPaths)
+    val bP = basePaths(updatedPlan)
+    assert(bP.length == indexPaths.length)
+    assert(bP.zip(indexPaths).forall {
+      case (a, b) =>
+        a.toString.startsWith(b.toString)
+    })
   }
 
   /** method to check if tree structures of two logical plans are the same. */

--- a/src/test/scala/com/microsoft/hyperspace/util/JsonUtilsTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/util/JsonUtilsTests.scala
@@ -44,7 +44,7 @@ class JsonUtilsTests extends SparkFunSuite {
           CoveringIndex.Properties.Columns(Seq("id"), Seq("name", "school")),
           IndexLogEntry.schemaString(schema),
           10)),
-      Content("path", Seq()),
+      NewContent(Directory("path")),
       Source(SparkPlan(sourcePlanProperties)),
       Map())
     index.state = Constants.States.ACTIVE


### PR DESCRIPTION
### What changes were proposed in this pull request?


This is the output of the directory structure when we create a `Content1` object by passing a directory path. Refer [here](https://github.com/apoorvedave1/hyperspace-1/blob/ea245527ea292e0f3aa3ad9bf1ff0dadd1a12edb/src/main/scala/com/microsoft/hyperspace/index/ExperimentalStructure.scala#L72) for sample code:
**Print the content object**
```
Content1(Directory(file:/C:/,List(),List(Directory(Users,List(),List(Directory(apdave,List(),List(Directory(repo2,List(),List(Directory(testdata,List(),List(Directory(sampleparquet,WrappedArray(FileInfo1(part-00000-5782bdd3-4729-44e6-b54b-51b557f66792-c000.snappy.parquet,1473,1585280921507), FileInfo1(part-00000-e8c8821f-a1b2-4b3b-be9e-687b6fa6d057-c000.snappy.parquet,1878,1585280853559), FileInfo1(_SUCCESS,0,1585280921663)),List()))))))))))))
```

**Print the json conversion of the object**
```
{
  "root" : {
    "name" : "file:/C:/",
    "files" : [ ],
    "subDirs" : [ {
      "name" : "Users",
      "files" : [ ],
      "subDirs" : [ {
        "name" : "apdave",
        "files" : [ ],
        "subDirs" : [ {
          "name" : "repo2",
          "files" : [ ],
          "subDirs" : [ {
            "name" : "testdata",
            "files" : [ ],
            "subDirs" : [ {
              "name" : "sampleparquet",
              "files" : [ {
                "name" : "part-00000-5782bdd3-4729-44e6-b54b-51b557f66792-c000.snappy.parquet",
                "size" : 1473,
                "modifiedTime" : 1585280921507
              }, {
                "name" : "part-00000-e8c8821f-a1b2-4b3b-be9e-687b6fa6d057-c000.snappy.parquet",
                "size" : 1878,
                "modifiedTime" : 1585280853559
              }, {
                "name" : "_SUCCESS",
                "size" : 0,
                "modifiedTime" : 1585280921663
              } ],
              "subDirs" : [ ]
            } ]
          } ]
        } ]
      } ]
    } ]
  }
}
```

**Convert back from json to content1 object. Note it's the same as the first one.**
```
Content1(Directory(file:/C:/,List(),List(Directory(Users,List(),List(Directory(apdave,List(),List(Directory(repo2,List(),List(Directory(testdata,List(),List(Directory(sampleparquet,List(FileInfo1(part-00000-5782bdd3-4729-44e6-b54b-51b557f66792-c000.snappy.parquet,1473,1585280921507), FileInfo1(part-00000-e8c8821f-a1b2-4b3b-be9e-687b6fa6d057-c000.snappy.parquet,1878,1585280853559), FileInfo1(_SUCCESS,0,1585280921663)),List()))))))))))))
```

**Asserting the return object is same as the original**
`true`

**List leaf files using `content.files` api**
```
file:/C:/Users/apdave/repo2/testdata/sampleparquet/part-00000-5782bdd3-4729-44e6-b54b-51b557f66792-c000.snappy.parquet
file:/C:/Users/apdave/repo2/testdata/sampleparquet/part-00000-e8c8821f-a1b2-4b3b-be9e-687b6fa6d057-c000.snappy.parquet
file:/C:/Users/apdave/repo2/testdata/sampleparquet/_SUCCESS
```
### Why are the changes needed?


### Does this PR introduce _any_ user-facing change?


### How was this patch tested?
