### PR TITLE
CSharp example notebook

### DIFF
--- a/notebooks/csharp/Hitchhikers Guide to Hyperspace.ipynb
+++ b/notebooks/csharp/Hitchhikers Guide to Hyperspace.ipynb
@@ -571,7 +571,7 @@
         "```sql\n",
         "SELECT employees.deptId, empName, departments.deptId, deptName\n",
         "FROM   employees, departments \n",
-        "WHERE  employees.deptId = departments.deptId\"\n",
+        "WHERE  employees.deptId = departments.deptId\n",
         "```\n",
         "\n",
         "The output of running the cell below shows the query results which are the names of 14 employees and the name of department each employee works in. The query plan is also included in the output. Notice how the file locations for two FileScan operators shows that Spark™ used \"empIndex\" and \"deptIndex1\" indexes to run the query.   \n",

--- a/notebooks/csharp/Hitchhikers Guide to Hyperspace.ipynb
+++ b/notebooks/csharp/Hitchhikers Guide to Hyperspace.ipynb
@@ -532,7 +532,7 @@
         "```sql\n",
         "SELECT deptName \n",
         "FROM departments\n",
-        "WHERE deptId > 20\"\n",
+        "WHERE deptId > 20\n",
         "```\n",
         "Similar to our first example, the output of the cell below shows the query results (names of two departments) and the query plan. The location of data file in the FileScan operator shows that 'deptIndex1\" was used to run the query.   \n",
         ""

--- a/notebooks/csharp/Hitchhikers Guide to Hyperspace.ipynb
+++ b/notebooks/csharp/Hitchhikers Guide to Hyperspace.ipynb
@@ -39,11 +39,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 24,
+      "execution_count": 46,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 24,
+          "execution_count": 46,
           "data": {
             "text/plain": "-1"
           },
@@ -76,7 +76,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 25,
+      "execution_count": 47,
       "outputs": [],
       "metadata": {},
       "source": [
@@ -145,11 +145,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 26,
+      "execution_count": 48,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 26,
+          "execution_count": 48,
           "data": {
             "text/plain": "+-----+-------+------+\n|empId|empName|deptId|\n+-----+-------+------+\n| 7499|  ALLEN|    30|\n| 7521|   WARD|    30|\n| 7369|  SMITH|    20|\n| 7844| TURNER|    30|\n| 7876|  ADAMS|    20|\n| 7900|  JAMES|    30|\n| 7934| MILLER|    10|\n| 7566|  JONES|    20|\n| 7698|  BLAKE|    30|\n| 7782|  CLARK|    10|\n| 7788|  SCOTT|    20|\n| 7839|   KING|    10|\n| 7902|   FORD|    20|\n| 7654| MARTIN|    30|\n+-----+-------+------+\n\n+------+----------+--------+\n|deptId|  deptName|location|\n+------+----------+--------+\n|    10|Accounting|New York|\n|    40|Operations|  Boston|\n|    20|  Research|  Dallas|\n|    30|     Sales| Chicago|\n+------+----------+--------+"
           },
@@ -190,7 +190,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 27,
+      "execution_count": 49,
       "outputs": [],
       "metadata": {},
       "source": [
@@ -227,7 +227,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 28,
+      "execution_count": 50,
       "outputs": [],
       "metadata": {},
       "source": [
@@ -252,7 +252,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 29,
+      "execution_count": 51,
       "outputs": [],
       "metadata": {},
       "source": [
@@ -282,11 +282,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 30,
+      "execution_count": 52,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 30,
+          "execution_count": 52,
           "data": {
             "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation| state|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+"
           },
@@ -312,11 +312,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 31,
+      "execution_count": 53,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 31,
+          "execution_count": 53,
           "data": {
             "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+"
           },
@@ -343,11 +343,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 32,
+      "execution_count": 54,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 32,
+          "execution_count": 54,
           "data": {
             "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+"
           },
@@ -379,11 +379,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 33,
+      "execution_count": 55,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 33,
+          "execution_count": 55,
           "data": {
             "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation| state|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+"
           },
@@ -415,7 +415,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 34,
+      "execution_count": 56,
       "outputs": [],
       "metadata": {},
       "source": [
@@ -440,11 +440,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 35,
+      "execution_count": 57,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 35,
+          "execution_count": 57,
           "data": {
             "text/plain": "+-----+-------+------+\n|empId|empName|deptId|\n+-----+-------+------+\n| 7499|  ALLEN|    30|\n| 7521|   WARD|    30|\n| 7369|  SMITH|    20|\n| 7844| TURNER|    30|\n| 7876|  ADAMS|    20|\n+-----+-------+------+\nonly showing top 5 rows\n\n+------+----------+--------+\n|deptId|  deptName|location|\n+------+----------+--------+\n|    10|Accounting|New York|\n|    40|Operations|  Boston|\n|    20|  Research|  Dallas|\n|    30|     Sales| Chicago|\n+------+----------+--------+"
           },
@@ -502,13 +502,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 36,
+      "execution_count": 58,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 36,
+          "execution_count": 58,
           "data": {
-            "text/plain": "+--------+\n|deptName|\n+--------+\n|Research|\n+--------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#725 = 20)\n   +- Relation[deptId#725,deptName#726,location#727] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#726]\n+- Filter (deptId#725 = 20)\n   +- Relation[deptId#725,deptName#726,location#727] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#726]\n+- Filter (isnotnull(deptId#725) && (deptId#725 = 20))\n   +- Relation[deptId#725,deptName#726] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#726]\n+- *(1) Filter (isnotnull(deptId#725) && (deptId#725 = 20))\n   +- *(1) FileScan parquet [deptId#725,deptName#726] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), EqualTo(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+            "text/plain": "+--------+\n|deptName|\n+--------+\n|Research|\n+--------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#1075 = 20)\n   +- Relation[deptId#1075,deptName#1076,location#1077] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#1076]\n+- Filter (deptId#1075 = 20)\n   +- Relation[deptId#1075,deptName#1076,location#1077] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#1076]\n+- Filter (isnotnull(deptId#1075) && (deptId#1075 = 20))\n   +- Relation[deptId#1075,deptName#1076,location#1077] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#1076]\n+- *(1) Filter (isnotnull(deptId#1075) && (deptId#1075 = 20))\n   +- *(1) FileScan parquet [deptId#1075,deptName#1076] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/<yourpath>/departments.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId), EqualTo(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
           },
           "metadata": {}
         }
@@ -541,13 +541,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 37,
+      "execution_count": 59,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 37,
+          "execution_count": 59,
           "data": {
-            "text/plain": "+----------+\n|  deptName|\n+----------+\n|Operations|\n|     Sales|\n+----------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#725 > 20)\n   +- Relation[deptId#725,deptName#726,location#727] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#726]\n+- Filter (deptId#725 > 20)\n   +- Relation[deptId#725,deptName#726,location#727] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#726]\n+- Filter (isnotnull(deptId#725) && (deptId#725 > 20))\n   +- Relation[deptId#725,deptName#726] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#726]\n+- *(1) Filter (isnotnull(deptId#725) && (deptId#725 > 20))\n   +- *(1) FileScan parquet [deptId#725,deptName#726] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+            "text/plain": "+----------+\n|  deptName|\n+----------+\n|Operations|\n|     Sales|\n+----------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#1075 > 20)\n   +- Relation[deptId#1075,deptName#1076,location#1077] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#1076]\n+- Filter (deptId#1075 > 20)\n   +- Relation[deptId#1075,deptName#1076,location#1077] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#1076]\n+- Filter (isnotnull(deptId#1075) && (deptId#1075 > 20))\n   +- Relation[deptId#1075,deptName#1076] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#1076]\n+- *(1) Filter (isnotnull(deptId#1075) && (deptId#1075 > 20))\n   +- *(1) FileScan parquet [deptId#1075,deptName#1076] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
           },
           "metadata": {}
         }
@@ -581,13 +581,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 38,
+      "execution_count": 60,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 38,
+          "execution_count": 60,
           "data": {
-            "text/plain": "+-------+----------+\n|empName|  deptName|\n+-------+----------+\n|  SMITH|  Research|\n|  SCOTT|  Research|\n|   FORD|  Research|\n|  ADAMS|  Research|\n|  JONES|  Research|\n|   KING|Accounting|\n| MILLER|Accounting|\n|  CLARK|Accounting|\n|  JAMES|     Sales|\n| MARTIN|     Sales|\n|  ALLEN|     Sales|\n|   WARD|     Sales|\n| TURNER|     Sales|\n|  BLAKE|     Sales|\n+-------+----------+\n\n== Parsed Logical Plan ==\nProject [empName#720, deptName#726]\n+- Join Inner, (deptId#721 = deptId#725)\n   :- Relation[empId#719,empName#720,deptId#721] parquet\n   +- Relation[deptId#725,deptName#726,location#727] parquet\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#720, deptName#726]\n+- Join Inner, (deptId#721 = deptId#725)\n   :- Relation[empId#719,empName#720,deptId#721] parquet\n   +- Relation[deptId#725,deptName#726,location#727] parquet\n\n== Optimized Logical Plan ==\nProject [empName#720, deptName#726]\n+- Join Inner, (deptId#721 = deptId#725)\n   :- Project [empName#720, deptId#721]\n   :  +- Filter isnotnull(deptId#721)\n   :     +- Relation[empName#720,deptId#721] parquet\n   +- Project [deptId#725, deptName#726]\n      +- Filter isnotnull(deptId#725)\n         +- Relation[deptId#725,deptName#726] parquet\n\n== Physical Plan ==\n*(3) Project [empName#720, deptName#726]\n+- *(3) SortMergeJoin [deptId#721], [deptId#725], Inner\n   :- *(1) Project [empName#720, deptId#721]\n   :  +- *(1) Filter isnotnull(deptId#721)\n   :     +- *(1) FileScan parquet [deptId#721,empName#720] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#725, deptName#726]\n      +- *(2) Filter isnotnull(deptId#725)\n         +- *(2) FileScan parquet [deptId#725,deptName#726] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
+            "text/plain": "+-------+----------+\n|empName|  deptName|\n+-------+----------+\n|  ADAMS|  Research|\n|  JONES|  Research|\n|  SMITH|  Research|\n|  SCOTT|  Research|\n|   FORD|  Research|\n| MILLER|Accounting|\n|  CLARK|Accounting|\n|   KING|Accounting|\n|  ALLEN|     Sales|\n|   WARD|     Sales|\n| TURNER|     Sales|\n|  BLAKE|     Sales|\n|  JAMES|     Sales|\n| MARTIN|     Sales|\n+-------+----------+\n\n== Parsed Logical Plan ==\nProject [empName#1070, deptName#1076]\n+- Join Inner, (deptId#1071 = deptId#1075)\n   :- Relation[empId#1069,empName#1070,deptId#1071] parquet\n   +- Relation[deptId#1075,deptName#1076,location#1077] parquet\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#1070, deptName#1076]\n+- Join Inner, (deptId#1071 = deptId#1075)\n   :- Relation[empId#1069,empName#1070,deptId#1071] parquet\n   +- Relation[deptId#1075,deptName#1076,location#1077] parquet\n\n== Optimized Logical Plan ==\nProject [empName#1070, deptName#1076]\n+- Join Inner, (deptId#1071 = deptId#1075)\n   :- Project [empName#1070, deptId#1071]\n   :  +- Filter isnotnull(deptId#1071)\n   :     +- Relation[empId#1069,empName#1070,deptId#1071] parquet\n   +- Project [deptId#1075, deptName#1076]\n      +- Filter isnotnull(deptId#1075)\n         +- Relation[deptId#1075,deptName#1076,location#1077] parquet\n\n== Physical Plan ==\n*(5) Project [empName#1070, deptName#1076]\n+- *(5) SortMergeJoin [deptId#1071], [deptId#1075], Inner\n   :- *(2) Sort [deptId#1071 ASC NULLS FIRST], false, 0\n   :  +- Exchange hashpartitioning(deptId#1071, 200), [id=#851]\n   :     +- *(1) Project [empName#1070, deptId#1071]\n   :        +- *(1) Filter isnotnull(deptId#1071)\n   :           +- *(1) FileScan parquet [empName#1070,deptId#1071] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/<yourpath>/employees.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<empName:string,deptId:int>\n   +- *(4) Sort [deptId#1075 ASC NULLS FIRST], false, 0\n      +- Exchange hashpartitioning(deptId#1075, 200), [id=#857]\n         +- *(3) Project [deptId#1075, deptName#1076]\n            +- *(3) Filter isnotnull(deptId#1075)\n               +- *(3) FileScan parquet [deptId#1075,deptName#1076] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/<yourpath>/departments.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>"
           },
           "metadata": {}
         }
@@ -618,13 +618,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 39,
+      "execution_count": 61,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 39,
+          "execution_count": 61,
           "data": {
-            "text/plain": "+-------+----------+\n|empName|  deptName|\n+-------+----------+\n|  SMITH|  Research|\n|  SCOTT|  Research|\n|   FORD|  Research|\n|  ADAMS|  Research|\n|  JONES|  Research|\n|   KING|Accounting|\n| MILLER|Accounting|\n|  CLARK|Accounting|\n|  JAMES|     Sales|\n| MARTIN|     Sales|\n|  ALLEN|     Sales|\n|   WARD|     Sales|\n| TURNER|     Sales|\n|  BLAKE|     Sales|\n+-------+----------+\n\n== Parsed Logical Plan ==\n'Project ['EMP.empName, 'DEPT.deptName]\n+- 'Filter ('EMP.deptId = 'DEPT.deptId)\n   +- 'Join Inner\n      :- 'UnresolvedRelation `EMP`\n      +- 'UnresolvedRelation `DEPT`\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#720, deptName#726]\n+- Filter (deptId#721 = deptId#725)\n   +- Join Inner\n      :- SubqueryAlias `emp`\n      :  +- Relation[empId#719,empName#720,deptId#721] parquet\n      +- SubqueryAlias `dept`\n         +- Relation[deptId#725,deptName#726,location#727] parquet\n\n== Optimized Logical Plan ==\nProject [empName#720, deptName#726]\n+- Join Inner, (deptId#721 = deptId#725)\n   :- Project [empName#720, deptId#721]\n   :  +- Filter isnotnull(deptId#721)\n   :     +- Relation[empName#720,deptId#721] parquet\n   +- Project [deptId#725, deptName#726]\n      +- Filter isnotnull(deptId#725)\n         +- Relation[deptId#725,deptName#726] parquet\n\n== Physical Plan ==\n*(3) Project [empName#720, deptName#726]\n+- *(3) SortMergeJoin [deptId#721], [deptId#725], Inner\n   :- *(1) Project [empName#720, deptId#721]\n   :  +- *(1) Filter isnotnull(deptId#721)\n   :     +- *(1) FileScan parquet [deptId#721,empName#720] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#725, deptName#726]\n      +- *(2) Filter isnotnull(deptId#725)\n         +- *(2) FileScan parquet [deptId#725,deptName#726] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
+            "text/plain": "+-------+----------+\n|empName|  deptName|\n+-------+----------+\n|  ADAMS|  Research|\n|  JONES|  Research|\n|  SMITH|  Research|\n|  SCOTT|  Research|\n|   FORD|  Research|\n| MILLER|Accounting|\n|  CLARK|Accounting|\n|   KING|Accounting|\n|  ALLEN|     Sales|\n|   WARD|     Sales|\n| TURNER|     Sales|\n|  BLAKE|     Sales|\n|  JAMES|     Sales|\n| MARTIN|     Sales|\n+-------+----------+\n\n== Parsed Logical Plan ==\n'Project ['EMP.empName, 'DEPT.deptName]\n+- 'Filter ('EMP.deptId = 'DEPT.deptId)\n   +- 'Join Inner\n      :- 'UnresolvedRelation `EMP`\n      +- 'UnresolvedRelation `DEPT`\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#1070, deptName#1076]\n+- Filter (deptId#1071 = deptId#1075)\n   +- Join Inner\n      :- SubqueryAlias `emp`\n      :  +- Relation[empId#1069,empName#1070,deptId#1071] parquet\n      +- SubqueryAlias `dept`\n         +- Relation[deptId#1075,deptName#1076,location#1077] parquet\n\n== Optimized Logical Plan ==\nProject [empName#1070, deptName#1076]\n+- Join Inner, (deptId#1071 = deptId#1075)\n   :- Project [empName#1070, deptId#1071]\n   :  +- Filter isnotnull(deptId#1071)\n   :     +- Relation[empName#1070,deptId#1071] parquet\n   +- Project [deptId#1075, deptName#1076]\n      +- Filter isnotnull(deptId#1075)\n         +- Relation[deptId#1075,deptName#1076] parquet\n\n== Physical Plan ==\n*(3) Project [empName#1070, deptName#1076]\n+- *(3) SortMergeJoin [deptId#1071], [deptId#1075], Inner\n   :- *(1) Project [empName#1070, deptId#1071]\n   :  +- *(1) Filter isnotnull(deptId#1071)\n   :     +- *(1) FileScan parquet [deptId#1071,empName#1070] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#1075, deptName#1076]\n      +- *(2) Filter isnotnull(deptId#1075)\n         +- *(2) FileScan parquet [deptId#1075,deptName#1076] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
           },
           "metadata": {}
         }
@@ -654,13 +654,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 40,
+      "execution_count": 62,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 40,
+          "execution_count": 62,
           "data": {
-            "text/html": "<pre>=============================================================<br>Plan with indexes:<br>=============================================================<br>Project [empName#720, deptName#726]<br>+- SortMergeJoin [deptId#721], [deptId#725], Inner<br>   :- *(1) Project [empName#720, deptId#721]<br>   :  +- *(1) Filter isnotnull(deptId#721)<br>   :     +- *(1) FileScan parquet [deptId#721,empName#720] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200<br>   +- *(2) Project [deptId#725, deptName#726]<br>      +- *(2) Filter isnotnull(deptId#725)<br>         +- *(2) FileScan parquet [deptId#725,deptName#726] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200<br><br>=============================================================<br>Plan without indexes:<br>=============================================================<br>Project [empName#720, deptName#726]<br>+- SortMergeJoin [deptId#721], [deptId#725], Inner<br>   :- *(1) Project [empName#720, deptId#721]<br>   :  +- *(1) Filter isnotnull(deptId#721)<br>   :     +- *(1) FileScan parquet [deptId#721,empName#720] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200<br>   +- *(2) Project [deptId#725, deptName#726]<br>      +- *(2) Filter isnotnull(deptId#725)<br>         +- *(2) FileScan parquet [deptId#725,deptName#726] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200<br><br>=============================================================<br>Indexes used:<br>=============================================================<br>deptIndex1:abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/warehouse/indexes/deptIndex1/v__=0<br>empIndex:abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/warehouse/indexes/empIndex/v__=0<br><br></pre>"
+            "text/html": "<pre>=============================================================<br>Plan with indexes:<br>=============================================================<br>Project [empName#1070, deptName#1076]<br>+- SortMergeJoin [deptId#1071], [deptId#1075], Inner<br>   <b style=\"background:LightGreen\">:- *(1) Project [empName#1070, deptId#1071]</b><br>   <b style=\"background:LightGreen\">:  +- *(1) Filter isnotnull(deptId#1071)</b><br>   <b style=\"background:LightGreen\">:     +- *(1) FileScan parquet [deptId#1071,empName#1070] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200</b><br>   <b style=\"background:LightGreen\">+- *(2) Project [deptId#1075, deptName#1076]</b><br>      <b style=\"background:LightGreen\">+- *(2) Filter isnotnull(deptId#1075)</b><br>         <b style=\"background:LightGreen\">+- *(2) FileScan parquet [deptId#1075,deptName#1076] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200</b><br><br>=============================================================<br>Plan without indexes:<br>=============================================================<br>Project [empName#1070, deptName#1076]<br>+- SortMergeJoin [deptId#1071], [deptId#1075], Inner<br>   <b style=\"background:LightGreen\">:- *(2) Sort [deptId#1071 ASC NULLS FIRST], false, 0</b><br>   <b style=\"background:LightGreen\">:  +- Exchange hashpartitioning(deptId#1071, 200), [id=#956]</b><br>   <b style=\"background:LightGreen\">:     +- *(1) Project [empName#1070, deptId#1071]</b><br>   <b style=\"background:LightGreen\">:        +- *(1) Filter isnotnull(deptId#1071)</b><br>   <b style=\"background:LightGreen\">:           +- *(1) FileScan parquet [empName#1070,deptId#1071] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/<yourpath>/employees.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<empName:string,deptId:int></b><br>   <b style=\"background:LightGreen\">+- *(4) Sort [deptId#1075 ASC NULLS FIRST], false, 0</b><br>      <b style=\"background:LightGreen\">+- Exchange hashpartitioning(deptId#1075, 200), [id=#962]</b><br>         <b style=\"background:LightGreen\">+- *(3) Project [deptId#1075, deptName#1076]</b><br>            <b style=\"background:LightGreen\">+- *(3) Filter isnotnull(deptId#1075)</b><br>               <b style=\"background:LightGreen\">+- *(3) FileScan parquet [deptId#1075,deptName#1076] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/<yourpath>/departments.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string></b><br><br>=============================================================<br>Indexes used:<br>=============================================================<br>deptIndex1:abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/warehouse/indexes/deptIndex1/v__=0<br>empIndex:abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/warehouse/indexes/empIndex/v__=0<br><br></pre>"
           },
           "metadata": {}
         }
