### PR TITLE
Modify getCandidateIndex for hybrid scan

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -31,7 +31,7 @@ object RuleUtils {
    *
    * @param indexManager indexManager
    * @param plan logical plan
-   * @param hybridScanEnabled HybridScan config.
+   * @param hybridScanEnabled Flag that checks if hybrid scan is enabled or disabled.
    * @return indexes built for this plan
    */
   def getCandidateIndexes(
@@ -56,11 +56,11 @@ object RuleUtils {
     }
 
     def isHybridScanCandidate(entry: IndexLogEntry, files: Seq[FileInfo]): Boolean = {
-      // TODO Some threshold about the similarity of source data files - number of common
-      //  files or total size of common files.
+      // TODO: Some threshold about the similarity of source data files - number of common files or
+      //  total size of common files.
       //  See https://github.com/microsoft/hyperspace/issues/159
-      // TODO As in [[PlanSignatureProvider]], Source plan signature comparison is required
-      //  to support arbitrary source plans at index creation.
+      // TODO: As in [[PlanSignatureProvider]], Source plan signature comparison is required to
+      //  support arbitrary source plans at index creation.
       //  See https://github.com/microsoft/hyperspace/issues/158
 
       // Find a common file between the input relation & index source files.
@@ -84,8 +84,8 @@ object RuleUtils {
             location.allFiles.map(f =>
               FileInfo(f.getPath.toString, f.getLen, f.getModificationTime))
         }
-        .flatten
-      allIndexes.filter(index => index.created && isHybridScanCandidate(index, files))
+      assert(files.length == 1)
+      allIndexes.filter(index => index.created && isHybridScanCandidate(index, files.flatten))
     } else {
       allIndexes.filter(index => index.created && signatureValid(index))
     }

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -58,10 +58,9 @@ object RuleUtils {
     def isHybridScanCandidate(entry: IndexLogEntry, files: Set[FileInfo]): Boolean = {
       // compare all the metadata of source files
       assert(entry.relations.length == 1)
-      val commonFiles = files.intersect(entry.allSourceFileInfos)
       // TODO threshold for the number of CommonFiles
       // TODO plan signature
-      commonFiles.nonEmpty
+      files.exists(entry.allSourceFileInfos.contains)
     }
 
     // TODO: the following check only considers indexes in ACTIVE state for usage. Update

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -63,7 +63,8 @@ object RuleUtils {
       //  to support arbitrary source plans at index creation.
       //  See https://github.com/microsoft/hyperspace/issues/158
 
-      // compare all the metadata of source files
+      // Find a common file between the input relation & index source files.
+      // Without the threshold described above, we can utilize exists & contain functions here.
       files.exists(entry.allSourceFileInfos.contains)
     }
 

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.types.{StructField, StructType}
 import com.microsoft.hyperspace.HyperspaceException
 import com.microsoft.hyperspace.actions.Constants
 import com.microsoft.hyperspace.index._
+import com.microsoft.hyperspace.index.Hdfs.Properties
 
 trait HyperspaceRuleTestSuite extends HyperspaceSuite {
   private val filenames = Seq("f1.parquet", "f2.parquet")
@@ -39,7 +40,13 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
     LogicalPlanSignatureProvider.create(signClass).signature(plan) match {
       case Some(s) =>
         val sourcePlanProperties = SparkPlan.Properties(
-          Seq(),
+          Seq(
+            Relation(
+              Seq("dummy"),
+              Hdfs(Properties(Content(Directory("/")))),
+              "schema",
+              "format",
+              Map())),
           null,
           null,
           LogicalPlanFingerprint(LogicalPlanFingerprint.Properties(Seq(Signature(signClass, s)))))

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -120,6 +120,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
     val readDf = spark.read.parquet(dataPath)
     indexManager.create(readDf, IndexConfig("index1", Seq("id")))
 
+    // Append new files.
     df.write.mode("append").parquet(dataPath)
 
     {
@@ -141,6 +142,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
           .length === 1)
     }
 
+    // Delete 1 file.
     readDf.queryExecution.optimizedPlan foreach {
       case LogicalRelation(
       HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _), _, _, _) =>
@@ -159,6 +161,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
           .length === 1)
     }
 
+    // Replace all files.
     df.write.mode("overwrite").parquet(dataPath)
 
     {
@@ -171,7 +174,6 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
             hybridScanEnabled = true)
           .length === 0)
     }
-
   }
 
   private def validateLogicalRelation(plan: LogicalPlan, expected: LogicalRelation): Unit = {

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -131,7 +131,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
             indexManager,
             readDf.queryExecution.optimizedPlan,
             hybridScanEnabled = false)
-          .length === 0)
+          .isEmpty)
 
       assert(
         RuleUtils
@@ -172,7 +172,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
             indexManager,
             readDf.queryExecution.optimizedPlan,
             hybridScanEnabled = true)
-          .length === 0)
+          .isEmpty)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->
- `lazy val allSourceFileInfos: Set[FileInfo]`
  - `lazy val` because this source file list of an index referred several times when applying Rules.
  - `Set` instead of `Seq` because
    - comparison of 2 Set[FileInfo] is the only use case of allSourceFileInfos now.
    - performance issue
- `isHybridScanCandidate()`
  1. get the current file list of the given relation
  2. check if there's any common files with index.allSourceFileInfos
    - TODO: plan signature comparison #158 
    - TODO: number of common files(or size) threshold #159 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The current signature design is not appropriate for hybrid scan.
For delete support, we need to figure out the list of deleted source files and check the other source files still have the same metadata when index build time or not.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test