### PR TITLE
Hybrid scan operator for leveraging index alongside newly appended data - BucketUnion

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/execution/BucketUnionExec.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/execution/BucketUnionExec.scala
@@ -29,21 +29,25 @@ import org.apache.spark.sql.execution.SparkPlan
 import com.microsoft.hyperspace.index.plans.logical.BucketUnion
 
 /**
- * [[BucketUnionRDD]] is required for index HybridScan to merge index data and appended
- * data without re-shuffling of index data. Spark does not support Union using Partition
- * Specification, but just [[PartitionerAwareUnionRDD]] operation and even it does not
- * retain outputPartitioning of result. So we define a new Union operation complying
- * with the following conditions:
+ * [[BucketUnionRDD]] is required for the hybrid scan operation which merges index data and 
+ * appended data without re-shuffling the index data. Spark does not support Union that retains
+ * output partition specification (i.e., using PartitionSpecification). The default operation 
+ * [[PartitionerAwareUnionRDD]] does not retain outputPartitioning of result i.e., even if both 
+ * sides are bucketed in a compatible way, it will cause a shuffle. 
+ * 
+ * To avoid these issues, we define a new BucketUnion operation that avoids a shuffle when
+ * the following conditions are satisfied:
  *   - input RDDs must have the same number of partitions.
  *   - input RDDs must have the same partitioning keys.
  *   - input RDDs must have the same column schema.
  *
- * Unfortunately, there is no explicit API to check Partitioning keys in RDD, we have to
- * assure that on the caller side. Therefore, [[BucketUnionRDD]] is Hyperspace
+ * Unfortunately, since there is no explicit API to check Partitioning keys in RDD, we have to
+ * asset the partitioning keys on the caller side. Therefore, [[BucketUnionRDD]] is Hyperspace
  * internal use only.
  *
- * You can find more detailed information about Bucketing optimization in
- * [[https://youtu.be/7cvaH33S7uc Bucketing 2.0: Improve Spark SQL Performance by Removing Shuffle]]
+ * You can find more detailed information about Bucketing optimization in:
+ * [[Bucketing 2.0: Improve Spark SQL Performance by Removing Shuffle]]
+ * Video: [[https://youtu.be/7cvaH33S7uc ]]
  */
 private[hyperspace] class BucketUnionRDD[T: ClassTag](
     sc: SparkContext,

--- a/src/main/scala/com/microsoft/hyperspace/index/execution/BucketUnionExec.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/execution/BucketUnionExec.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning}
 import org.apache.spark.sql.execution.SparkPlan
 