@@ -668,6 +668,9 @@
       "metadata": {},
       "source": [
         "spark.Conf().Set(\"spark.hyperspace.explain.displayMode\", \"html\");\n",
+        "spark.Conf().Set(\"spark.hyperspace.explain.displayMode.highlight.beginTag\", \"<b style=\\\"background:LightGreen\\\">\");\n",
+        "spark.Conf().Set(\"spark.hyperspace.explain.displayMode.highlight.endTag\", \"</b>\");\n",
+        "\n",
         "hyperspace.Explain(eqJoin, false, input => DisplayHTML(input));"
       ],
       "attachments": {}
@@ -687,11 +690,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 41,
+      "execution_count": 63,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 41,
+          "execution_count": 63,
           "data": {
             "text/plain": "+------+---------------+-------------+\n|deptId|       deptName|     location|\n+------+---------------+-------------+\n|    60|Human Resources|San Francisco|\n|    10|     Accounting|     New York|\n|    50|      Inovation|      Seattle|\n|    40|     Operations|       Boston|\n|    20|       Research|       Dallas|\n|    30|          Sales|      Chicago|\n+------+---------------+-------------+"
           },
@@ -719,13 +722,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 42,
+      "execution_count": 64,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 42,
+          "execution_count": 64,
           "data": {
-            "text/plain": "+---------------+\n|       deptName|\n+---------------+\n|Human Resources|\n|      Inovation|\n|     Operations|\n|          Sales|\n+---------------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#829 > 20)\n   +- Relation[deptId#829,deptName#830,location#831] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#830]\n+- Filter (deptId#829 > 20)\n   +- Relation[deptId#829,deptName#830,location#831] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#830]\n+- Filter (isnotnull(deptId#829) && (deptId#829 > 20))\n   +- Relation[deptId#829,deptName#830] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#830]\n+- *(1) Filter (isnotnull(deptId#829) && (deptId#829 > 20))\n   +- *(1) FileScan parquet [deptId#829,deptName#830] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+            "text/plain": "+---------------+\n|       deptName|\n+---------------+\n|Human Resources|\n|      Inovation|\n|     Operations|\n|          Sales|\n+---------------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#1179 > 20)\n   +- Relation[deptId#1179,deptName#1180,location#1181] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#1180]\n+- Filter (deptId#1179 > 20)\n   +- Relation[deptId#1179,deptName#1180,location#1181] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#1180]\n+- Filter (isnotnull(deptId#1179) && (deptId#1179 > 20))\n   +- Relation[deptId#1179,deptName#1180,location#1181] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#1180]\n+- *(1) Filter (isnotnull(deptId#1179) && (deptId#1179 > 20))\n   +- *(1) FileScan parquet [deptId#1179,deptName#1180] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/<yourpath>/departments.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
           },
           "metadata": {}
         }
