### PR TITLE
Change lineage to save full file path

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -207,7 +207,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
         ResolverUtils.resolve(spark, _, columnsFromIndexConfig).isEmpty)
       val allIndexColumns = columnsFromIndexConfig ++ missingPartitionColumns
       df.select(allIndexColumns.head, allIndexColumns.tail: _*)
-        .withColumn(IndexConstants.DATA_FILE_NAME_COLUMN, getFileName(input_file_name()))
+        .withColumn(IndexConstants.DATA_FILE_NAME_COLUMN, input_file_name())
     } else {
       df.select(columnsFromIndexConfig.head, columnsFromIndexConfig.tail: _*)
     }
@@ -225,7 +225,4 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
     assert(partitionSchemas.length == 1)
     partitionSchemas.head.map(_.name)
   }
-
-  private val getFileName: UserDefinedFunction = udf(
-    (fullFilePath: String) => FilenameUtils.getName(fullFilePath))
 }

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -18,13 +18,11 @@ package com.microsoft.hyperspace.actions
 
 import java.io.FileNotFoundException
 
-import org.apache.commons.io.FilenameUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation, PartitioningAwareFileIndex}
-import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.functions.{input_file_name, udf}
+import org.apache.spark.sql.functions.input_file_name
 import org.apache.spark.sql.sources.DataSourceRegister
 
 import com.microsoft.hyperspace.HyperspaceException

--- a/src/test/scala/com/microsoft/hyperspace/index/CreateIndexTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/CreateIndexTests.scala
@@ -219,7 +219,7 @@ class CreateIndexTests extends HyperspaceSuite with SQLHelper {
     }
   }
 
-  test("Verify content of lineage column") {
+  test("Verify content of lineage column.") {
     withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
       val dataFileNames = new Path(nonPartitionedDataPath)
         .getFileSystem(new Configuration)

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -80,7 +80,6 @@ class IndexManagerTests extends HyperspaceSuite with SQLHelper {
             s"$systemPath/${indexConfig1.indexName}" +
               s"/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0",
             Constants.States.ACTIVE)
-          val xx = actual.equals(expected)
           assert(actual.equals(expected))
         }
       }

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -68,8 +68,8 @@ class IndexManagerTests extends HyperspaceSuite with SQLHelper {
           var expectedSchema =
             StructType(Seq(StructField("RGUID", StringType), StructField("Date", StringType)))
           if (enableLineage) {
-            expectedSchema =
-              expectedSchema.add(StructField(IndexConstants.DATA_FILE_NAME_COLUMN, StringType))
+            expectedSchema = expectedSchema.add(
+              StructField(IndexConstants.DATA_FILE_NAME_COLUMN, StringType, false))
           }
           val expected = new IndexSummary(
             indexConfig1.indexName,
@@ -80,6 +80,7 @@ class IndexManagerTests extends HyperspaceSuite with SQLHelper {
             s"$systemPath/${indexConfig1.indexName}" +
               s"/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0",
             Constants.States.ACTIVE)
+          val xx = actual.equals(expected)
           assert(actual.equals(expected))
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR changes the value of lineage column in index records to save full file path with file name, and not just the file name.

Sample index record before this change (as it is currently):
| RGUID &nbsp;&nbsp;                           	| Date    	| _data_file_name 	|
|----------------------------------	|----------	|--------------------------------------------------------------------	|
| 50d690516ca641438166049a6303650c 	| 2018-09-03 	| part-00002-31c6e2ec-1fe1-4d3c-88fd-9e2b6970190d-c000.snappy.parquet 	|

Sample index record after this change:
| RGUID &nbsp;&nbsp;                           	| Date    	| _data_file_name 	|
|----------------------------------	|----------	|--------------------------------------------------------------------	|
| 50d690516ca641438166049a6303650c 	| 2018-09-03 	| file:///C:/hyperspace-1/src/test/resources/createIndexTests/sampleparquet/part-00002-31c6e2ec-1fe1-4d3c-88fd-9e2b6970190d-c000.snappy.parquet 	|
 
### Why are the changes needed?
Capturing full file path name makes lineage column self-descriptive for identifying data source files. This can be used for further optimizations s.a. predicate push down during read to include/exclude index records from specific source data file(s).


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
New test case added under `CreateIndexTests.scala` to verify the value of file name column captured as part of lineage.