-import com.microsoft.hyperspace.HyperspaceException
+import com.microsoft.hyperspace.index.plans.logical.BucketUnion
 
 /**
  * [[BucketUnionRDD]] is required for index HybridScan to merge index data and appended
@@ -106,11 +106,8 @@ private[hyperspace] case class BucketUnionExec(children: Seq[SparkPlan], bucketS
   override def output: Seq[Attribute] = children.head.output
 
   override def outputPartitioning: Partitioning = {
-    val childPartitions = children.map(_.outputPartitioning).collect {
-      case h: HashPartitioning => h.numPartitions
-      case _ => throw HyperspaceException("Only HashPartitioning is supported.")
-    }
-    assert(childPartitions.toSet.size == 1)
+    assert(children.map(_.outputPartitioning).toSet.size == 1)
+    assert(children.head.outputPartitioning.isInstanceOf[HashPartitioning])
     children.head.outputPartitioning
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/execution/BucketUnionExec.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/execution/BucketUnionExec.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index.execution
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.{OneToOneDependency, Partition, SparkContext, TaskContext}
+import org.apache.spark.rdd.{PartitionerAwareUnionRDD, RDD}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning}
+import org.apache.spark.sql.execution.SparkPlan
+
+import com.microsoft.hyperspace.HyperspaceException
+
+/**
+ * [[BucketUnionRDD]] is required for index HybridScan to merge index data and appended
+ * data without re-shuffling of index data. Spark does not support Union using Partition
+ * Specification, but just [[PartitionerAwareUnionRDD]] operation and even it does not
+ * retain outputPartitioning of result. So we define a new Union operation complying
+ * with the following conditions:
+ *   - input RDDs must have the same number of partitions.
+ *   - input RDDs must have the same partitioning keys.
+ *   - input RDDs must have the same column schema.
+ *
+ * Unfortunately, there is no explicit API to check Partitioning keys in RDD, we have to
+ * assure that on the caller side. Therefore, [[BucketUnionRDD]] is Hyperspace
+ * internal use only.
+ *
+ * You can find more detailed information about Bucketing optimization in
+ * [[https://youtu.be/7cvaH33S7uc Bucketing 2.0: Improve Spark SQL Performance by Removing Shuffle]]
+ */
+private[hyperspace] class BucketUnionRDD[T: ClassTag](
+    sc: SparkContext,
+    var rdds: Seq[RDD[T]],
+    bucketSpec: BucketSpec)
+    extends RDD[T](sc, rdds.map(x => new OneToOneDependency(x))) {
+  require(rdds.nonEmpty)
+  require(rdds.forall(_.getNumPartitions == bucketSpec.numBuckets))
+
+  // copy from org.apache.spark.rdd.PartitionerAwareUnionRDD
+  override def getPartitions: Array[Partition] = {
+    val numBuckets = bucketSpec.numBuckets
+    (0 until numBuckets).map { index =>
+      new BucketUnionRDDPartition(rdds, index)
+    }.toArray
+  }
+
+  // copy from org.apache.spark.rdd.PartitionerAwareUnionRDD
+  override def compute(s: Partition, context: TaskContext): Iterator[T] = {
+    val parentPartitions = s.asInstanceOf[BucketUnionRDDPartition].parents
+    rdds.zip(parentPartitions).iterator.flatMap {
+      case (rdd, p) => rdd.iterator(p, context)
+    }
+  }
+
+  // copy from org.apache.spark.rdd.PartitionerAwareUnionRDD
+  override def clearDependencies() {
+    super.clearDependencies()
+    rdds = null
+  }
+}
+
+/**
+ * [[BucketUnionRDDPartition]] keeps partitions for each partition index.
+ * @param rdds  Input RDDs.
+ * @param index Partition index.
+ */
+private[hyperspace] class BucketUnionRDDPartition(
+    @transient val rdds: Seq[RDD[_]],
+    override val index: Int)
+    extends Partition {
+  val parents: Array[Partition] = rdds.map(_.partitions(index)).toArray
+
+  override def hashCode(): Int = index
+  override def equals(other: Any): Boolean = super.equals(other)
+}
+
+/**
+ * [[BucketUnionExec]] is Spark Plan for [[BucketUnion]].
+ *
+ * @param children Child plans.
+ * @param bucketSpec Bucket specification.
+ */
+private[hyperspace] case class BucketUnionExec(children: Seq[SparkPlan], bucketSpec: BucketSpec)
+    extends SparkPlan {
+  override protected def doExecute(): RDD[InternalRow] = {
+    new BucketUnionRDD[InternalRow](sparkContext, children.map(_.execute()), bucketSpec)
+  }
+
+  override def output: Seq[Attribute] = children.head.output
+
+  override def outputPartitioning: Partitioning = {
+    val childPartitions = children.map(_.outputPartitioning).collect {
+      case h: HashPartitioning => h.numPartitions
+      case _ => throw HyperspaceException("Only HashPartitioning is supported.")
+    }
+    assert(childPartitions.toSet.size == 1)
+    children.head.outputPartitioning
+  }
+}