@@ -741,7 +744,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 43,
+      "execution_count": 65,
       "outputs": [],
       "metadata": {},
       "source": [

--- a/notebooks/csharp/Hitchhikers Guide to Hyperspace.ipynb
+++ b/notebooks/csharp/Hitchhikers Guide to Hyperspace.ipynb
@@ -1,0 +1,758 @@
+{
+  "metadata": {
+    "saveOutput": true,
+    "language_info": {
+      "name": "csharp"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2,
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Hitchhiker's Guide to Hyperspace - An Indexing Subsystem for Apache Spark™\n",
+        "Hyperspace introduces the ability for Apache Spark™ users to create indexes on their datasets (e.g., CSV, JSON, Parquet etc.) and leverage them for potential query and workload acceleration.\n",
+        "\n",
+        "In this notebook, we highlight the basics of Hyperspace, emphasizing on its simplicity and shows how it can be used by just anyone.\n",
+        "\n",
+        "**Disclaimer**: Hyperspace helps accelerate your workloads/queries under two circumstances:\n",
+        "\n",
+        "  1. Queries contain filters on predicates with high selectivity (e.g., you want to select 100 matching rows from a million candidate rows)\n",
+        "  2. Queries contain a join that requires heavy-shuffles (e.g., you want to join a 100 GB dataset with a 10 GB dataset)\n",
+        "\n",
+        "You may want to carefully monitor your workloads and determine whether indexing is helping you on a case-by-case basis."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Setup\n",
+        "To begin with, let's start a new Spark™ session. Since this notebook is a tutorial merely to illustrate what Hyperspace can offer, we will make a configuration change that allow us to highlight what Hyperspace is doing on small datasets. By default, Spark™ uses *broadcast join* to optimize join queries when the data size for one side of join is small (which is the case for the sample data we use in this tutorial). Therefore, we disable broadcast joins so that later when we run join queries, Spark™ uses *sort-merge* join. This is mainly to show how Hyperspace indexes would be used at scale for accelerating join queries.\n",
+        "\n",
+        "The output of running the cell below shows a reference to the successfully created Spark™ session and prints out '-1' as the value for the modified join config which indicates that broadcast join is successfully disabled."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 24,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 24,
+          "data": {
+            "text/plain": "-1"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "// Disable BroadcastHashJoin, so Spark™ will use standard SortMergeJoin. Currently hyperspace indexes utilize SortMergeJoin to speed up query.\n",
+        "spark.Conf().Set(\"spark.sql.autoBroadcastJoinThreshold\", -1);\n",
+        "\n",
+        "// Verify that BroadcastHashJoin is set correctly \n",
+        "Console.WriteLine(spark.Conf().Get(\"spark.sql.autoBroadcastJoinThreshold\"));"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Data Preparation\n",
+        "\n",
+        "To prepare our environment, we will create sample data records and save them as parquet data files. While we use Parquet for illustration, you can use other formats such as CSV. In the subsequent cells, we will also demonstrate how you can create several Hyperspace indexes on this sample dataset and how one can make Spark™ use them when running queries. \n",
+        "\n",
+        "Our example records correspond to two datasets: *department* and *employee*. You should configure \"empLocation\" and \"deptLocation\" paths so that on the storage account they point to your desired location to save generated data files. \n",
+        "\n",
+        "The output of running below cell shows contents of our datasets as lists of triplets followed by references to dataFrames created to save the content of each dataset in our preferred location."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "outputs": [],
+      "metadata": {},
+      "source": [
+        "using Microsoft.Spark.Sql.Types;\n",
+        "\n",
+        "// Sample department records\n",
+        "var departments = new List<GenericRow>()\n",
+        "{\n",
+        "    new GenericRow(new object[] {10, \"Accounting\", \"New York\"}),\n",
+        "    new GenericRow(new object[] {20, \"Research\", \"Dallas\"}),\n",
+        "    new GenericRow(new object[] {30, \"Sales\", \"Chicago\"}),\n",
+        "    new GenericRow(new object[] {40, \"Operations\", \"Boston\"})\n",
+        "};\n",
+        "\n",
+        "// Sample employee records\n",
+        "var employees = new List<GenericRow>() {\n",
+        "      new GenericRow(new object[] {7369, \"SMITH\", 20}),\n",
+        "      new GenericRow(new object[] {7499, \"ALLEN\", 30}),\n",
+        "      new GenericRow(new object[] {7521, \"WARD\", 30}),\n",
+        "      new GenericRow(new object[] {7566, \"JONES\", 20}),\n",
+        "      new GenericRow(new object[] {7698, \"BLAKE\", 30}),\n",
+        "      new GenericRow(new object[] {7782, \"CLARK\", 10}),\n",
+        "      new GenericRow(new object[] {7788, \"SCOTT\", 20}),\n",
+        "      new GenericRow(new object[] {7839, \"KING\", 10}),\n",
+        "      new GenericRow(new object[] {7844, \"TURNER\", 30}),\n",
+        "      new GenericRow(new object[] {7876, \"ADAMS\", 20}),\n",
+        "      new GenericRow(new object[] {7900, \"JAMES\", 30}),\n",
+        "      new GenericRow(new object[] {7934, \"MILLER\", 10}),\n",
+        "      new GenericRow(new object[] {7902, \"FORD\", 20}),\n",
+        "      new GenericRow(new object[] {7654, \"MARTIN\", 30})\n",
+        "};\n",
+        "\n",
+        "// Save sample data in the Parquet format\n",
+        "var departmentSchema = new StructType(new List<StructField>()\n",
+        "{\n",
+        "    new StructField(\"deptId\", new IntegerType()),\n",
+        "    new StructField(\"deptName\", new StringType()),\n",
+        "    new StructField(\"location\", new StringType())\n",
+        "});\n",
+        "var employeeSchema = new StructType(new List<StructField>()\n",
+        "{\n",
+        "    new StructField(\"empId\", new IntegerType()),\n",
+        "    new StructField(\"empName\", new StringType()),\n",
+        "    new StructField(\"deptId\", new IntegerType())\n",
+        "});\n",
+        "\n",
+        "DataFrame empData = spark.CreateDataFrame(employees, employeeSchema); \n",
+        "DataFrame deptData = spark.CreateDataFrame(departments, departmentSchema); \n",
+        "\n",
+        "string empLocation = \"/<yourpath>/employees.parquet\";       //TODO ** customize this location path **\n",
+        "string deptLocation = \"/<yourpath>/departments.parquet\";     //TODO ** customize this location path **\n",
+        "empData.Write().Mode(\"overwrite\").Parquet(empLocation);\n",
+        "deptData.Write().Mode(\"overwrite\").Parquet(deptLocation);"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Let's verify the contents of parquet files we created above to make sure they contain expected records in correct format. We later use these data files to create Hyperspace indexes and run sample queries.\n",
+        "\n",
+        "Running below cell, the output displays the rows in employee and department dataFrames in a tabular form. There should be 14 employees and 4 departments, each matching with one of triplets we created in the previous cell."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 26,
+          "data": {
+            "text/plain": "+-----+-------+------+\n|empId|empName|deptId|\n+-----+-------+------+\n| 7499|  ALLEN|    30|\n| 7521|   WARD|    30|\n| 7369|  SMITH|    20|\n| 7844| TURNER|    30|\n| 7876|  ADAMS|    20|\n| 7900|  JAMES|    30|\n| 7934| MILLER|    10|\n| 7566|  JONES|    20|\n| 7698|  BLAKE|    30|\n| 7782|  CLARK|    10|\n| 7788|  SCOTT|    20|\n| 7839|   KING|    10|\n| 7902|   FORD|    20|\n| 7654| MARTIN|    30|\n+-----+-------+------+\n\n+------+----------+--------+\n|deptId|  deptName|location|\n+------+----------+--------+\n|    10|Accounting|New York|\n|    40|Operations|  Boston|\n|    20|  Research|  Dallas|\n|    30|     Sales| Chicago|\n+------+----------+--------+"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "// empLocation and deptLocation are the user defined locations above to save parquet files\n",
+        "DataFrame empDF = spark.Read().Parquet(empLocation);\n",
+        "DataFrame deptDF = spark.Read().Parquet(deptLocation);\n",
+        "\n",
+        "// Verify the data is available and correct\n",
+        "empDF.Show();\n",
+        "deptDF.Show();"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Hello Hyperspace Index!\n",
+        "Hyperspace lets users create indexes on records scanned from persisted data files. Once successfully created, an entry corresponding to the index is added to the Hyperspace's metadata. This metadata is later used by Apache Spark™'s optimizer (with our extensions) during query processing to find and use proper indexes. \n",
+        "\n",
+        "Once indexes are created, users can perform several actions:\n",
+        "  - **Refresh** If the underlying data changes, users can refresh an existing index to capture that. \n",
+        "  - **Delete** If the index is not needed, users can perform a soft-delete i.e., index is not physically deleted but is marked as 'deleted' so it is no longer used in your workloads.\n",
+        "  - **Vacuum** If an index is no longer required, users can vacuum it which forces a physical deletion of the index contents and associated metadata completely from Hyperspace's metadata.\n",
+        "\n",
+        "Below sections show how such index management operations can be done in Hyperspace.\n",
+        "\n",
+        "First, we need to import the required libraries and create an instance of Hyperspace. We later use this instance to invoke different Hyperspace APIs to create indexes on our sample data and modify those indexes.\n",
+        "\n",
+        "Output of running below cell shows a reference to the created instance of Hyperspace."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "outputs": [],
+      "metadata": {},
+      "source": [
+        "// Create an instance of Hyperspace\n",
+        "using Microsoft.Spark.Extensions.Hyperspace;\n",
+        "\n",
+        "Hyperspace hyperspace = new Hyperspace(spark);"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Create Indexes\n",
+        "To create a Hyperspace index, the user needs to provide 2 pieces of information:\n",
+        "* An Apache Spark™ DataFrame which references the data to be indexed.\n",
+        "* An index configuration object: IndexConfig, which specifies the *index name*, *indexed* and *included* columns of the index. \n",
+        "\n",
+        "We start by creating three Hyperspace indexes on our sample data: two indexes on the department dataset named \"deptIndex1\" and \"deptIndex2\", and one index on the employee dataset named 'empIndex'. \n",
+        "For each index, we need a corresponding IndexConfig to capture the name along with columns lists for the indexed and included columns. Running below cell creates these indexConfigs and its output lists them.\n",
+        "\n",
+        "**Note**: An *index column* is a column that appears in your filters or join conditions. An *included column* is a column that appears in your select/project.\n",
+        "\n",
+        "For instance, in the following query:\n",
+        "```sql\n",
+        "SELECT X\n",
+        "FROM Table\n",
+        "WHERE Y = 2\n",
+        "```\n",
+        "X can be an *index column* and Y can be an *included column*."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 28,
+      "outputs": [],
+      "metadata": {},
+      "source": [
+        "// Create index configurations\n",
+        "using Microsoft.Spark.Extensions.Hyperspace.Index;\n",
+        "\n",
+        "var empIndexConfig = new IndexConfig(\"empIndex\", new string[] {\"deptId\"}, new string[] {\"empName\"});\n",
+        "var deptIndexConfig1 = new IndexConfig(\"deptIndex1\", new string[] {\"deptId\"}, new string[] {\"deptName\"});\n",
+        "var deptIndexConfig2 = new IndexConfig(\"deptIndex2\", new string[] {\"location\"}, new string[] {\"deptName\"});"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Now, we create three indexes using our index configurations. For this purpose, we invoke \"createIndex\" command on our Hyperspace instance. This command requires an index configuration and the dataFrame containing rows to be indexed.\n",
+        "Running below cell creates three indexes.\n",
+        ""
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 29,
+      "outputs": [],
+      "metadata": {},
+      "source": [
+        "// Create indexes from configurations\n",
+        "hyperspace.CreateIndex(empDF, empIndexConfig);\n",
+        "hyperspace.CreateIndex(deptDF, deptIndexConfig1);\n",
+        "hyperspace.CreateIndex(deptDF, deptIndexConfig2);"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### List Indexes\n",
+        "\n",
+        "Below code shows how a user can list all available indexes in a Hyperspace instance. It uses \"indexes\" API which returns information about existing indexes as a Spark™'s DataFrame so you can perform additional operations. For instance, you can invoke valid operations on this DataFrame for checking its content or analyzing it further (for example filtering specific indexes or grouping them according to some desired property). \n",
+        "\n",
+        "Below cell uses DataFrame's 'show' action to fully print the rows and show details of our indexes in a tabular form. For each index, we can see all information Hyperspace has stored about it in the metadata. You will immediately notice the following:\n",
+        "  - \"config.indexName\", \"config.indexedColumns\", \"config.includedColumns\" and \"status.status\" are the fields that a user normally refers to. \n",
+        "  - \"dfSignature\" is automatically generated by Hyperspace and is unique for each index. Hyperspace uses this signature internally to maintain the index and exploit it at query time. \n",
+        "  \n",
+        "In the output below, all three indexes should have \"ACTIVE\" as status and their name, indexed columns, and included columns should match with what we defined in index configurations above.\n",
+        ""
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 30,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 30,
+          "data": {
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation| state|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "hyperspace.Indexes().Show();"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Delete Indexes\n",
+        "A user can drop an existing index by using the \"deleteIndex\" API and providing the index name. Index deletion does a soft delete: It mainly updates index's status in the Hyperspace metadata from \"ACTIVE\" to \"DELETED\". This will exclude the dropped index from any future query optimization and Hyperspace no longer picks that index for any query. However, index files for a deleted index still remain available (since it is a soft-delete), so that the index could be restored if user asks for.\n",
+        "\n",
+        "Below cell deletes index with name \"deptIndex2\" and lists Hyperspace metadata after that. The output should be similar to above cell for \"List Indexes\" except for \"deptIndex2\" which now should have its status changed into \"DELETED\"."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 31,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 31,
+          "data": {
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "hyperspace.DeleteIndex(\"deptIndex2\");\n",
+        "\n",
+        "hyperspace.Indexes().Show();"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Restore Indexes\n",
+        "A user can use the \"restoreIndex\" API to restore a deleted index. This will bring back the latest version of index into ACTIVE status and makes it usable again for queries. Below cell shows an example of \"restoreIndex\" usage. We delete \"deptIndex1\" and restore it. The output shows \"deptIndex1\" first went into the \"DELETED\" status after invoking \"deleteIndex\" command and came back to the \"ACTIVE\" status after calling \"restoreIndex\".\n",
+        ""
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 32,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 32,
+          "data": {
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "hyperspace.DeleteIndex(\"deptIndex1\");\n",
+        "\n",
+        "hyperspace.Indexes().Show();\n",
+        "\n",
+        "hyperspace.RestoreIndex(\"deptIndex1\");\n",
+        "\n",
+        "hyperspace.Indexes().Show();"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Vacuum Indexes\n",
+        "The user can perform a hard-delete i.e., fully remove files and the metadata entry for a deleted index using \"vacuumIndex\" command. Once done, this action is irreversible as it physically deletes all the index files (which is why it is a hard-delete).\n",
+        " \n",
+        "The cell below vacuums the \"deptIndex2\" index and shows Hyperspace metadata after vaccuming. You should see metadata entries for two indexes \"deptIndex1\" and \"empIndex\" both with \"ACTIVE\" status and no entry for \"deptIndex2\"."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 33,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 33,
+          "data": {
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation| state|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "hyperspace.VacuumIndex(\"deptIndex2\");\n",
+        "\n",
+        "hyperspace.Indexes().Show();"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Enable/Disable Hyperspace\n",
+        "\n",
+        "Hyperspace provides APIs to enable or disable index usage with Spark™.\n",
+        "\n",
+        "  - By using \"enableHyperspace\" command, Hyperspace optimization rules become visible to the Apache Spark™ optimizer and they will exploit existing Hyperspace indexes to optimize user queries.\n",
+        "  - By using \"disableHyperspace' command, Hyperspace rules no longer apply during query optimization. You should note that disabling Hyperspace has no impact on created indexes as they remain intact.\n",
+        "\n",
+        "Below cell shows how you can use these commands to enable or disable hyperspace. The output simply shows a reference to the existing Spark™ session whose configuration is updated."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 34,
+      "outputs": [],
+      "metadata": {},
+      "source": [
+        "// Enable Hyperspace\n",
+        "spark.EnableHyperspace();\n",
+        "\n",
+        "// Disable Hyperspace\n",
+        "spark.DisableHyperspace();"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Index Usage\n",
+        "In order to make Spark™ use Hyperspace indexes during query processing, the user needs to make sure that Hyperspace is enabled. \n",
+        "\n",
+        "The cell below enables Hyperspace and creates two DataFrames containing our sample data records which we use for running example queries. For each DataFrame, a few sample rows are printed."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 35,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 35,
+          "data": {
+            "text/plain": "+-----+-------+------+\n|empId|empName|deptId|\n+-----+-------+------+\n| 7499|  ALLEN|    30|\n| 7521|   WARD|    30|\n| 7369|  SMITH|    20|\n| 7844| TURNER|    30|\n| 7876|  ADAMS|    20|\n+-----+-------+------+\nonly showing top 5 rows\n\n+------+----------+--------+\n|deptId|  deptName|location|\n+------+----------+--------+\n|    10|Accounting|New York|\n|    40|Operations|  Boston|\n|    20|  Research|  Dallas|\n|    30|     Sales| Chicago|\n+------+----------+--------+"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "// Enable Hyperspace\n",
+        "spark.EnableHyperspace();\n",
+        "\n",
+        "DataFrame empDFrame = spark.Read().Parquet(empLocation);\n",
+        "DataFrame deptDFrame = spark.Read().Parquet(deptLocation);\n",
+        "\n",
+        "empDFrame.Show(5);\n",
+        "deptDFrame.Show(5);"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Hyperspace's Index Types\n",
+        "\n",
+        "Currently, Hyperspace has rules to exploit indexes for two groups of queries: \n",
+        "* Selection queries with lookup or range selection filtering predicates.\n",
+        "* Join queries with an equality join predicate (i.e. Equi-joins).\n",
+        ""
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Indexes for Accelerating Filters\n",
+        "\n",
+        "Our first example query does a lookup on department records (see below cell). In SQL, this query looks as follows:\n",
+        "\n",
+        "```sql\n",
+        "SELECT deptName \n",
+        "FROM departments\n",
+        "WHERE deptId = 20\n",
+        "```\n",
+        "\n",
+        "The output of running the cell below shows: \n",
+        "- query result, which is a single department name.\n",
+        "- query plan that Spark™ used to run the query. \n",
+        "\n",
+        "In the query plan, the \"FileScan\" operator at the bottom of the plan shows the datasource where the records were read from. The location of this file indicates the path to the latest version of the \"deptIndex1\" index. This shows  that according to the query and using Hyperspace optimization rules, Spark™ decided to exploit the proper index at runtime.\n",
+        ""
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 36,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 36,
+          "data": {
+            "text/plain": "+--------+\n|deptName|\n+--------+\n|Research|\n+--------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#725 = 20)\n   +- Relation[deptId#725,deptName#726,location#727] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#726]\n+- Filter (deptId#725 = 20)\n   +- Relation[deptId#725,deptName#726,location#727] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#726]\n+- Filter (isnotnull(deptId#725) && (deptId#725 = 20))\n   +- Relation[deptId#725,deptName#726] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#726]\n+- *(1) Filter (isnotnull(deptId#725) && (deptId#725 = 20))\n   +- *(1) FileScan parquet [deptId#725,deptName#726] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), EqualTo(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "// Filter with equality predicate\n",
+        "DataFrame eqFilter = deptDFrame.Filter(\"deptId = 20\").Select(\"deptName\");\n",
+        "eqFilter.Show();\n",
+        "\n",
+        "eqFilter.Explain(true);"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Our second example is a range selection query on department records. In SQL, this query looks as follows:\n",
+        "\n",
+        "```sql\n",
+        "SELECT deptName \n",
+        "FROM departments\n",
+        "WHERE deptId > 20\"\n",
+        "```\n",
+        "Similar to our first example, the output of the cell below shows the query results (names of two departments) and the query plan. The location of data file in the FileScan operator shows that 'deptIndex1\" was used to run the query.   \n",
+        ""
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 37,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 37,
+          "data": {
+            "text/plain": "+----------+\n|  deptName|\n+----------+\n|Operations|\n|     Sales|\n+----------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#725 > 20)\n   +- Relation[deptId#725,deptName#726,location#727] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#726]\n+- Filter (deptId#725 > 20)\n   +- Relation[deptId#725,deptName#726,location#727] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#726]\n+- Filter (isnotnull(deptId#725) && (deptId#725 > 20))\n   +- Relation[deptId#725,deptName#726] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#726]\n+- *(1) Filter (isnotnull(deptId#725) && (deptId#725 > 20))\n   +- *(1) FileScan parquet [deptId#725,deptName#726] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "// Filter with range selection predicate\n",
+        "DataFrame rangeFilter = deptDFrame.Filter(\"deptId > 20\").Select(\"deptName\");\n",
+        "rangeFilter.Show();\n",
+        "\n",
+        "rangeFilter.Explain(true);"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Our third example is a query joining department and employee records on the department id. The equivalent SQL statement is shown below:\n",
+        "\n",
+        "```sql\n",
+        "SELECT employees.deptId, empName, departments.deptId, deptName\n",
+        "FROM   employees, departments \n",
+        "WHERE  employees.deptId = departments.deptId\"\n",
+        "```\n",
+        "\n",
+        "The output of running the cell below shows the query results which are the names of 14 employees and the name of department each employee works in. The query plan is also included in the output. Notice how the file locations for two FileScan operators shows that Spark™ used \"empIndex\" and \"deptIndex1\" indexes to run the query.   \n",
+        ""
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 38,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 38,
+          "data": {
+            "text/plain": "+-------+----------+\n|empName|  deptName|\n+-------+----------+\n|  SMITH|  Research|\n|  SCOTT|  Research|\n|   FORD|  Research|\n|  ADAMS|  Research|\n|  JONES|  Research|\n|   KING|Accounting|\n| MILLER|Accounting|\n|  CLARK|Accounting|\n|  JAMES|     Sales|\n| MARTIN|     Sales|\n|  ALLEN|     Sales|\n|   WARD|     Sales|\n| TURNER|     Sales|\n|  BLAKE|     Sales|\n+-------+----------+\n\n== Parsed Logical Plan ==\nProject [empName#720, deptName#726]\n+- Join Inner, (deptId#721 = deptId#725)\n   :- Relation[empId#719,empName#720,deptId#721] parquet\n   +- Relation[deptId#725,deptName#726,location#727] parquet\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#720, deptName#726]\n+- Join Inner, (deptId#721 = deptId#725)\n   :- Relation[empId#719,empName#720,deptId#721] parquet\n   +- Relation[deptId#725,deptName#726,location#727] parquet\n\n== Optimized Logical Plan ==\nProject [empName#720, deptName#726]\n+- Join Inner, (deptId#721 = deptId#725)\n   :- Project [empName#720, deptId#721]\n   :  +- Filter isnotnull(deptId#721)\n   :     +- Relation[empName#720,deptId#721] parquet\n   +- Project [deptId#725, deptName#726]\n      +- Filter isnotnull(deptId#725)\n         +- Relation[deptId#725,deptName#726] parquet\n\n== Physical Plan ==\n*(3) Project [empName#720, deptName#726]\n+- *(3) SortMergeJoin [deptId#721], [deptId#725], Inner\n   :- *(1) Project [empName#720, deptId#721]\n   :  +- *(1) Filter isnotnull(deptId#721)\n   :     +- *(1) FileScan parquet [deptId#721,empName#720] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#725, deptName#726]\n      +- *(2) Filter isnotnull(deptId#725)\n         +- *(2) FileScan parquet [deptId#725,deptName#726] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "// Join\n",
+        "DataFrame eqJoin =\n",
+        "      empDFrame\n",
+        "      .Join(deptDFrame, empDFrame.Col(\"deptId\") == deptDFrame.Col(\"deptId\"))\n",
+        "      .Select(empDFrame.Col(\"empName\"), deptDFrame.Col(\"deptName\"));\n",
+        "\n",
+        "eqJoin.Show();\n",
+        "\n",
+        "eqJoin.Explain(true);"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Support for SQL Semantics\n",
+        "\n",
+        "The index usage is transparent to whether the user uses DataFrame API or Spark™ SQL. The following example shows the same join example as before, in sql form, showing the use of indexes if applicable."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 39,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 39,
+          "data": {
+            "text/plain": "+-------+----------+\n|empName|  deptName|\n+-------+----------+\n|  SMITH|  Research|\n|  SCOTT|  Research|\n|   FORD|  Research|\n|  ADAMS|  Research|\n|  JONES|  Research|\n|   KING|Accounting|\n| MILLER|Accounting|\n|  CLARK|Accounting|\n|  JAMES|     Sales|\n| MARTIN|     Sales|\n|  ALLEN|     Sales|\n|   WARD|     Sales|\n| TURNER|     Sales|\n|  BLAKE|     Sales|\n+-------+----------+\n\n== Parsed Logical Plan ==\n'Project ['EMP.empName, 'DEPT.deptName]\n+- 'Filter ('EMP.deptId = 'DEPT.deptId)\n   +- 'Join Inner\n      :- 'UnresolvedRelation `EMP`\n      +- 'UnresolvedRelation `DEPT`\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#720, deptName#726]\n+- Filter (deptId#721 = deptId#725)\n   +- Join Inner\n      :- SubqueryAlias `emp`\n      :  +- Relation[empId#719,empName#720,deptId#721] parquet\n      +- SubqueryAlias `dept`\n         +- Relation[deptId#725,deptName#726,location#727] parquet\n\n== Optimized Logical Plan ==\nProject [empName#720, deptName#726]\n+- Join Inner, (deptId#721 = deptId#725)\n   :- Project [empName#720, deptId#721]\n   :  +- Filter isnotnull(deptId#721)\n   :     +- Relation[empName#720,deptId#721] parquet\n   +- Project [deptId#725, deptName#726]\n      +- Filter isnotnull(deptId#725)\n         +- Relation[deptId#725,deptName#726] parquet\n\n== Physical Plan ==\n*(3) Project [empName#720, deptName#726]\n+- *(3) SortMergeJoin [deptId#721], [deptId#725], Inner\n   :- *(1) Project [empName#720, deptId#721]\n   :  +- *(1) Filter isnotnull(deptId#721)\n   :     +- *(1) FileScan parquet [deptId#721,empName#720] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#725, deptName#726]\n      +- *(2) Filter isnotnull(deptId#725)\n         +- *(2) FileScan parquet [deptId#725,deptName#726] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "empDFrame.CreateOrReplaceTempView(\"EMP\");\n",
+        "deptDFrame.CreateOrReplaceTempView(\"DEPT\");\n",
+        "\n",
+        "var joinQuery = spark.Sql(\"SELECT EMP.empName, DEPT.deptName FROM EMP, DEPT WHERE EMP.deptId = DEPT.deptId\");\n",
+        "\n",
+        "joinQuery.Show();\n",
+        "joinQuery.Explain(true);"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Explain API\n",
+        "Indexes are great but how do you know if they are being used? Hyperspace allows users to compare their original plan vs the updated index-dependent plan before running their query. You have an option to choose from html/plaintext/console mode to display the command output. \n",
+        "\n",
+        "The following cell shows an example with HTML. The highlighted section represents the difference between original and updated plans along with the indexes being used."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 40,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 40,
+          "data": {
+            "text/html": "<pre>=============================================================<br>Plan with indexes:<br>=============================================================<br>Project [empName#720, deptName#726]<br>+- SortMergeJoin [deptId#721], [deptId#725], Inner<br>   :- *(1) Project [empName#720, deptId#721]<br>   :  +- *(1) Filter isnotnull(deptId#721)<br>   :     +- *(1) FileScan parquet [deptId#721,empName#720] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200<br>   +- *(2) Project [deptId#725, deptName#726]<br>      +- *(2) Filter isnotnull(deptId#725)<br>         +- *(2) FileScan parquet [deptId#725,deptName#726] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200<br><br>=============================================================<br>Plan without indexes:<br>=============================================================<br>Project [empName#720, deptName#726]<br>+- SortMergeJoin [deptId#721], [deptId#725], Inner<br>   :- *(1) Project [empName#720, deptId#721]<br>   :  +- *(1) Filter isnotnull(deptId#721)<br>   :     +- *(1) FileScan parquet [deptId#721,empName#720] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200<br>   +- *(2) Project [deptId#725, deptName#726]<br>      +- *(2) Filter isnotnull(deptId#725)<br>         +- *(2) FileScan parquet [deptId#725,deptName#726] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200<br><br>=============================================================<br>Indexes used:<br>=============================================================<br>deptIndex1:abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/warehouse/indexes/deptIndex1/v__=0<br>empIndex:abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/warehouse/indexes/empIndex/v__=0<br><br></pre>"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "spark.Conf().Set(\"spark.hyperspace.explain.displayMode\", \"html\");\n",
+        "hyperspace.Explain(eqJoin, false, input => DisplayHTML(input));"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Refresh Indexes\n",
+        "If the original data on which an index was created changes, then the index will no longer capture the latest state of data. The user can refresh such a stale index using \"refreshIndex\" command. This causes the index to be fully rebuilt and updates it according to the latest data records (don't worry, we will show you how to *incrementally refresh* your index in other notebooks).\n",
+        "\n",
+        "The two cells below show an example for this scenario:\n",
+        "- First cell adds two more departments to the original departments data. It reads and prints list of departments to verify new departments are added correctly. The output shows 6 departments in total: four old ones and two new. Invoking \"refreshIndex\" updates \"deptIndex1\" so index captures new departments.\n",
+        "- Second cell runs our range selection query example. The results should now contain four departments: two are the ones, seen before when we ran the query above, and two are the new departments we just added."
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 41,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 41,
+          "data": {
+            "text/plain": "+------+---------------+-------------+\n|deptId|       deptName|     location|\n+------+---------------+-------------+\n|    60|Human Resources|San Francisco|\n|    10|     Accounting|     New York|\n|    50|      Inovation|      Seattle|\n|    40|     Operations|       Boston|\n|    20|       Research|       Dallas|\n|    30|          Sales|      Chicago|\n+------+---------------+-------------+"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "var extraDepartments = new List<GenericRow>()\n",
+        "{\n",
+        "    new GenericRow(new object[] {50, \"Inovation\", \"Seattle\"}),\n",
+        "    new GenericRow(new object[] {60, \"Human Resources\", \"San Francisco\"})\n",
+        "};\n",
+        "\t  \n",
+        "DataFrame extraDeptData = spark.CreateDataFrame(extraDepartments, departmentSchema);\n",
+        "extraDeptData.Write().Mode(\"Append\").Parquet(deptLocation);\n",
+        "\n",
+        "DataFrame deptDFrameUpdated = spark.Read().Parquet(deptLocation);\n",
+        "\n",
+        "deptDFrameUpdated.Show(10);\n",
+        "\n",
+        "hyperspace.RefreshIndex(\"deptIndex1\");"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 42,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 42,
+          "data": {
+            "text/plain": "+---------------+\n|       deptName|\n+---------------+\n|Human Resources|\n|      Inovation|\n|     Operations|\n|          Sales|\n+---------------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#829 > 20)\n   +- Relation[deptId#829,deptName#830,location#831] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#830]\n+- Filter (deptId#829 > 20)\n   +- Relation[deptId#829,deptName#830,location#831] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#830]\n+- Filter (isnotnull(deptId#829) && (deptId#829 > 20))\n   +- Relation[deptId#829,deptName#830] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#830]\n+- *(1) Filter (isnotnull(deptId#829) && (deptId#829 > 20))\n   +- *(1) FileScan parquet [deptId#829,deptName#830] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "DataFrame newRangeFilter = deptDFrameUpdated.Filter(\"deptId > 20\").Select(\"deptName\");\n",
+        "newRangeFilter.Show();\n",
+        "\n",
+        "newRangeFilter.Explain(true);"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 43,
+      "outputs": [],
+      "metadata": {},
+      "source": [
+        "// Clean-up the remaining indexes\n",
+        "hyperspace.DeleteIndex(\"empIndex\");\n",
+        "hyperspace.DeleteIndex(\"deptIndex1\");\n",
+        "\n",
+        "hyperspace.VacuumIndex(\"empIndex\");\n",
+        "hyperspace.VacuumIndex(\"deptIndex1\");"
+      ],
+      "attachments": {}
+    }
+  ]
+}

--- a/notebooks/python/Hitchhikers Guide to Hyperspace.ipynb
+++ b/notebooks/python/Hitchhikers Guide to Hyperspace.ipynb
@@ -39,11 +39,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 4,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 16,
+          "execution_count": 4,
           "data": {
             "text/plain": "-1"
           },
@@ -79,7 +79,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": 5,
       "outputs": [],
       "metadata": {},
       "source": [
@@ -119,13 +119,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": 6,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 18,
+          "execution_count": 6,
           "data": {
-            "text/plain": "+-----+-------+------+\n|empId|empName|deptId|\n+-----+-------+------+\n| 7369|  SMITH|    20|\n| 7499|  ALLEN|    30|\n| 7566|  JONES|    20|\n| 7698|  BLAKE|    30|\n| 7521|   WARD|    30|\n+-----+-------+------+\n\n+------+----------+--------+\n|deptId|  deptName|location|\n+------+----------+--------+\n|    10|Accounting|New York|\n|    40|Operations|  Boston|\n|    20|  Research|  Dallas|\n|    30|     Sales| Chicago|\n+------+----------+--------+"
+            "text/plain": "+-----+-------+------+\n|empId|empName|deptId|\n+-----+-------+------+\n| 7369|  SMITH|    20|\n| 7499|  ALLEN|    30|\n| 7521|   WARD|    30|\n| 7566|  JONES|    20|\n| 7698|  BLAKE|    30|\n+-----+-------+------+\n\n+------+----------+--------+\n|deptId|  deptName|location|\n+------+----------+--------+\n|    10|Accounting|New York|\n|    40|Operations|  Boston|\n|    20|  Research|  Dallas|\n|    30|     Sales| Chicago|\n+------+----------+--------+"
           },
           "metadata": {}
         }
@@ -164,7 +164,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": 7,
       "outputs": [],
       "metadata": {},
       "source": [
@@ -201,7 +201,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": 8,
       "outputs": [],
       "metadata": {},
       "source": [
@@ -225,7 +225,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
+      "execution_count": 9,
       "outputs": [],
       "metadata": {},
       "source": [
@@ -256,13 +256,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 23,
+      "execution_count": 10,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 23,
+          "execution_count": 10,
           "data": {
-            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation| state|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...|ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...|ACTIVE|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|/location/...|ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+"
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation| state|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+"
           },
           "metadata": {}
         }
@@ -286,13 +286,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 24,
+      "execution_count": 11,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 24,
+          "execution_count": 11,
           "data": {
-            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...| ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...|DELETED|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|/location/...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+"
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+"
           },
           "metadata": {}
         }
@@ -317,13 +317,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 25,
+      "execution_count": 12,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 25,
+          "execution_count": 12,
           "data": {
-            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...|DELETED|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...|DELETED|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|/location/...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...| ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|/location/...|DELETED|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|/location/...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+"
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+"
           },
           "metadata": {}
         }
@@ -353,14 +353,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 72,
+      "execution_count": 13,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 13,
           "data": {
-            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+--------------------+------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|           queryPlan| state|\n+----------+--------------+---------------+----------+--------------------+--------------------+--------------------+------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|/datasets/idx...|Relation[deptId#1...|ACTIVE|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|/datasets/idx...|Relation[empId#19...|ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+--------------------+------+"
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation| state|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+"
           },
-          "execution_count": 72,
           "metadata": {}
         }
       ],
@@ -388,13 +388,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 26,
+      "execution_count": 14,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 26,
+          "execution_count": 14,
           "data": {
-            "text/plain": "<pyspark.sql.session.SparkSession object at 0x7f30d4c90dd8>"
+            "text/plain": "<pyspark.sql.session.SparkSession object at 0x7f0d3bf1beb8>"
           },
           "metadata": {}
         }
@@ -422,13 +422,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 27,
+      "execution_count": 15,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 27,
+          "execution_count": 15,
           "data": {
-            "text/plain": "+-----+-------+------+\n|empId|empName|deptId|\n+-----+-------+------+\n| 7369|  SMITH|    20|\n| 7499|  ALLEN|    30|\n| 7566|  JONES|    20|\n| 7698|  BLAKE|    30|\n| 7521|   WARD|    30|\n+-----+-------+------+\n\n+------+----------+--------+\n|deptId|  deptName|location|\n+------+----------+--------+\n|    10|Accounting|New York|\n|    40|Operations|  Boston|\n|    20|  Research|  Dallas|\n|    30|     Sales| Chicago|\n+------+----------+--------+"
+            "text/plain": "+-----+-------+------+\n|empId|empName|deptId|\n+-----+-------+------+\n| 7369|  SMITH|    20|\n| 7499|  ALLEN|    30|\n| 7521|   WARD|    30|\n| 7566|  JONES|    20|\n| 7698|  BLAKE|    30|\n+-----+-------+------+\n\n+------+----------+--------+\n|deptId|  deptName|location|\n+------+----------+--------+\n|    10|Accounting|New York|\n|    40|Operations|  Boston|\n|    20|  Research|  Dallas|\n|    30|     Sales| Chicago|\n+------+----------+--------+"
           },
           "metadata": {}
         }
@@ -484,13 +484,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 28,
+      "execution_count": 16,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 28,
+          "execution_count": 16,
           "data": {
-            "text/plain": "+--------+\n|deptName|\n+--------+\n|Research|\n+--------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#492 = 20)\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#493]\n+- Filter (deptId#492 = 20)\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#493]\n+- Filter (isnotnull(deptId#492) && (deptId#492 = 20))\n   +- Relation[deptId#492,deptName#493] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#493]\n+- *(1) Filter (isnotnull(deptId#492) && (deptId#492 = 20))\n   +- *(1) FileScan parquet [deptId#492,deptName#493] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/deptIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId), EqualTo(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+            "text/plain": "+--------+\n|deptName|\n+--------+\n|Research|\n+--------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#294 = 20)\n   +- Relation[deptId#294,deptName#295,location#296] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#295]\n+- Filter (deptId#294 = 20)\n   +- Relation[deptId#294,deptName#295,location#296] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#295]\n+- Filter (isnotnull(deptId#294) && (deptId#294 = 20))\n   +- Relation[deptId#294,deptName#295] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#295]\n+- *(1) Filter (isnotnull(deptId#294) && (deptId#294 = 20))\n   +- *(1) FileScan parquet [deptId#294,deptName#295] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), EqualTo(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
           },
           "metadata": {}
         }
@@ -524,13 +524,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 29,
+      "execution_count": 17,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 29,
+          "execution_count": 17,
           "data": {
-            "text/plain": "+----------+\n|  deptName|\n+----------+\n|Operations|\n|     Sales|\n+----------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#492 > 20)\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#493]\n+- Filter (deptId#492 > 20)\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#493]\n+- Filter (isnotnull(deptId#492) && (deptId#492 > 20))\n   +- Relation[deptId#492,deptName#493] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#493]\n+- *(1) Filter (isnotnull(deptId#492) && (deptId#492 > 20))\n   +- *(1) FileScan parquet [deptId#492,deptName#493] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/deptIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+            "text/plain": "+----------+\n|  deptName|\n+----------+\n|Operations|\n|     Sales|\n+----------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#294 > 20)\n   +- Relation[deptId#294,deptName#295,location#296] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#295]\n+- Filter (deptId#294 > 20)\n   +- Relation[deptId#294,deptName#295,location#296] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#295]\n+- Filter (isnotnull(deptId#294) && (deptId#294 > 20))\n   +- Relation[deptId#294,deptName#295] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#295]\n+- *(1) Filter (isnotnull(deptId#294) && (deptId#294 > 20))\n   +- *(1) FileScan parquet [deptId#294,deptName#295] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
           },
           "metadata": {}
         }
@@ -565,13 +565,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 30,
+      "execution_count": 18,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 30,
+          "execution_count": 18,
           "data": {
-            "text/plain": "+-------+--------+\n|empName|deptName|\n+-------+--------+\n|  SMITH|Research|\n|  JONES|Research|\n|  ALLEN|   Sales|\n|  BLAKE|   Sales|\n|   WARD|   Sales|\n+-------+--------+\n\n== Parsed Logical Plan ==\nProject [empName#487, deptName#493]\n+- Join Inner, (deptId#488 = deptId#492)\n   :- Relation[empId#486,empName#487,deptId#488] parquet\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#487, deptName#493]\n+- Join Inner, (deptId#488 = deptId#492)\n   :- Relation[empId#486,empName#487,deptId#488] parquet\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Optimized Logical Plan ==\nProject [empName#487, deptName#493]\n+- Join Inner, (deptId#488 = deptId#492)\n   :- Project [empName#487, deptId#488]\n   :  +- Filter isnotnull(deptId#488)\n   :     +- Relation[empName#487,deptId#488] parquet\n   +- Project [deptId#492, deptName#493]\n      +- Filter isnotnull(deptId#492)\n         +- Relation[deptId#492,deptName#493] parquet\n\n== Physical Plan ==\n*(3) Project [empName#487, deptName#493]\n+- *(3) SortMergeJoin [deptId#488], [deptId#492], Inner\n   :- *(1) Project [empName#487, deptId#488]\n   :  +- *(1) Filter isnotnull(deptId#488)\n   :     +- *(1) FileScan parquet [deptId#488,empName#487] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/empIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#492, deptName#493]\n      +- *(2) Filter isnotnull(deptId#492)\n         +- *(2) FileScan parquet [deptId#492,deptName#493] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/deptIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
+            "text/plain": "+-------+--------+\n|empName|deptName|\n+-------+--------+\n|  SMITH|Research|\n|  JONES|Research|\n|  ALLEN|   Sales|\n|   WARD|   Sales|\n|  BLAKE|   Sales|\n+-------+--------+\n\n== Parsed Logical Plan ==\nProject [empName#289, deptName#295]\n+- Join Inner, (deptId#290 = deptId#294)\n   :- Relation[empId#288,empName#289,deptId#290] parquet\n   +- Relation[deptId#294,deptName#295,location#296] parquet\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#289, deptName#295]\n+- Join Inner, (deptId#290 = deptId#294)\n   :- Relation[empId#288,empName#289,deptId#290] parquet\n   +- Relation[deptId#294,deptName#295,location#296] parquet\n\n== Optimized Logical Plan ==\nProject [empName#289, deptName#295]\n+- Join Inner, (deptId#290 = deptId#294)\n   :- Project [empName#289, deptId#290]\n   :  +- Filter isnotnull(deptId#290)\n   :     +- Relation[empName#289,deptId#290] parquet\n   +- Project [deptId#294, deptName#295]\n      +- Filter isnotnull(deptId#294)\n         +- Relation[deptId#294,deptName#295] parquet\n\n== Physical Plan ==\n*(3) Project [empName#289, deptName#295]\n+- *(3) SortMergeJoin [deptId#290], [deptId#294], Inner\n   :- *(1) Project [empName#289, deptId#290]\n   :  +- *(1) Filter isnotnull(deptId#290)\n   :     +- *(1) FileScan parquet [deptId#290,empName#289] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#294, deptName#295]\n      +- *(2) Filter isnotnull(deptId#294)\n         +- *(2) FileScan parquet [deptId#294,deptName#295] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
           },
           "metadata": {}
         }
@@ -590,13 +590,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 31,
+      "execution_count": 19,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 31,
+          "execution_count": 19,
           "data": {
-            "text/plain": "+-------+--------+\n|empName|deptName|\n+-------+--------+\n|  SMITH|Research|\n|  JONES|Research|\n|  ALLEN|   Sales|\n|  BLAKE|   Sales|\n|   WARD|   Sales|\n+-------+--------+\n\n== Parsed Logical Plan ==\nProject [empName#487, deptName#493]\n+- Join Inner, (deptId#488 = deptId#492)\n   :- Relation[empId#486,empName#487,deptId#488] parquet\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#487, deptName#493]\n+- Join Inner, (deptId#488 = deptId#492)\n   :- Relation[empId#486,empName#487,deptId#488] parquet\n   +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Optimized Logical Plan ==\nProject [empName#487, deptName#493]\n+- Join Inner, (deptId#488 = deptId#492)\n   :- Project [empName#487, deptId#488]\n   :  +- Filter isnotnull(deptId#488)\n   :     +- Relation[empName#487,deptId#488] parquet\n   +- Project [deptId#492, deptName#493]\n      +- Filter isnotnull(deptId#492)\n         +- Relation[deptId#492,deptName#493] parquet\n\n== Physical Plan ==\n*(3) Project [empName#487, deptName#493]\n+- *(3) SortMergeJoin [deptId#488], [deptId#492], Inner\n   :- *(1) Project [empName#487, deptId#488]\n   :  +- *(1) Filter isnotnull(deptId#488)\n   :     +- *(1) FileScan parquet [deptId#488,empName#487] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/empIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#492, deptName#493]\n      +- *(2) Filter isnotnull(deptId#492)\n         +- *(2) FileScan parquet [deptId#492,deptName#493] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/deptIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
+            "text/plain": "+-------+--------+\n|empName|deptName|\n+-------+--------+\n|  SMITH|Research|\n|  JONES|Research|\n|  ALLEN|   Sales|\n|   WARD|   Sales|\n|  BLAKE|   Sales|\n+-------+--------+\n\n== Parsed Logical Plan ==\nProject [empName#289, deptName#295]\n+- Join Inner, (deptId#290 = deptId#294)\n   :- Relation[empId#288,empName#289,deptId#290] parquet\n   +- Relation[deptId#294,deptName#295,location#296] parquet\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#289, deptName#295]\n+- Join Inner, (deptId#290 = deptId#294)\n   :- Relation[empId#288,empName#289,deptId#290] parquet\n   +- Relation[deptId#294,deptName#295,location#296] parquet\n\n== Optimized Logical Plan ==\nProject [empName#289, deptName#295]\n+- Join Inner, (deptId#290 = deptId#294)\n   :- Project [empName#289, deptId#290]\n   :  +- Filter isnotnull(deptId#290)\n   :     +- Relation[empName#289,deptId#290] parquet\n   +- Project [deptId#294, deptName#295]\n      +- Filter isnotnull(deptId#294)\n         +- Relation[deptId#294,deptName#295] parquet\n\n== Physical Plan ==\n*(3) Project [empName#289, deptName#295]\n+- *(3) SortMergeJoin [deptId#290], [deptId#294], Inner\n   :- *(1) Project [empName#289, deptId#290]\n   :  +- *(1) Filter isnotnull(deptId#290)\n   :     +- *(1) FileScan parquet [deptId#290,empName#289] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#294, deptName#295]\n      +- *(2) Filter isnotnull(deptId#294)\n         +- *(2) FileScan parquet [deptId#294,deptName#295] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
           },
           "metadata": {}
         }
@@ -625,13 +625,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 32,
+      "execution_count": 20,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 32,
+          "execution_count": 20,
           "data": {
-            "text/plain": "+-------+--------+\n|empName|deptName|\n+-------+--------+\n|  SMITH|Research|\n|  JONES|Research|\n|  ALLEN|   Sales|\n|  BLAKE|   Sales|\n|   WARD|   Sales|\n+-------+--------+\n\n== Parsed Logical Plan ==\n'Project ['EMP.empName, 'DEPT.deptName]\n+- 'Filter ('EMP.deptId = 'DEPT.deptId)\n   +- 'Join Inner\n      :- 'UnresolvedRelation `EMP`\n      +- 'UnresolvedRelation `DEPT`\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#487, deptName#493]\n+- Filter (deptId#488 = deptId#492)\n   +- Join Inner\n      :- SubqueryAlias `emp`\n      :  +- Relation[empId#486,empName#487,deptId#488] parquet\n      +- SubqueryAlias `dept`\n         +- Relation[deptId#492,deptName#493,location#494] parquet\n\n== Optimized Logical Plan ==\nProject [empName#487, deptName#493]\n+- Join Inner, (deptId#488 = deptId#492)\n   :- Project [empName#487, deptId#488]\n   :  +- Filter isnotnull(deptId#488)\n   :     +- Relation[empName#487,deptId#488] parquet\n   +- Project [deptId#492, deptName#493]\n      +- Filter isnotnull(deptId#492)\n         +- Relation[deptId#492,deptName#493] parquet\n\n== Physical Plan ==\n*(3) Project [empName#487, deptName#493]\n+- *(3) SortMergeJoin [deptId#488], [deptId#492], Inner\n   :- *(1) Project [empName#487, deptId#488]\n   :  +- *(1) Filter isnotnull(deptId#488)\n   :     +- *(1) FileScan parquet [deptId#488,empName#487] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/empIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#492, deptName#493]\n      +- *(2) Filter isnotnull(deptId#492)\n         +- *(2) FileScan parquet [deptId#492,deptName#493] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/deptIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
+            "text/plain": "+-------+--------+\n|empName|deptName|\n+-------+--------+\n|  SMITH|Research|\n|  JONES|Research|\n|  ALLEN|   Sales|\n|   WARD|   Sales|\n|  BLAKE|   Sales|\n+-------+--------+\n\n== Parsed Logical Plan ==\n'Project ['EMP.empName, 'DEPT.deptName]\n+- 'Filter ('EMP.deptId = 'DEPT.deptId)\n   +- 'Join Inner\n      :- 'UnresolvedRelation `EMP`\n      +- 'UnresolvedRelation `DEPT`\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#289, deptName#295]\n+- Filter (deptId#290 = deptId#294)\n   +- Join Inner\n      :- SubqueryAlias `emp`\n      :  +- Relation[empId#288,empName#289,deptId#290] parquet\n      +- SubqueryAlias `dept`\n         +- Relation[deptId#294,deptName#295,location#296] parquet\n\n== Optimized Logical Plan ==\nProject [empName#289, deptName#295]\n+- Join Inner, (deptId#290 = deptId#294)\n   :- Project [empName#289, deptId#290]\n   :  +- Filter isnotnull(deptId#290)\n   :     +- Relation[empName#289,deptId#290] parquet\n   +- Project [deptId#294, deptName#295]\n      +- Filter isnotnull(deptId#294)\n         +- Relation[deptId#294,deptName#295] parquet\n\n== Physical Plan ==\n*(3) Project [empName#289, deptName#295]\n+- *(3) SortMergeJoin [deptId#290], [deptId#294], Inner\n   :- *(1) Project [empName#289, deptId#290]\n   :  +- *(1) Filter isnotnull(deptId#290)\n   :     +- *(1) FileScan parquet [deptId#290,empName#289] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#294, deptName#295]\n      +- *(2) Filter isnotnull(deptId#294)\n         +- *(2) FileScan parquet [deptId#294,deptName#295] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
           },
           "metadata": {}
         }
@@ -663,13 +663,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 42,
+      "execution_count": 21,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 42,
+          "execution_count": 21,
           "data": {
-            "text/html": "<pre>=============================================================<br>Plan with indexes:<br>=============================================================<br>Project [empName#487, deptName#493]<br>+- SortMergeJoin [deptId#488], [deptId#492], Inner<br>   <b style=\"background:LightGreen\">:- *(1) Project [empName#487, deptId#488]</b><br>   <b style=\"background:LightGreen\">:  +- *(1) Filter isnotnull(deptId#488)</b><br>   <b style=\"background:LightGreen\">:     +- *(1) FileScan parquet [deptId#488,empName#487] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/empIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200</b><br>   <b style=\"background:LightGreen\">+- *(2) Project [deptId#492, deptName#493]</b><br>      <b style=\"background:LightGreen\">+- *(2) Filter isnotnull(deptId#492)</b><br>         <b style=\"background:LightGreen\">+- *(2) FileScan parquet [deptId#492,deptName#493] Batched: true, Format: Parquet, Location: InMemoryFileIndex[/location/deptIndex1/v__=0], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200</b><br><br>=============================================================<br>Plan without indexes:<br>=============================================================<br>Project [empName#487, deptName#493]<br>+- SortMergeJoin [deptId#488], [deptId#492], Inner<br>   <b style=\"background:LightGreen\">:- *(2) Sort [deptId#488 ASC NULLS FIRST], false, 0</b><br>   <b style=\"background:LightGreen\">:  +- Exchange hashpartitioning(deptId#488, 200), [id=#353]</b><br>   <b style=\"background:LightGreen\">:     +- *(1) Project [empName#487, deptId#488]</b><br>   <b style=\"background:LightGreen\">:        +- *(1) Filter isnotnull(deptId#488)</b><br>   <b style=\"background:LightGreen\">:           +- *(1) FileScan parquet [empName#487,deptId#488] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@location../employees.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<empName:string,deptId:int></b><br>   <b style=\"background:LightGreen\">+- *(4) Sort [deptId#492 ASC NULLS FIRST], false, 0</b><br>      <b style=\"background:LightGreen\">+- Exchange hashpartitioning(deptId#492, 200), [id=#359]</b><br>         <b style=\"background:LightGreen\">+- *(3) Project [deptId#492, deptName#493]</b><br>            <b style=\"background:LightGreen\">+- *(3) Filter isnotnull(deptId#492)</b><br>               <b style=\"background:LightGreen\">+- *(3) FileScan parquet [deptId#492,deptName#493] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@location../departments.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string></b><br><br>=============================================================<br>Indexes used:<br>=============================================================<br>deptIndex1:/location/deptIndex1/v__=0<br>empIndex1:/location/empIndex1/v__=0<br><br>=============================================================<br>Physical operator stats:<br>=============================================================<br>+------------------+-------------------+------------------+----------+<br>| Physical Operator|Hyperspace Disabled|Hyperspace Enabled|Difference|<br>+------------------+-------------------+------------------+----------+<br>|     *InputAdapter|                  4|                 2|        -2|<br>|  *ShuffleExchange|                  2|                 0|        -2|<br>|             *Sort|                  2|                 0|        -2|<br>|*WholeStageCodegen|                  5|                 3|        -2|<br>|            Filter|                  2|                 2|         0|<br>|           Project|                  3|                 3|         0|<br>|      Scan parquet|                  2|                 2|         0|<br>|     SortMergeJoin|                  1|                 1|         0|<br>+------------------+-------------------+------------------+----------+<br><br></pre>"
+            "text/html": "<pre>=============================================================<br>Plan with indexes:<br>=============================================================<br>Project [empName#289, deptName#295]<br>+- SortMergeJoin [deptId#290], [deptId#294], Inner<br>   <b style=\"background:LightGreen\">:- *(1) Project [empName#289, deptId#290]</b><br>   <b style=\"background:LightGreen\">:  +- *(1) Filter isnotnull(deptId#290)</b><br>   <b style=\"background:LightGreen\">:     +- *(1) FileScan parquet [deptId#290,empName#289] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200</b><br>   <b style=\"background:LightGreen\">+- *(2) Project [deptId#294, deptName#295]</b><br>      <b style=\"background:LightGreen\">+- *(2) Filter isnotnull(deptId#294)</b><br>         <b style=\"background:LightGreen\">+- *(2) FileScan parquet [deptId#294,deptName#295] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200</b><br><br>=============================================================<br>Plan without indexes:<br>=============================================================<br>Project [empName#289, deptName#295]<br>+- SortMergeJoin [deptId#290], [deptId#294], Inner<br>   <b style=\"background:LightGreen\">:- *(2) Sort [deptId#290 ASC NULLS FIRST], false, 0</b><br>   <b style=\"background:LightGreen\">:  +- Exchange hashpartitioning(deptId#290, 200), [id=#286]</b><br>   <b style=\"background:LightGreen\">:     +- *(1) Project [empName#289, deptId#290]</b><br>   <b style=\"background:LightGreen\">:        +- *(1) Filter isnotnull(deptId#290)</b><br>   <b style=\"background:LightGreen\">:           +- *(1) FileScan parquet [empName#289,deptId#290] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/<yourpath>/employees.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<empName:string,deptId:int></b><br>   <b style=\"background:LightGreen\">+- *(4) Sort [deptId#294 ASC NULLS FIRST], false, 0</b><br>      <b style=\"background:LightGreen\">+- Exchange hashpartitioning(deptId#294, 200), [id=#292]</b><br>         <b style=\"background:LightGreen\">+- *(3) Project [deptId#294, deptName#295]</b><br>            <b style=\"background:LightGreen\">+- *(3) Filter isnotnull(deptId#294)</b><br>               <b style=\"background:LightGreen\">+- *(3) FileScan parquet [deptId#294,deptName#295] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/<yourpath>/departments.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string></b><br><br>=============================================================<br>Indexes used:<br>=============================================================<br>deptIndex1:abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/warehouse/indexes/deptIndex1/v__=0<br>empIndex1:abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/warehouse/indexes/empIndex1/v__=0<br><br>=============================================================<br>Physical operator stats:<br>=============================================================<br>+------------------+-------------------+------------------+----------+<br>| Physical Operator|Hyperspace Disabled|Hyperspace Enabled|Difference|<br>+------------------+-------------------+------------------+----------+<br>|     *InputAdapter|                  4|                 2|        -2|<br>|  *ShuffleExchange|                  2|                 0|        -2|<br>|             *Sort|                  2|                 0|        -2|<br>|*WholeStageCodegen|                  5|                 3|        -2|<br>|            Filter|                  2|                 2|         0|<br>|           Project|                  3|                 3|         0|<br>|      Scan parquet|                  2|                 2|         0|<br>|     SortMergeJoin|                  1|                 1|         0|<br>+------------------+-------------------+------------------+----------+<br><br></pre>"
           },
           "metadata": {}
         }
@@ -698,13 +698,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 43,
+      "execution_count": 22,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 43,
+          "execution_count": 22,
           "data": {
-            "text/plain": "+------+---------------+-------------+\n|deptId|       deptName|     location|\n+------+---------------+-------------+\n|    60|Human Resources|San Francisco|\n|    60|Human Resources|San Francisco|\n|    10|     Accounting|     New York|\n|    50|      Inovation|      Seattle|\n|    50|      Inovation|      Seattle|\n|    40|     Operations|       Boston|\n|    20|       Research|       Dallas|\n|    30|          Sales|      Chicago|\n+------+---------------+-------------+"
+            "text/plain": "+------+---------------+-------------+\n|deptId|       deptName|     location|\n+------+---------------+-------------+\n|    60|Human Resources|San Francisco|\n|    10|     Accounting|     New York|\n|    40|     Operations|       Boston|\n|    50|      Inovation|      Seattle|\n|    20|       Research|       Dallas|\n|    30|          Sales|      Chicago|\n+------+---------------+-------------+"
           },
           "metadata": {}
         }
@@ -725,13 +725,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 45,
+      "execution_count": 23,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 45,
+          "execution_count": 23,
           "data": {
-            "text/plain": "+---------------+\n|       deptName|\n+---------------+\n|Human Resources|\n|Human Resources|\n|      Inovation|\n|      Inovation|\n|     Operations|\n|          Sales|\n+---------------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#905 > 20)\n   +- Relation[deptId#905,deptName#906,location#907] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#906]\n+- Filter (deptId#905 > 20)\n   +- Relation[deptId#905,deptName#906,location#907] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#906]\n+- Filter (isnotnull(deptId#905) && (deptId#905 > 20))\n   +- Relation[deptId#905,deptName#906,location#907] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#906]\n+- *(1) Filter (isnotnull(deptId#905) && (deptId#905 > 20))\n   +- *(1) FileScan parquet [deptId#905,deptName#906] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@location../departments.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+            "text/plain": "+---------------+\n|       deptName|\n+---------------+\n|Human Resources|\n|     Operations|\n|      Inovation|\n|          Sales|\n+---------------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#476 > 20)\n   +- Relation[deptId#476,deptName#477,location#478] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#477]\n+- Filter (deptId#476 > 20)\n   +- Relation[deptId#476,deptName#477,location#478] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#477]\n+- Filter (isnotnull(deptId#476) && (deptId#476 > 20))\n   +- Relation[deptId#476,deptName#477,location#478] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#477]\n+- *(1) Filter (isnotnull(deptId#476) && (deptId#476 > 20))\n   +- *(1) FileScan parquet [deptId#476,deptName#477] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/<yourpath>/departments.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
           },
           "metadata": {}
         }
@@ -742,6 +742,40 @@
         "newRangeFilter.show()\n",
         "\n",
         "newRangeFilter.explain(True)"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 26,
+          "data": {
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation| state|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n| empIndex1|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+"
+          },
+          "metadata": {}
+        }
+      ],
+      "metadata": {},
+      "source": [
+        "hyperspace.indexes().show()"
+      ],
+      "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "outputs": [],
+      "metadata": {},
+      "source": [
+        "# Clean-up the remaining indexes\n",
+        "hyperspace.deleteIndex(\"empIndex1\")\n",
+        "hyperspace.deleteIndex(\"deptIndex1\")\n",
+        "\n",
+        "hyperspace.vacuumIndex(\"empIndex1\")\n",
+        "hyperspace.vacuumIndex(\"deptIndex1\")"
       ],
       "attachments": {}
     }

--- a/notebooks/scala/Hitchhikers Guide to Hyperspace.ipynb
+++ b/notebooks/scala/Hitchhikers Guide to Hyperspace.ipynb
@@ -1,4 +1,12 @@
 {
+  "metadata": {
+    "saveOutput": true,
+    "language_info": {
+      "name": "scala"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2,
   "cells": [
     {
       "cell_type": "markdown",
@@ -31,13 +39,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 4,
       "outputs": [
         {
           "output_type": "execute_result",
-          "execution_count": 3,
+          "execution_count": 4,
           "data": {
-            "text/plain": "res3: org.apache.spark.sql.Spark™Session = org.apache.spark.sql.Spark™Session@297e957d\n-1"
+            "text/plain": "res1: org.apache.spark.sql.SparkSession = org.apache.spark.sql.SparkSession@5eda8913\n-1"
           },
           "metadata": {}
         }
@@ -71,14 +79,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 5,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 5,
           "data": {
-            "text/plain": "import org.apache.spark.sql.DataFrame\ndepartments: Seq[(Int, String, String)] = List((10,Accounting,New York), (20,Research,Dallas), (30,Sales,Chicago), (40,Operations,Boston))\nemployees: Seq[(Int, String, Int)] = List((7369,SMITH,20), (7499,ALLEN,30), (7521,WARD,30), (7566,JONES,20), (7698,BLAKE,30), (7782,CLARK,10), (7788,SCOTT,20), (7839,KING,10), (7844,TURNER,30), (7876,ADAMS,20), (7900,JAMES,30), (7934,MILLER,10), (7902,FORD,20), (7654,MARTIN,30))\nimport spark.implicits._\nempData: org.apache.spark.sql.DataFrame = [empId: int, empName: string ... 1 more field]\ndeptData: org.apache.spark.sql.DataFrame = [deptId: int, deptName: string ... 1 more field]\nempLocation: String = /your-path/employees.parquet\ndeptLocation: String = /your-path/departments.parquet"
+            "text/plain": "import org.apache.spark.sql.DataFrame\ndepartments: Seq[(Int, String, String)] = List((10,Accounting,New York), (20,Research,Dallas), (30,Sales,Chicago), (40,Operations,Boston))\nemployees: Seq[(Int, String, Int)] = List((7369,SMITH,20), (7499,ALLEN,30), (7521,WARD,30), (7566,JONES,20), (7698,BLAKE,30), (7782,CLARK,10), (7788,SCOTT,20), (7839,KING,10), (7844,TURNER,30), (7876,ADAMS,20), (7900,JAMES,30), (7934,MILLER,10), (7902,FORD,20), (7654,MARTIN,30))\nimport spark.implicits._\nempData: org.apache.spark.sql.DataFrame = [empId: int, empName: string ... 1 more field]\ndeptData: org.apache.spark.sql.DataFrame = [deptId: int, deptName: string ... 1 more field]\nempLocation: String = /<yourpath>/employees.parquet\ndeptLocation: String = /<yourpath>/departments.parquet"
           },
-          "execution_count": 4,
           "metadata": {}
         }
       ],
@@ -134,14 +142,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 6,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 6,
           "data": {
             "text/plain": "empDF: org.apache.spark.sql.DataFrame = [empId: int, empName: string ... 1 more field]\ndeptDF: org.apache.spark.sql.DataFrame = [deptId: int, deptName: string ... 1 more field]\n+-----+-------+------+\n|empId|empName|deptId|\n+-----+-------+------+\n| 7499|  ALLEN|    30|\n| 7521|   WARD|    30|\n| 7369|  SMITH|    20|\n| 7844| TURNER|    30|\n| 7876|  ADAMS|    20|\n| 7900|  JAMES|    30|\n| 7934| MILLER|    10|\n| 7839|   KING|    10|\n| 7566|  JONES|    20|\n| 7698|  BLAKE|    30|\n| 7782|  CLARK|    10|\n| 7788|  SCOTT|    20|\n| 7902|   FORD|    20|\n| 7654| MARTIN|    30|\n+-----+-------+------+\n\n+------+----------+--------+\n|deptId|  deptName|location|\n+------+----------+--------+\n|    10|Accounting|New York|\n|    40|Operations|  Boston|\n|    20|  Research|  Dallas|\n|    30|     Sales| Chicago|\n+------+----------+--------+"
           },
-          "execution_count": 5,
           "metadata": {}
         }
       ],
@@ -179,14 +187,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 7,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 7,
           "data": {
-            "text/plain": "import com.microsoft.hyperspace._\nhyperspace: com.microsoft.hyperspace.Hyperspace = com.microsoft.hyperspace.Hyperspace@1432f740"
+            "text/plain": "import com.microsoft.hyperspace._\nhyperspace: com.microsoft.hyperspace.Hyperspace = com.microsoft.hyperspace.Hyperspace@26fcb198"
           },
-          "execution_count": 6,
           "metadata": {}
         }
       ],
@@ -225,14 +233,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 8,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 8,
           "data": {
             "text/plain": "import com.microsoft.hyperspace.index.IndexConfig\nempIndexConfig: com.microsoft.hyperspace.index.IndexConfig = [indexName: empIndex; indexedColumns: deptid; includedColumns: empname]\ndeptIndexConfig1: com.microsoft.hyperspace.index.IndexConfig = [indexName: deptIndex1; indexedColumns: deptid; includedColumns: deptname]\ndeptIndexConfig2: com.microsoft.hyperspace.index.IndexConfig = [indexName: deptIndex2; indexedColumns: location; includedColumns: deptname]"
           },
-          "execution_count": 7,
           "metadata": {}
         }
       ],
@@ -259,21 +267,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 9,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 9,
           "data": {
-            "text/plain": "import com.microsoft.hyperspace.index.Index"
+            "text/plain": "import com.microsoft.hyperspace.index._"
           },
-          "execution_count": 8,
           "metadata": {}
         }
       ],
       "metadata": {},
       "source": [
         "// Create indexes from configurations\n",
-        "import com.microsoft.hyperspace.index.Index\n",
+        "import com.microsoft.hyperspace.index._\n",
         "\n",
         "hyperspace.createIndex(empDF, empIndexConfig)\n",
         "hyperspace.createIndex(deptDF, deptIndexConfig1)\n",
@@ -300,14 +308,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": 10,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 10,
           "data": {
-            "text/plain": "+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+\n|config.indexName|config.indexedColumns|config.includedColumns|        schemaString|   signatureProvider|         dfSignature|      serializedPlan|numBuckets|             dirPath|status.value|stats.indexSize|\n+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+\n|      deptIndex1|             [deptId]|            [deptName]|`deptId` INT,`dep...|com.microsoft.cha...|0effc1610ae2e7c49...|Relation[deptId#3...|       200|abfss://datasets@...|      ACTIVE|              0|\n|      deptIndex2|           [location]|            [deptName]|`location` STRING...|com.microsoft.cha...|0effc1610ae2e7c49...|Relation[deptId#3...|       200|abfss://datasets@...|      ACTIVE|              0|\n|        empIndex|             [deptId]|             [empName]|`deptId` INT,`emp...|com.microsoft.cha...|30768c6c9b2533004...|Relation[empId#32...|       200|abfss://datasets@...|      ACTIVE|              0|\n+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+"
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation| state|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+"
           },
-          "execution_count": 9,
           "metadata": {}
         }
       ],
@@ -330,14 +338,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": 11,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 11,
           "data": {
-            "text/plain": "+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+\n|config.indexName|config.indexedColumns|config.includedColumns|        schemaString|   signatureProvider|         dfSignature|      serializedPlan|numBuckets|             dirPath|status.value|stats.indexSize|\n+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+\n|      deptIndex1|             [deptId]|            [deptName]|`deptId` INT,`dep...|com.microsoft.cha...|0effc1610ae2e7c49...|Relation[deptId#3...|       200|abfss://datasets@...|      ACTIVE|              0|\n|      deptIndex2|           [location]|            [deptName]|`location` STRING...|com.microsoft.cha...|0effc1610ae2e7c49...|Relation[deptId#3...|       200|abfss://datasets@...|     DELETED|              0|\n|        empIndex|             [deptId]|             [empName]|`deptId` INT,`emp...|com.microsoft.cha...|30768c6c9b2533004...|Relation[empId#32...|       200|abfss://datasets@...|      ACTIVE|              0|\n+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+"
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+"
           },
-          "execution_count": 10,
           "metadata": {}
         }
       ],
@@ -361,14 +369,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 12,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 12,
           "data": {
-            "text/plain": "+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+\n|config.indexName|config.indexedColumns|config.includedColumns|        schemaString|   signatureProvider|         dfSignature|      serializedPlan|numBuckets|             dirPath|status.value|stats.indexSize|\n+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+\n|      deptIndex1|             [deptId]|            [deptName]|`deptId` INT,`dep...|com.microsoft.cha...|0effc1610ae2e7c49...|Relation[deptId#3...|       200|abfss://datasets@...|     DELETED|              0|\n|      deptIndex2|           [location]|            [deptName]|`location` STRING...|com.microsoft.cha...|0effc1610ae2e7c49...|Relation[deptId#3...|       200|abfss://datasets@...|     DELETED|              0|\n|        empIndex|             [deptId]|             [empName]|`deptId` INT,`emp...|com.microsoft.cha...|30768c6c9b2533004...|Relation[empId#32...|       200|abfss://datasets@...|      ACTIVE|              0|\n+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+\n\n+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+\n|config.indexName|config.indexedColumns|config.includedColumns|        schemaString|   signatureProvider|         dfSignature|      serializedPlan|numBuckets|             dirPath|status.value|stats.indexSize|\n+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+\n|      deptIndex1|             [deptId]|            [deptName]|`deptId` INT,`dep...|com.microsoft.cha...|0effc1610ae2e7c49...|Relation[deptId#3...|       200|abfss://datasets@...|      ACTIVE|              0|\n|      deptIndex2|           [location]|            [deptName]|`location` STRING...|com.microsoft.cha...|0effc1610ae2e7c49...|Relation[deptId#3...|       200|abfss://datasets@...|     DELETED|              0|\n|        empIndex|             [deptId]|             [empName]|`deptId` INT,`emp...|com.microsoft.cha...|30768c6c9b2533004...|Relation[empId#32...|       200|abfss://datasets@...|      ACTIVE|              0|\n+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+"
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation|  state|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n|deptIndex2|    [location]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|DELETED|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...| ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+-------+"
           },
-          "execution_count": 11,
           "metadata": {}
         }
       ],
@@ -397,14 +405,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 13,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 13,
           "data": {
-            "text/plain": "+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+\n|config.indexName|config.indexedColumns|config.includedColumns|        schemaString|   signatureProvider|         dfSignature|      serializedPlan|numBuckets|             dirPath|status.value|stats.indexSize|\n+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+\n|      deptIndex1|             [deptId]|            [deptName]|`deptId` INT,`dep...|com.microsoft.cha...|0effc1610ae2e7c49...|Relation[deptId#3...|       200|abfss://datasets@...|      ACTIVE|              0|\n|        empIndex|             [deptId]|             [empName]|`deptId` INT,`emp...|com.microsoft.cha...|30768c6c9b2533004...|Relation[empId#32...|       200|abfss://datasets@...|      ACTIVE|              0|\n+----------------+---------------------+----------------------+--------------------+--------------------+--------------------+--------------------+----------+--------------------+------------+---------------+"
+            "text/plain": "+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|      name|indexedColumns|includedColumns|numBuckets|              schema|       indexLocation| state|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+\n|deptIndex1|      [deptId]|     [deptName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n|  empIndex|      [deptId]|      [empName]|       200|{\"type\":\"struct\",...|abfss://data@arca...|ACTIVE|\n+----------+--------------+---------------+----------+--------------------+--------------------+------+"
           },