--- a/src/main/scala/com/microsoft/hyperspace/index/execution/BucketUnionExec.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/execution/BucketUnionExec.scala
@@ -29,12 +29,12 @@ import org.apache.spark.sql.execution.SparkPlan
 import com.microsoft.hyperspace.index.plans.logical.BucketUnion
 
 /**
- * [[BucketUnionRDD]] is required for the hybrid scan operation which merges index data and 
+ * [[BucketUnionRDD]] is required for the hybrid scan operation which merges index data and
  * appended data without re-shuffling the index data. Spark does not support Union that retains
- * output partition specification (i.e., using PartitionSpecification). The default operation 
- * [[PartitionerAwareUnionRDD]] does not retain outputPartitioning of result i.e., even if both 
- * sides are bucketed in a compatible way, it will cause a shuffle. 
- * 
+ * output partition specification (i.e., using PartitionSpecification). The default operation
+ * [[PartitionerAwareUnionRDD]] does not retain outputPartitioning of result i.e., even if both
+ * sides are bucketed in a compatible way, it will cause a shuffle.
+ *
  * To avoid these issues, we define a new BucketUnion operation that avoids a shuffle when
  * the following conditions are satisfied:
  *   - input RDDs must have the same number of partitions.
@@ -46,7 +46,7 @@ import com.microsoft.hyperspace.index.plans.logical.BucketUnion
  * internal use only.
  *
  * You can find more detailed information about Bucketing optimization in:
- * [[Bucketing 2.0: Improve Spark SQL Performance by Removing Shuffle]]
+ * ''Bucketing 2.0: Improve Spark SQL Performance by Removing Shuffle''
  * Video: [[https://youtu.be/7cvaH33S7uc ]]
  */
 private[hyperspace] class BucketUnionRDD[T: ClassTag](

--- a/src/main/scala/com/microsoft/hyperspace/index/execution/BucketUnionStrategy.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/execution/BucketUnionStrategy.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index.execution
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.{SparkPlan, SparkStrategy}
+
+import com.microsoft.hyperspace.index.plans.logical.BucketUnion
+
+/**
+ * [[BucketUnionStrategy]] is SparkStrategy for converting [[BucketUnion]] (Logical Plan)
+ * to [[BucketUnionExec]] (Spark Plan)
+ */
+private[hyperspace] object BucketUnionStrategy extends SparkStrategy {
+  override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+    case p: BucketUnion =>
+      BucketUnionExec(p.children.map(planLater), p.bucketSpec) :: Nil
+    case _ => Nil
+  }
+}

--- a/src/main/scala/com/microsoft/hyperspace/index/plans/logical/BucketUnion.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/plans/logical/BucketUnion.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index.plans.logical
+
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+/**
+ * [[BucketUnion]] is logical plan for Bucket-aware Union operation which retains
+ * outputPartitioning of result RDDs so as to avoid performing unnecessary Shuffle after
+ * Union operation per bucket.
+ *
+ * @param children Child plans.
+ * @param bucketSpec Bucket Specification.
+ */
+private[hyperspace] case class BucketUnion(children: Seq[LogicalPlan], bucketSpec: BucketSpec)
+    extends LogicalPlan {
+  require(resolved)
+  override def output: Seq[Attribute] = children.head.output
+
+  // copy from org.apache.spark.sql.catalyst.plans.logical.Union
+  override def maxRows: Option[Long] = {
+    if (children.exists(_.maxRows.isEmpty)) {
+      None
+    } else {
+      Some(children.flatMap(_.maxRows).sum)
+    }
+  }
+
+  // copy from org.apache.spark.sql.catalyst.plans.logical.Union
+  override def maxRowsPerPartition: Option[Long] = {
+    if (children.exists(_.maxRowsPerPartition.isEmpty)) {
+      None
+    } else {
+      Some(children.flatMap(_.maxRowsPerPartition).sum)
+    }
+  }
+
+  // copy from org.apache.spark.sql.catalyst.plans.logical.Union
+  override lazy val resolved: Boolean = {
+    // allChildrenCompatible needs to be evaluated after childrenResolved
+    def allChildrenCompatible: Boolean =
+      children.tail.forall(
+        child =>
+          // compare the attribute number with the first child
+          child.output.length == children.head.output.length &&
+            // compare the data types with the first child
+            child.output.zip(children.head.output).forall {
+              case (l, r) => l.dataType.equals(r.dataType)
+          })
+    children.length > 1 && childrenResolved && allChildrenCompatible
+  }
+}