-          "execution_count": 12,
           "metadata": {}
         }
       ],
@@ -433,14 +441,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 14,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 14,
           "data": {
-            "text/plain": "res48: org.apache.spark.sql.Spark™Session = org.apache.spark.sql.Spark™Session@39fe1ddb\nres51: org.apache.spark.sql.Spark™Session = org.apache.spark.sql.Spark™Session@39fe1ddb"
+            "text/plain": "res46: org.apache.spark.sql.SparkSession = org.apache.spark.sql.SparkSession@5eda8913\nres49: org.apache.spark.sql.SparkSession = org.apache.spark.sql.SparkSession@5eda8913"
           },
-          "execution_count": 13,
           "metadata": {}
         }
       ],
@@ -467,14 +475,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 15,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 15,
           "data": {
-            "text/plain": "res53: org.apache.spark.sql.Spark™Session = org.apache.spark.sql.Spark™Session@39fe1ddb\nempDFrame: org.apache.spark.sql.DataFrame = [empId: int, empName: string ... 1 more field]\ndeptDFrame: org.apache.spark.sql.DataFrame = [deptId: int, deptName: string ... 1 more field]\n+-----+-------+------+\n|empId|empName|deptId|\n+-----+-------+------+\n| 7499|  ALLEN|    30|\n| 7521|   WARD|    30|\n| 7369|  SMITH|    20|\n| 7844| TURNER|    30|\n| 7876|  ADAMS|    20|\n+-----+-------+------+\nonly showing top 5 rows\n\n+------+----------+--------+\n|deptId|  deptName|location|\n+------+----------+--------+\n|    10|Accounting|New York|\n|    40|Operations|  Boston|\n|    20|  Research|  Dallas|\n|    30|     Sales| Chicago|\n+------+----------+--------+"
+            "text/plain": "res51: org.apache.spark.sql.SparkSession = org.apache.spark.sql.SparkSession@5eda8913\nempDFrame: org.apache.spark.sql.DataFrame = [empId: int, empName: string ... 1 more field]\ndeptDFrame: org.apache.spark.sql.DataFrame = [deptId: int, deptName: string ... 1 more field]\n+-----+-------+------+\n|empId|empName|deptId|\n+-----+-------+------+\n| 7499|  ALLEN|    30|\n| 7521|   WARD|    30|\n| 7369|  SMITH|    20|\n| 7844| TURNER|    30|\n| 7876|  ADAMS|    20|\n+-----+-------+------+\nonly showing top 5 rows\n\n+------+----------+--------+\n|deptId|  deptName|location|\n+------+----------+--------+\n|    10|Accounting|New York|\n|    40|Operations|  Boston|\n|    20|  Research|  Dallas|\n|    30|     Sales| Chicago|\n+------+----------+--------+"
           },
-          "execution_count": 14,
           "metadata": {}
         }
       ],
@@ -529,14 +537,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 16,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 16,
           "data": {
-            "text/plain": "eqFilter: org.apache.spark.sql.DataFrame = [deptName: string]\n+--------+\n|deptName|\n+--------+\n|Research|\n+--------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#533 = 20)\n   +- Relation[deptId#533,deptName#534,location#535] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#534]\n+- Filter (deptId#533 = 20)\n   +- Relation[deptId#533,deptName#534,location#535] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#534]\n+- Filter (isnotnull(deptId#533) && (deptId#533 = 20))\n   +- Relation[deptId#533,deptName#534,location#535] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#534]\n+- *(1) Filter (isnotnull(deptId#533) && (deptId#533 = 20))\n   +- *(1) FileScan parquet [deptId#533,deptName#534] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://datasets@hyperspacebenchmark.dfs.core.windows.net/hyperspaceon..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), EqualTo(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+            "text/plain": "eqFilter: org.apache.spark.sql.DataFrame = [deptName: string]\n+--------+\n|deptName|\n+--------+\n|Research|\n+--------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#308 = 20)\n   +- Relation[deptId#308,deptName#309,location#310] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#309]\n+- Filter (deptId#308 = 20)\n   +- Relation[deptId#308,deptName#309,location#310] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#309]\n+- Filter (isnotnull(deptId#308) && (deptId#308 = 20))\n   +- Relation[deptId#308,deptName#309] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#309]\n+- *(1) Filter (isnotnull(deptId#308) && (deptId#308 = 20))\n   +- *(1) FileScan parquet [deptId#308,deptName#309] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), EqualTo(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
           },