--- a/src/main/scala/com/microsoft/hyperspace/index/plans/logical/BucketUnion.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/plans/logical/BucketUnion.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
 /**
  * [[BucketUnion]] is logical plan for Bucket-aware Union operation which retains
- * outputPartitioning of result RDDs so as to avoid performing unnecessary Shuffle after
+ * outputPartitioning of result RDDs so as to avoid performing unnecessary shuffle after
  * Union operation per bucket.
  *
  * @param children Child plans.

--- a/src/test/scala/com/microsoft/hyperspace/index/BucketUnionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/BucketUnionTest.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
+
+import com.microsoft.hyperspace.index.execution.{BucketUnionExec, BucketUnionRDD, BucketUnionRDDPartition, BucketUnionStrategy}
+import com.microsoft.hyperspace.index.plans.logical.BucketUnion
+
+class BucketUnionTest extends HyperspaceSuite {
+  override val systemPath = new Path("src/test/resources/bucketUnionTest")
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+  }
+
+  test("BucketUnion require test") {
+    import spark.implicits._
+    val df1 = Seq((1, "name1"), (2, "name2")).toDF("id", "name")
+    val df1_1 = Seq((1, "name1"), (2, "name2")).toDF("id", "name")
+    val df1_2 = Seq(("name1", 1), ("name2", 2)).toDF("name", "id")
+    val df2 = Seq((1, "name1", 20), (2, "name2", 10)).toDF("id", "name", "age")
+
+    intercept[IllegalArgumentException] {
+      BucketUnion(
+        Seq(df1.queryExecution.optimizedPlan, df2.queryExecution.optimizedPlan),
+        BucketSpec(1, Seq(), Seq()))
+      fail("shouldn't be reached")
+    }
+    intercept[IllegalArgumentException] {
+      BucketUnion(
+        Seq(df1.queryExecution.optimizedPlan, df1_2.queryExecution.optimizedPlan),
+        BucketSpec(1, Seq(), Seq()))
+      fail("shouldn't be reached")
+    }
+    BucketUnion(
+      Seq(df1.queryExecution.optimizedPlan, df1_1.queryExecution.optimizedPlan),
+      BucketSpec(1, Seq(), Seq()))
+  }
+
+  test("BucketUnionStrategy test") {
+    import spark.implicits._
+    val df1 = Seq((1, "name1"), (2, "name2")).toDF("id", "name")
+    val df1_1 = Seq((1, "name1"), (2, "name2")).toDF("id", "name")
+    val bucket = BucketUnion(
+      Seq(df1.queryExecution.optimizedPlan, df1_1.queryExecution.optimizedPlan),
+      BucketSpec(1, Seq(), Seq()))
+
+    var bucketUnionExecSeen = false
+    BucketUnionStrategy(bucket).collect {
+      case BucketUnionExec(_, _) => bucketUnionExecSeen = true
+    }
+    assert(bucketUnionExecSeen)
+
+    bucketUnionExecSeen = false
+    BucketUnionStrategy(df1.queryExecution.optimizedPlan).collect {
+      case BucketUnionExec(_, _) => bucketUnionExecSeen = true
+    }
+    assert(!bucketUnionExecSeen)
+  }
+
+  test("BucketUnionExec test") {
+    import spark.implicits._
+    val df1 = Seq((1, "name1"), (2, "name2")).toDF("id", "name")
+    val p1 = df1.repartition(10)
+    val df1_1 = Seq((1, "name1"), (2, "name2")).toDF("id", "name")
+    val p1_1 = df1_1.repartition(9)
+    val p1_2 = df1_1.repartition(10)
+
+    intercept[AssertionError] {
+      val bucket = BucketUnion(
+        Seq(p1.queryExecution.optimizedPlan, p1_1.queryExecution.optimizedPlan),
+        BucketSpec(10, Seq(), Seq()))
+      spark.sessionState.executePlan(bucket).sparkPlan
+      fail("shouldn't be reached")
+    }
+
+    val bucket = BucketUnion(
+      Seq(p1.queryExecution.optimizedPlan, p1_2.queryExecution.optimizedPlan),
+      BucketSpec(10, Seq(), Seq()))
+
+    val exec = BucketUnionStrategy(bucket)
+
+    val plan = exec.collect {
+      case p: BucketUnionExec =>
+        assert(p.bucketSpec.numBuckets == 10)
+        assert(p.children.length == 2)
+        assert(p.output.length == p1.schema.fields.length)
+    }
+  }
+
+  test("BucketUnionRDD test") {
+    import spark.implicits._
+    val df1 = Seq((2, "name1"), (3, "name2")).toDF("id", "name")
+    val p1 = df1.repartition(10, $"id")
+    val df1_1 = Seq((2, "name1"), (3, "name2")).toDF("id", "name")
+    val p1_1 = df1_1.repartition(10, $"id")
+    val bucketSpec = BucketSpec(10, Seq("id"), Seq())
+
+    val rdd = new BucketUnionRDD[Row](spark.sparkContext, Seq(p1.rdd, p1_1.rdd), bucketSpec)
+    assert(rdd.getPartitions.length == 10)
+    assert(rdd.collect.length == 4)
+    rdd.partitions.head.asInstanceOf[BucketUnionRDDPartition]
+
+    val partitionSum = rdd
+      .mapPartitionsWithIndex {
+        case (partitionNum, it) => Iterator.single(partitionNum -> it.map(r => r.getInt(0)).sum)
+      }
+      .collect()
+      .toSeq
+
+    val availableSum = Set(0, 4, 6, 10)
+    assert(partitionSum.forall(p => availableSum.contains(p._2)))
+  }
+}

--- a/src/test/scala/com/microsoft/hyperspace/index/BucketUnionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/BucketUnionTest.scala
@@ -25,13 +25,6 @@ import com.microsoft.hyperspace.index.plans.logical.BucketUnion
 
 class BucketUnionTest extends HyperspaceSuite {
   override val systemPath = new Path("src/test/resources/bucketUnionTest")
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-  }
-
-  override def afterAll(): Unit = {
-    super.afterAll()
-  }
 
   test("BucketUnion require test") {
     import spark.implicits._
@@ -40,18 +33,20 @@ class BucketUnionTest extends HyperspaceSuite {
     val df1_2 = Seq(("name1", 1), ("name2", 2)).toDF("name", "id")
     val df2 = Seq((1, "name1", 20), (2, "name2", 10)).toDF("id", "name", "age")
 
+    // different column schema
     intercept[IllegalArgumentException] {
       BucketUnion(
         Seq(df1.queryExecution.optimizedPlan, df2.queryExecution.optimizedPlan),
         BucketSpec(1, Seq(), Seq()))
-      fail("shouldn't be reached")
     }
+
+    // different order of columns
     intercept[IllegalArgumentException] {
       BucketUnion(
         Seq(df1.queryExecution.optimizedPlan, df1_2.queryExecution.optimizedPlan),
         BucketSpec(1, Seq(), Seq()))
-      fail("shouldn't be reached")
     }
+
     BucketUnion(
       Seq(df1.queryExecution.optimizedPlan, df1_1.queryExecution.optimizedPlan),
       BucketSpec(1, Seq(), Seq()))
@@ -65,17 +60,13 @@ class BucketUnionTest extends HyperspaceSuite {
       Seq(df1.queryExecution.optimizedPlan, df1_1.queryExecution.optimizedPlan),
       BucketSpec(1, Seq(), Seq()))
 
-    var bucketUnionExecSeen = false
-    BucketUnionStrategy(bucket).collect {
-      case BucketUnionExec(_, _) => bucketUnionExecSeen = true
-    }
-    assert(bucketUnionExecSeen)
+    assert(BucketUnionStrategy(bucket).collect {
+      case BucketUnionExec(_, _) => true
+    }.length == 1)
 
-    bucketUnionExecSeen = false
-    BucketUnionStrategy(df1.queryExecution.optimizedPlan).collect {
-      case BucketUnionExec(_, _) => bucketUnionExecSeen = true
-    }
-    assert(!bucketUnionExecSeen)
+    assert(BucketUnionStrategy(df1.queryExecution.optimizedPlan).collect {
+      case BucketUnionExec(_, _) => true
+    }.isEmpty)
   }
 
   test("BucketUnionExec test") {
@@ -86,40 +77,39 @@ class BucketUnionTest extends HyperspaceSuite {
     val p1_1 = df1_1.repartition(9)
     val p1_2 = df1_1.repartition(10)
 
+    // different number of partition
     intercept[AssertionError] {
       val bucket = BucketUnion(
         Seq(p1.queryExecution.optimizedPlan, p1_1.queryExecution.optimizedPlan),
         BucketSpec(10, Seq(), Seq()))
       spark.sessionState.executePlan(bucket).sparkPlan
-      fail("shouldn't be reached")
     }
 
     val bucket = BucketUnion(
       Seq(p1.queryExecution.optimizedPlan, p1_2.queryExecution.optimizedPlan),
       BucketSpec(10, Seq(), Seq()))
 
-    val exec = BucketUnionStrategy(bucket)
-
-    val plan = exec.collect {
+    assert(BucketUnionStrategy(bucket).collect {
       case p: BucketUnionExec =>
         assert(p.bucketSpec.numBuckets == 10)
         assert(p.children.length == 2)
         assert(p.output.length == p1.schema.fields.length)
-    }
+      true
+    }.length == 1)
   }
 
   test("BucketUnionRDD test") {
     import spark.implicits._
     val df1 = Seq((2, "name1"), (3, "name2")).toDF("id", "name")
     val p1 = df1.repartition(10, $"id")
-    val df1_1 = Seq((2, "name1"), (3, "name2")).toDF("id", "name")
-    val p1_1 = df1_1.repartition(10, $"id")
+    val df2 = Seq((2, "name1"), (3, "name2")).toDF("id", "name")
+    val p2 = df2.repartition(10, $"id")
     val bucketSpec = BucketSpec(10, Seq("id"), Seq())
 
-    val rdd = new BucketUnionRDD[Row](spark.sparkContext, Seq(p1.rdd, p1_1.rdd), bucketSpec)
+    val rdd = new BucketUnionRDD[Row](spark.sparkContext, Seq(p1.rdd, p2.rdd), bucketSpec)
     assert(rdd.getPartitions.length == 10)
     assert(rdd.collect.length == 4)
-    rdd.partitions.head.asInstanceOf[BucketUnionRDDPartition]
+    assert(rdd.partitions.head.isInstanceOf[BucketUnionRDDPartition])
 
     val partitionSum = rdd
       .mapPartitionsWithIndex {
@@ -128,6 +118,8 @@ class BucketUnionTest extends HyperspaceSuite {
       .collect()
       .toSeq
 
+    // since rows with id=2 assigned to the same partition and likewise rows with id=3,
+    // summation of each partition should be one of [0, 4, 6, 10]
     val availableSum = Set(0, 4, 6, 10)
     assert(partitionSum.forall(p => availableSum.contains(p._2)))
   }

--- a/src/test/scala/com/microsoft/hyperspace/index/BucketUnionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/BucketUnionTest.scala
@@ -69,7 +69,7 @@ class BucketUnionTest extends HyperspaceSuite {
     }.isEmpty)
   }
 
-  test("BucketUnionExec test") {
+  test("BucketUnionExec test that partition count matches on both sides") {
     import spark.implicits._
     val df1 = Seq((1, "name1"), (2, "name2")).toDF("id", "name")
     val p1 = df1.repartition(10)

--- a/src/test/scala/com/microsoft/hyperspace/index/BucketUnionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/BucketUnionTest.scala
@@ -16,48 +16,48 @@
 
 package com.microsoft.hyperspace.index
 
-import org.apache.hadoop.fs.Path
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 
+import com.microsoft.hyperspace.SparkInvolvedSuite
 import com.microsoft.hyperspace.index.execution.{BucketUnionExec, BucketUnionRDD, BucketUnionRDDPartition, BucketUnionStrategy}
 import com.microsoft.hyperspace.index.plans.logical.BucketUnion
 
-class BucketUnionTest extends HyperspaceSuite {
-  override val systemPath = new Path("src/test/resources/bucketUnionTest")
+class BucketUnionTest extends SparkFunSuite with SparkInvolvedSuite {
 
   test("BucketUnion test for operator pre-requisites") {
     import spark.implicits._
     val df1 = Seq((1, "name1"), (2, "name2")).toDF("id", "name")
-    val df1_1 = Seq((1, "name1"), (2, "name2")).toDF("id", "name")
-    val df1_2 = Seq(("name1", 1), ("name2", 2)).toDF("name", "id")
-    val df2 = Seq((1, "name1", 20), (2, "name2", 10)).toDF("id", "name", "age")
+    val df2 = Seq((1, "name1"), (2, "name2")).toDF("id", "name")
+    val df3 = Seq(("name1", 1), ("name2", 2)).toDF("name", "id")
+    val df4 = Seq((1, "name1", 20), (2, "name2", 10)).toDF("id", "name", "age")
 
     // different column schema
     intercept[IllegalArgumentException] {
       BucketUnion(
-        Seq(df1.queryExecution.optimizedPlan, df2.queryExecution.optimizedPlan),
+        Seq(df1.queryExecution.optimizedPlan, df4.queryExecution.optimizedPlan),
         BucketSpec(1, Seq(), Seq()))
     }
 
     // different order of columns
     intercept[IllegalArgumentException] {
       BucketUnion(
-        Seq(df1.queryExecution.optimizedPlan, df1_2.queryExecution.optimizedPlan),
+        Seq(df1.queryExecution.optimizedPlan, df3.queryExecution.optimizedPlan),
         BucketSpec(1, Seq(), Seq()))
     }
 
     BucketUnion(
-      Seq(df1.queryExecution.optimizedPlan, df1_1.queryExecution.optimizedPlan),
+      Seq(df1.queryExecution.optimizedPlan, df2.queryExecution.optimizedPlan),
       BucketSpec(1, Seq(), Seq()))
   }
 
   test("BucketUnionStrategy test if strategy introduces BucketUnionExec in the Spark Plan") {
     import spark.implicits._
     val df1 = Seq((1, "name1"), (2, "name2")).toDF("id", "name")
-    val df1_1 = Seq((1, "name1"), (2, "name2")).toDF("id", "name")
+    val df2 = Seq((1, "name1"), (2, "name2")).toDF("id", "name")
     val bucket = BucketUnion(
-      Seq(df1.queryExecution.optimizedPlan, df1_1.queryExecution.optimizedPlan),
+      Seq(df1.queryExecution.optimizedPlan, df2.queryExecution.optimizedPlan),
       BucketSpec(1, Seq(), Seq()))
 
     assert(BucketUnionStrategy(bucket).collect {
@@ -94,7 +94,7 @@ class BucketUnionTest extends HyperspaceSuite {
         assert(p.bucketSpec.numBuckets == 10)
         assert(p.children.length == 2)
         assert(p.output.length == p1.schema.fields.length)
-      true
+        true
     }.length == 1)
   }
 
@@ -102,13 +102,15 @@ class BucketUnionTest extends HyperspaceSuite {
     import spark.implicits._
     val df1 = Seq((2, "name1"), (3, "name2")).toDF("id", "name")
     val p1 = df1.repartition(10, $"id")
-    val df2 = Seq((2, "name1"), (3, "name2")).toDF("id", "name")
+    val df2 = Seq((2, "name3"), (3, "name4")).toDF("id", "name")
     val p2 = df2.repartition(10, $"id")
     val bucketSpec = BucketSpec(10, Seq("id"), Seq())
 
     val rdd = new BucketUnionRDD[Row](spark.sparkContext, Seq(p1.rdd, p2.rdd), bucketSpec)
+    assert(
+      rdd.collect.sortBy(r => (r.getInt(0), r.getString(1))).map(r => r.toSeq.toList).toList
+         == Seq(Seq(2, "name1"), Seq(2, "name3"), Seq(3, "name2"), Seq(3, "name4")))
     assert(rdd.getPartitions.length == 10)
-    assert(rdd.collect.length == 4)
     assert(rdd.partitions.head.isInstanceOf[BucketUnionRDDPartition])
 
     val partitionSum: Seq[Int] = rdd
@@ -116,9 +118,7 @@ class BucketUnionTest extends HyperspaceSuite {
       .collect()
       .toSeq
 
-    // since rows with id=2 assigned to the same partition and likewise rows with id=3,
-    // summation of each partition should be one of [0, 4, 6, 10]
-    val availableSum = Set(0, 4, 6, 10)
-    assert(partitionSum.forall(p => availableSum.contains(p)))
+    // Check if all partitioned keys with the same value fall in the same partition.
+    assert(partitionSum.equals(Seq(0, 6, 0, 0, 4, 0, 0, 0, 0, 0)))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->

For full context on the "why" for this PR, please see the main issue: https://github.com/microsoft/hyperspace/issues/150

Introducing a new `BucketUnion` operator that is useful for implementing hybrid scan, a technique that we propose that can leverage the index *and* appended data without the need to re-shuffle the index, thus preserving the benefits of the index.

As part of this, the following classes are being implemented:

  1. `BucketUnion`: Logical Plan operator; Used during logical plan optimization when the newly appended data needs to be union-ed with the data being read from the index.
  2. `BucketUnionExec`: SparkPlan (Physical operator); Calls into `BucketUnionRDD`
  3. `BucketUnionRDD`: RDD operator
  4. `BucketUnionRDDPartition`: Partition
  5. `BucketUnionStrategy`: SparkStrategy that is used when the Logical Plan is being converted to SparkPlan; More specifically, converts `BucketUnion` to `BucketUnionExec` 

> Note: You can find more detailed information about Bucketing optimization in [Bucketing 2.0: Improve Spark SQL Performance by Removing Shuffle](https://youtu.be/7cvaH33S7uc)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Spark does not support Union using `PartitionSpecification`, but just `PartitionerAwareUnionRDD` operation which does not retain outputPartitioning of result. Therefore, we define a new Union operation (being called the `BucketUnion`) which works when the following conditions are satisfied:

- input RDDs must have the same number of partitions.
- input RDDs must have the same partitioning keys.
- input RDDs must have the same column schema.

Unfortunately, since there is no explicit API to check Partitioning keys in RDD, we have to assure that on the caller side. Therefore, `BucketUnionRDD` is Hyperspace internal use only.

`BucketUnion` can be used to merge index data & newly appended data without losing the bucketing specification (`outputPartitioning`). 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
**Existing experience**:
When the underlying data changes, Hyperspace decides to not use the index anymore.

**New experience**:
When the underlying data changes *and* hybrid scan is enabled, Hyperspace utilizes the index to the extent possible and performs a linear scan on the new data.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
BucketUnionTest 