-          "execution_count": 15,
           "metadata": {}
         }
       ],
@@ -569,14 +577,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 17,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 17,
           "data": {
-            "text/plain": "rangeFilter: org.apache.spark.sql.DataFrame = [deptName: string]\n+----------+\n|  deptName|\n+----------+\n|Operations|\n|     Sales|\n+----------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#533 > 20)\n   +- Relation[deptId#533,deptName#534,location#535] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#534]\n+- Filter (deptId#533 > 20)\n   +- Relation[deptId#533,deptName#534,location#535] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#534]\n+- Filter (isnotnull(deptId#533) && (deptId#533 > 20))\n   +- Relation[deptId#533,deptName#534,location#535] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#534]\n+- *(1) Filter (isnotnull(deptId#533) && (deptId#533 > 20))\n   +- *(1) FileScan parquet [deptId#533,deptName#534] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://datasets@hyperspacebenchmark.dfs.core.windows.net/hyperspaceon..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+            "text/plain": "rangeFilter: org.apache.spark.sql.DataFrame = [deptName: string]\n+----------+\n|  deptName|\n+----------+\n|Operations|\n|     Sales|\n+----------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#308 > 20)\n   +- Relation[deptId#308,deptName#309,location#310] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#309]\n+- Filter (deptId#308 > 20)\n   +- Relation[deptId#308,deptName#309,location#310] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#309]\n+- Filter (isnotnull(deptId#308) && (deptId#308 > 20))\n   +- Relation[deptId#308,deptName#309] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#309]\n+- *(1) Filter (isnotnull(deptId#308) && (deptId#308 > 20))\n   +- *(1) FileScan parquet [deptId#308,deptName#309] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
           },
-          "execution_count": 16,
           "metadata": {}
         }
       ],
@@ -610,14 +618,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": 18,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 18,
           "data": {
-            "text/plain": "eqJoin: org.apache.spark.sql.DataFrame = [empName: string, deptName: string]\n+-------+----------+\n|empName|  deptName|\n+-------+----------+\n|  SMITH|  Research|\n|  JONES|  Research|\n|   FORD|  Research|\n|  ADAMS|  Research|\n|  SCOTT|  Research|\n|   KING|Accounting|\n|  CLARK|Accounting|\n| MILLER|Accounting|\n|  JAMES|     Sales|\n|  BLAKE|     Sales|\n| MARTIN|     Sales|\n|  ALLEN|     Sales|\n|   WARD|     Sales|\n| TURNER|     Sales|\n+-------+----------+\n\n== Parsed Logical Plan ==\nProject [empName#528, deptName#534]\n+- Join Inner, (deptId#529 = deptId#533)\n   :- Relation[empId#527,empName#528,deptId#529] parquet\n   +- Relation[deptId#533,deptName#534,location#535] parquet\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#528, deptName#534]\n+- Join Inner, (deptId#529 = deptId#533)\n   :- Relation[empId#527,empName#528,deptId#529] parquet\n   +- Relation[deptId#533,deptName#534,location#535] parquet\n\n== Optimized Logical Plan ==\nProject [empName#528, deptName#534]\n+- Join Inner, (deptId#529 = deptId#533)\n   :- Project [empName#528, deptId#529]\n   :  +- Filter isnotnull(deptId#529)\n   :     +- Relation[empName#528,deptId#529] parquet\n   +- Project [deptId#533, deptName#534]\n      +- Filter isnotnull(deptId#533)\n         +- Relation[deptId#533,deptName#534] parquet\n\n== Physical Plan ==\n*(3) Project [empName#528, deptName#534]\n+- *(3) SortMergeJoin [deptId#529], [deptId#533], Inner\n   :- *(1) Project [empName#528, deptId#529]\n   :  +- *(1) Filter isnotnull(deptId#529)\n   :     +- *(1) FileScan parquet [deptId#529,empName#528] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://datasets@hyperspacebenchmark.dfs.core.windows.net/hyperspaceon..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#533, deptName#534]\n      +- *(2) Filter isnotnull(deptId#533)\n         +- *(2) FileScan parquet [deptId#533,deptName#534] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://datasets@hyperspacebenchmark.dfs.core.windows.net/hyperspaceon..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
+            "text/plain": "eqJoin: org.apache.spark.sql.DataFrame = [empName: string, deptName: string]\n+-------+----------+\n|empName|  deptName|\n+-------+----------+\n|  ADAMS|  Research|\n|  SCOTT|  Research|\n|  SMITH|  Research|\n|  JONES|  Research|\n|   FORD|  Research|\n| MILLER|Accounting|\n|   KING|Accounting|\n|  CLARK|Accounting|\n|  ALLEN|     Sales|\n|   WARD|     Sales|\n| TURNER|     Sales|\n|  JAMES|     Sales|\n|  BLAKE|     Sales|\n| MARTIN|     Sales|\n+-------+----------+\n\n== Parsed Logical Plan ==\nProject [empName#303, deptName#309]\n+- Join Inner, (deptId#304 = deptId#308)\n   :- Relation[empId#302,empName#303,deptId#304] parquet\n   +- Relation[deptId#308,deptName#309,location#310] parquet\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#303, deptName#309]\n+- Join Inner, (deptId#304 = deptId#308)\n   :- Relation[empId#302,empName#303,deptId#304] parquet\n   +- Relation[deptId#308,deptName#309,location#310] parquet\n\n== Optimized Logical Plan ==\nProject [empName#303, deptName#309]\n+- Join Inner, (deptId#304 = deptId#308)\n   :- Project [empName#303, deptId#304]\n   :  +- Filter isnotnull(deptId#304)\n   :     +- Relation[empName#303,deptId#304] parquet\n   +- Project [deptId#308, deptName#309]\n      +- Filter isnotnull(deptId#308)\n         +- Relation[deptId#308,deptName#309] parquet\n\n== Physical Plan ==\n*(3) Project [empName#303, deptName#309]\n+- *(3) SortMergeJoin [deptId#304], [deptId#308], Inner\n   :- *(1) Project [empName#303, deptId#304]\n   :  +- *(1) Filter isnotnull(deptId#304)\n   :     +- *(1) FileScan parquet [deptId#304,empName#303] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#308, deptName#309]\n      +- *(2) Filter isnotnull(deptId#308)\n         +- *(2) FileScan parquet [deptId#308,deptName#309] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
           },
-          "execution_count": 17,
           "metadata": {}
         }
       ],
@@ -648,14 +656,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": 19,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 19,
           "data": {
-            "text/plain": "joinQuery: org.apache.spark.sql.DataFrame = [empName: string, deptName: string]\n+-------+----------+\n|empName|  deptName|\n+-------+----------+\n|  SMITH|  Research|\n|  JONES|  Research|\n|   FORD|  Research|\n|  ADAMS|  Research|\n|  SCOTT|  Research|\n|   KING|Accounting|\n|  CLARK|Accounting|\n| MILLER|Accounting|\n|  JAMES|     Sales|\n|  BLAKE|     Sales|\n| MARTIN|     Sales|\n|  ALLEN|     Sales|\n|   WARD|     Sales|\n| TURNER|     Sales|\n+-------+----------+\n\n== Parsed Logical Plan ==\n'Project ['EMP.empName, 'DEPT.deptName]\n+- 'Filter ('EMP.deptId = 'DEPT.deptId)\n   +- 'Join Inner\n      :- 'UnresolvedRelation `EMP`\n      +- 'UnresolvedRelation `DEPT`\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#528, deptName#534]\n+- Filter (deptId#529 = deptId#533)\n   +- Join Inner\n      :- SubqueryAlias `emp`\n      :  +- Relation[empId#527,empName#528,deptId#529] parquet\n      +- SubqueryAlias `dept`\n         +- Relation[deptId#533,deptName#534,location#535] parquet\n\n== Optimized Logical Plan ==\nProject [empName#528, deptName#534]\n+- Join Inner, (deptId#529 = deptId#533)\n   :- Project [empName#528, deptId#529]\n   :  +- Filter isnotnull(deptId#529)\n   :     +- Relation[empId#527,empName#528,deptId#529] parquet\n   +- Project [deptId#533, deptName#534]\n      +- Filter isnotnull(deptId#533)\n         +- Relation[deptId#533,deptName#534,location#535] parquet\n\n== Physical Plan ==\n*(5) Project [empName#528, deptName#534]\n+- *(5) SortMergeJoin [deptId#529], [deptId#533], Inner\n   :- *(2) Sort [deptId#529 ASC NULLS FIRST], false, 0\n   :  +- Exchange hashpartitioning(deptId#529, 200)\n   :     +- *(1) Project [empName#528, deptId#529]\n   :        +- *(1) Filter isnotnull(deptId#529)\n   :           +- *(1) FileScan parquet [deptId#529,empName#528] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://datasets@hyperspacebenchmark.dfs.core.windows.net/hyperspaceon..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>\n   +- *(4) Sort [deptId#533 ASC NULLS FIRST], false, 0\n      +- Exchange hashpartitioning(deptId#533, 200)\n         +- *(3) Project [deptId#533, deptName#534]\n            +- *(3) Filter isnotnull(deptId#533)\n               +- *(3) FileScan parquet [deptId#533,deptName#534] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://datasets@hyperspacebenchmark.dfs.core.windows.net/your-path/departments.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>"
+            "text/plain": "joinQuery: org.apache.spark.sql.DataFrame = [empName: string, deptName: string]\n+-------+----------+\n|empName|  deptName|\n+-------+----------+\n|  ADAMS|  Research|\n|  SCOTT|  Research|\n|  SMITH|  Research|\n|  JONES|  Research|\n|   FORD|  Research|\n| MILLER|Accounting|\n|   KING|Accounting|\n|  CLARK|Accounting|\n|  ALLEN|     Sales|\n|   WARD|     Sales|\n| TURNER|     Sales|\n|  JAMES|     Sales|\n|  BLAKE|     Sales|\n| MARTIN|     Sales|\n+-------+----------+\n\n== Parsed Logical Plan ==\n'Project ['EMP.empName, 'DEPT.deptName]\n+- 'Filter ('EMP.deptId = 'DEPT.deptId)\n   +- 'Join Inner\n      :- 'UnresolvedRelation `EMP`\n      +- 'UnresolvedRelation `DEPT`\n\n== Analyzed Logical Plan ==\nempName: string, deptName: string\nProject [empName#303, deptName#309]\n+- Filter (deptId#304 = deptId#308)\n   +- Join Inner\n      :- SubqueryAlias `emp`\n      :  +- Relation[empId#302,empName#303,deptId#304] parquet\n      +- SubqueryAlias `dept`\n         +- Relation[deptId#308,deptName#309,location#310] parquet\n\n== Optimized Logical Plan ==\nProject [empName#303, deptName#309]\n+- Join Inner, (deptId#304 = deptId#308)\n   :- Project [empName#303, deptId#304]\n   :  +- Filter isnotnull(deptId#304)\n   :     +- Relation[empName#303,deptId#304] parquet\n   +- Project [deptId#308, deptName#309]\n      +- Filter isnotnull(deptId#308)\n         +- Relation[deptId#308,deptName#309] parquet\n\n== Physical Plan ==\n*(3) Project [empName#303, deptName#309]\n+- *(3) SortMergeJoin [deptId#304], [deptId#308], Inner\n   :- *(1) Project [empName#303, deptId#304]\n   :  +- *(1) Filter isnotnull(deptId#304)\n   :     +- *(1) FileScan parquet [deptId#304,empName#303] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200\n   +- *(2) Project [deptId#308, deptName#309]\n      +- *(2) Filter isnotnull(deptId#308)\n         +- *(2) FileScan parquet [deptId#308,deptName#309] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200"
           },
-          "execution_count": 18,
           "metadata": {}
         }
       ],
@@ -684,21 +692,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": 20,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 20,
           "data": {
-            "text/html": "<pre>=============================================================<br>Plan with indexes:<br>=============================================================<br>Project [empName#528, deptName#534]<br>+- SortMergeJoin [deptId#529], [deptId#533], Inner<br>   <b style=\"background:LightGreen\">:- *(1) Project [empName#528, deptId#529]</b><br>   <b style=\"background:LightGreen\">:  +- *(1) Filter isnotnull(deptId#529)</b><br>   <b style=\"background:LightGreen\">:     +- *(1) FileScan parquet [deptId#529,empName#528] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://datasets@hyperspacebenchmark.dfs.core.windows.net/hyperspaceon..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200</b><br>   <b style=\"background:LightGreen\">+- *(2) Project [deptId#533, deptName#534]</b><br>      <b style=\"background:LightGreen\">+- *(2) Filter isnotnull(deptId#533)</b><br>         <b style=\"background:LightGreen\">+- *(2) FileScan parquet [deptId#533,deptName#534] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://datasets@hyperspacebenchmark.dfs.core.windows.net/hyperspaceon..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200</b><br><br>=============================================================<br>Plan without indexes:<br>=============================================================<br>Project [empName#528, deptName#534]<br>+- SortMergeJoin [deptId#529], [deptId#533], Inner<br>   <b style=\"background:LightGreen\">:- *(2) Sort [deptId#529 ASC NULLS FIRST], false, 0</b><br>   <b style=\"background:LightGreen\">:  +- Exchange hashpartitioning(deptId#529, 200)</b><br>   <b style=\"background:LightGreen\">:     +- *(1) Project [empName#528, deptId#529]</b><br>   <b style=\"background:LightGreen\">:        +- *(1) Filter isnotnull(deptId#529)</b><br>   <b style=\"background:LightGreen\">:           +- *(1) FileScan parquet [empName#528,deptId#529] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://datasets@hyperspacebenchmark.dfs.core.windows.net/your-path/employees.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<empName:string,deptId:int></b><br>   <b style=\"background:LightGreen\">+- *(4) Sort [deptId#533 ASC NULLS FIRST], false, 0</b><br>      <b style=\"background:LightGreen\">+- Exchange hashpartitioning(deptId#533, 200)</b><br>         <b style=\"background:LightGreen\">+- *(3) Project [deptId#533, deptName#534]</b><br>            <b style=\"background:LightGreen\">+- *(3) Filter isnotnull(deptId#533)</b><br>               <b style=\"background:LightGreen\">+- *(3) FileScan parquet [deptId#533,deptName#534] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://datasets@hyperspacebenchmark.dfs.core.windows.net/your-path/departments.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string></b><br><br>=============================================================<br>Indexes used:<br>=============================================================<br>deptIndex1:abfss://datasets@hyperspacebenchmark.dfs.core.windows.net/hyperspaceonbbc/indexes/public/deptIndex1/v__=0<br>empIndex:abfss://datasets@hyperspacebenchmark.dfs.core.windows.net/hyperspaceonbbc/indexes/public/empIndex/v__=0<br><br></pre>"
+            "text/html": "<pre>=============================================================<br>Plan with indexes:<br>=============================================================<br>Project [empName#303, deptName#309]<br>+- SortMergeJoin [deptId#304], [deptId#308], Inner<br>   <b style=\"background:LightGreen\">:- *(1) Project [empName#303, deptId#304]</b><br>   <b style=\"background:LightGreen\">:  +- *(1) Filter isnotnull(deptId#304)</b><br>   <b style=\"background:LightGreen\">:     +- *(1) FileScan parquet [deptId#304,empName#303] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,empName:string>, SelectedBucketsCount: 200 out of 200</b><br>   <b style=\"background:LightGreen\">+- *(2) Project [deptId#308, deptName#309]</b><br>      <b style=\"background:LightGreen\">+- *(2) Filter isnotnull(deptId#308)</b><br>         <b style=\"background:LightGreen\">+- *(2) FileScan parquet [deptId#308,deptName#309] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string>, SelectedBucketsCount: 200 out of 200</b><br><br>=============================================================<br>Plan without indexes:<br>=============================================================<br>Project [empName#303, deptName#309]<br>+- SortMergeJoin [deptId#304], [deptId#308], Inner<br>   <b style=\"background:LightGreen\">:- *(2) Sort [deptId#304 ASC NULLS FIRST], false, 0</b><br>   <b style=\"background:LightGreen\">:  +- Exchange hashpartitioning(deptId#304, 200), [id=#245]</b><br>   <b style=\"background:LightGreen\">:     +- *(1) Project [empName#303, deptId#304]</b><br>   <b style=\"background:LightGreen\">:        +- *(1) Filter isnotnull(deptId#304)</b><br>   <b style=\"background:LightGreen\">:           +- *(1) FileScan parquet [empName#303,deptId#304] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/<yourpath>/employees.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<empName:string,deptId:int></b><br>   <b style=\"background:LightGreen\">+- *(4) Sort [deptId#308 ASC NULLS FIRST], false, 0</b><br>      <b style=\"background:LightGreen\">+- Exchange hashpartitioning(deptId#308, 200), [id=#251]</b><br>         <b style=\"background:LightGreen\">+- *(3) Project [deptId#308, deptName#309]</b><br>            <b style=\"background:LightGreen\">+- *(3) Filter isnotnull(deptId#308)</b><br>               <b style=\"background:LightGreen\">+- *(3) FileScan parquet [deptId#308,deptName#309] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/<yourpath>/departments.parquet], PartitionFilters: [], PushedFilters: [IsNotNull(deptId)], ReadSchema: struct<deptId:int,deptName:string></b><br><br>=============================================================<br>Indexes used:<br>=============================================================<br>deptIndex1:abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/warehouse/indexes/deptIndex1/v__=0<br>empIndex:abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/warehouse/indexes/empIndex/v__=0<br><br></pre>"
           },
-          "execution_count": 19,
           "metadata": {}
         }
       ],
       "metadata": {},
       "source": [
         "spark.conf.set(\"spark.hyperspace.explain.displayMode\", \"html\")\n",
-        "hyperspace.explain(eqJoin) { displayHTML }"
+        "hyperspace.explain(eqJoin)(displayHTML(_))"
       ],
       "attachments": {}
     },
@@ -717,14 +725,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": 21,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 21,
           "data": {
             "text/plain": "extraDepartments: Seq[(Int, String, String)] = List((50,Inovation,Seattle), (60,Human Resources,San Francisco))\nextraDeptData: org.apache.spark.sql.DataFrame = [deptId: int, deptName: string ... 1 more field]\ndeptDFrameUpdated: org.apache.spark.sql.DataFrame = [deptId: int, deptName: string ... 1 more field]\n+------+---------------+-------------+\n|deptId|       deptName|     location|\n+------+---------------+-------------+\n|    60|Human Resources|San Francisco|\n|    10|     Accounting|     New York|\n|    50|      Inovation|      Seattle|\n|    40|     Operations|       Boston|\n|    20|       Research|       Dallas|\n|    30|          Sales|      Chicago|\n+------+---------------+-------------+"
           },
-          "execution_count": 20,
           "metadata": {}
         }
       ],
@@ -747,14 +755,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": 22,
       "outputs": [
         {
           "output_type": "execute_result",
+          "execution_count": 22,
           "data": {
-            "text/plain": "newRangeFilter: org.apache.spark.sql.DataFrame = [deptName: string]\n+---------------+\n|       deptName|\n+---------------+\n|Human Resources|\n|      Inovation|\n|     Operations|\n|          Sales|\n+---------------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#674 > 20)\n   +- Relation[deptId#674,deptName#675,location#676] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#675]\n+- Filter (deptId#674 > 20)\n   +- Relation[deptId#674,deptName#675,location#676] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#675]\n+- Filter (isnotnull(deptId#674) && (deptId#674 > 20))\n   +- Relation[deptId#674,deptName#675,location#676] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#675]\n+- *(1) Filter (isnotnull(deptId#674) && (deptId#674 > 20))\n   +- *(1) FileScan parquet [deptId#674,deptName#675] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://datasets@hyperspacebenchmark.dfs.core.windows.net/hyperspaceon..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
+            "text/plain": "newRangeFilter: org.apache.spark.sql.DataFrame = [deptName: string]\n+---------------+\n|       deptName|\n+---------------+\n|Human Resources|\n|      Inovation|\n|     Operations|\n|          Sales|\n+---------------+\n\n== Parsed Logical Plan ==\n'Project [unresolvedalias('deptName, None)]\n+- Filter (deptId#423 > 20)\n   +- Relation[deptId#423,deptName#424,location#425] parquet\n\n== Analyzed Logical Plan ==\ndeptName: string\nProject [deptName#424]\n+- Filter (deptId#423 > 20)\n   +- Relation[deptId#423,deptName#424,location#425] parquet\n\n== Optimized Logical Plan ==\nProject [deptName#424]\n+- Filter (isnotnull(deptId#423) && (deptId#423 > 20))\n   +- Relation[deptId#423,deptName#424] parquet\n\n== Physical Plan ==\n*(1) Project [deptName#424]\n+- *(1) Filter (isnotnull(deptId#423) && (deptId#423 > 20))\n   +- *(1) FileScan parquet [deptId#423,deptName#424] Batched: true, Format: Parquet, Location: InMemoryFileIndex[abfss://data@mydatalake.dfs.core.windows.net/synapse/workspaces/myworkspace/war..., PartitionFilters: [], PushedFilters: [IsNotNull(deptId), GreaterThan(deptId,20)], ReadSchema: struct<deptId:int,deptName:string>"
           },
-          "execution_count": 21,
           "metadata": {}
         }
       ],
@@ -766,14 +774,21 @@
         "newRangeFilter.explain(true)"
       ],
       "attachments": {}
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "outputs": [],
+      "metadata": {},
+      "source": [
+        "// Clean-up the remaining indexes\n",
+        "hyperspace.deleteIndex(\"empIndex\")\n",
+        "hyperspace.deleteIndex(\"deptIndex1\")\n",
+        "\n",
+        "hyperspace.vacuumIndex(\"empIndex\")\n",
+        "hyperspace.vacuumIndex(\"deptIndex1\")"
+      ],
+      "attachments": {}
     }
-  ],
-  "metadata": {
-    "saveOutput": true,
-    "language_info": {
-      "name": "scala"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 2
+  ]
 }


### PR DESCRIPTION
# What changes were proposed in this pull request?
This PR addresses #75 by introducing a CSharp version of the example notebook. This new notebook is a direct port of the existing Scala notebook.

### Why are the changes needed?
Hyperspace currently only provides sample notebooks for Scala and Python.

### Does this PR introduce _any_ user-facing change?
1. New CSharp example notebook.
2. Some small improvements in the Scala and Python notebooks.


### How was this patch tested?
These notebooks were run in a Synapse workspace.
