### PR TITLE
Add merge functionality on Directory object

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -107,6 +107,7 @@ case class Directory(
     name: String,
     files: Seq[FileInfo] = Seq(),
     subDirs: Seq[Directory] = Seq()) {
+
   /**
    * Merge two Directory objects. For e.g., merging the following directories
    * /file:/C:/
@@ -126,17 +127,18 @@ case class Directory(
    *
    * @param that The other directory to merge this with.
    * @return Merged directory
-   * @throws HyperspaceException To merge two directories, their name should be same.
+   * @throws HyperspaceException If two directories to merge have different names.
    */
   def merge(that: Directory): Directory = {
     if (name.equals(that.name)) {
       val allFiles = files ++ that.files
       val subDirMap = subDirs.map(dir => dir.name -> dir).toMap
       val thatSubDirMap = that.subDirs.map(dir => dir.name -> dir).toMap
-      val subDir: Seq[Directory] = (subDirMap.keySet ++ thatSubDirMap.keySet).toSeq.map {
+      val mergedSubDirs: Seq[Directory] = (subDirMap.keySet ++ thatSubDirMap.keySet).toSeq.map {
         dirName =>
           if (subDirMap.contains(dirName) && thatSubDirMap.contains(dirName)) {
-            // If both directories contain a subDir with same name, merge subDirs respectively.
+            // If both directories contain a subDir with same name, merge corresponding subDirs
+            // recursively.
             subDirMap(dirName).merge(thatSubDirMap(dirName))
           } else {
             // Pick the subDir from whoever contains it.
@@ -144,10 +146,11 @@ case class Directory(
           }
       }
 
-      Directory(name, allFiles, subDirs = subDir)
+      Directory(name, allFiles, subDirs = mergedSubDirs)
     } else {
-      throw HyperspaceException(s"Merging directories with names $name and ${that.name} failed." +
-        s"Directory names must be same for merging Directories.")
+      throw HyperspaceException(
+        s"Merging directories with names $name and ${that.name} failed. " +
+          "Directory names must be same for merging directories.")
     }
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -134,16 +134,15 @@ case class Directory(
       val allFiles = files ++ that.files
       val subDirMap = subDirs.map(dir => dir.name -> dir).toMap
       val thatSubDirMap = that.subDirs.map(dir => dir.name -> dir).toMap
-      val mergedSubDirs: Seq[Directory] = (subDirMap.keySet ++ thatSubDirMap.keySet).toSeq.map {
-        dirName =>
-          if (subDirMap.contains(dirName) && thatSubDirMap.contains(dirName)) {
-            // If both directories contain a subDir with same name, merge corresponding subDirs
-            // recursively.
-            subDirMap(dirName).merge(thatSubDirMap(dirName))
-          } else {
-            // Pick the subDir from whoever contains it.
-            subDirMap.getOrElse(dirName, thatSubDirMap(dirName))
-          }
+      val mergedSubDirs = (subDirMap.keySet ++ thatSubDirMap.keySet).toSeq.map { dirName =>
+        if (subDirMap.contains(dirName) && thatSubDirMap.contains(dirName)) {
+          // If both directories contain a subDir with same name, merge corresponding subDirs
+          // recursively.
+          subDirMap(dirName).merge(thatSubDirMap(dirName))
+        } else {
+          // Pick the subDir from whoever contains it.
+          subDirMap.getOrElse(dirName, thatSubDirMap(dirName))
+        }
       }
 
       Directory(name, allFiles, subDirs = mergedSubDirs)

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -126,7 +126,7 @@ case class Directory(
    *               f1, f2
    *
    * @param that The other directory to merge this with.
-   * @return Merged directory
+   * @return Merged directory.
    * @throws HyperspaceException If two directories to merge have different names.
    */
   def merge(that: Directory): Directory = {

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -96,6 +96,27 @@ case class Directory(
     name: String,
     files: Seq[FileInfo] = Seq(),
     subDirs: Seq[Directory] = Seq()) {
+  /**
+   * Merge two Directory objects. For e.g., merging the following directories
+   * /file:/C:/
+   *          a/
+   *            b/
+   *              f1, f2
+   * and
+   * /file:/C:/
+   *          a/
+   *            f3, f4
+   * will be
+   * /file:/C:/
+   *           a/
+   *             f3, f4
+   *             b/
+   *               f1, f2
+   *
+   * @param that The other directory to merge this with.
+   * @return Merged directory
+   * @throws HyperspaceException To merge two directories, their name should be same.
+   */
   def merge(that: Directory): Directory = {
     if (name.equals(that.name)) {
       val allFiles = files ++ that.files
@@ -114,7 +135,8 @@ case class Directory(
 
       Directory(name, allFiles, subDirs = subDir)
     } else {
-      throw HyperspaceException("Directory names should match for merging Directories.")
+      throw HyperspaceException(s"Merging directories with names $name and ${that.name} failed." +
+        s"Directory names must be same for merging Directories.")
     }
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -84,6 +84,14 @@ object Content {
   def fromLeafFiles(files: Seq[FileStatus]): Content = Content(Directory.fromLeafFiles(files))
 }
 
+/**
+ * Directory is a representation of file system directory. It consists of a name (directory name),
+ * a list of files represented by sequence of [[FileInfo]], and a list of subdirectories.
+ *
+ * @param name Directory name.
+ * @param files List of leaf files in this directory.
+ * @param subDirs List of sub-directories in this directory.
+ */
 case class Directory(
     name: String,
     files: Seq[FileInfo] = Seq(),

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -445,7 +445,8 @@ class IndexLogEntryTest extends SparkFunSuite with SQLHelper with BeforeAndAfter
     // testDir/a/f2
     // testDir/a/b/f3
     // testDir/a/b/f4
-
+    // Expected Result: Merged Directory structure when merging Directory object of dir a with
+    // that of b.
     val tempDir = Files.createDirectories(Paths.get(testDir + "/temp"))
     val a = Files.createDirectories(Paths.get(tempDir + "/a"))
     val b = Files.createDirectories(Paths.get(a + "/b"))

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -439,6 +439,34 @@ class IndexLogEntryTest extends SparkFunSuite with SQLHelper with BeforeAndAfter
     FileUtils.deleteDirectory(tempDir.toFile)
   }
 
+  test("Directory.merge Test: test if merge works as expected.") {
+    // File Structure
+    // testDir/a/f1
+    // testDir/a/f2
+    // testDir/a/b/f3
+    // testDir/a/b/f4
+
+    val tempDir = Files.createDirectories(Paths.get(testDir + "/temp"))
+    val a = Files.createDirectories(Paths.get(tempDir + "/a"))
+    val b = Files.createDirectories(Paths.get(a + "/b"))
+    val f1 = Files.createFile(Paths.get(a + "/f1"))
+    val f2 = Files.createFile(Paths.get(a + "/f2"))
+    val f3 = Files.createFile(Paths.get(b + "/f3"))
+    val f4 = Files.createFile(Paths.get(b + "/f4"))
+
+    val aDirectory = Directory.fromDirectory(toPath(a))
+    val bDirectory = Directory.fromDirectory(toPath(b))
+
+    val expected = Directory.fromLeafFiles(Seq(f1, f2, f3, f4).map(toFileStatus))
+    val actual1 = aDirectory.merge(bDirectory)
+    val actual2 = bDirectory.merge(aDirectory)
+
+    assert(directoryEquals(actual1, expected))
+    assert(directoryEquals(actual2, expected))
+
+    FileUtils.deleteDirectory(tempDir.toFile)
+  }
+
   private def contentEquals(content1: Content, content2: Content): Boolean = {
     directoryEquals(content1.root, content2.root)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add support for `merge`ing two `com.microsoft.hyperspace.index.Directory` objects. Pre-requisite for #29,  #163.

#### Feature Description
We need a functionality to merge two directory trees in order to support future functionalities like `Append` and `Optimize`. When we create index only on partially unindexed data, we need to make sure to log the latest snapshot of the index as the combination of previously created index files and newly created index files. This can be done through the suggested `merge` api on index `Directory`. 

#### Example Usecase: Merge contents of partially created indexes in case of append:
1. User creates index on original data. This index is stored in index directory (say) `index/v__=0`. This will be stored in metadata as
```
{
  "root" : {
    "name" : "file:/C:/",
    "files" : [ ],
    "subDirs" : [ {
      "name" : "Users",
      "files" : [ ],
      "subDirs" : [ {
        "name" : "apdave",
        "files" : [ ],
        "subDirs" : [ {
          "name" : "repo2",
          "files" : [ ],
          "subDirs" : [ {
            "name" : "testdata",
            "files" : [ ],
            "subDirs" : [ {
              "name" : "v__=0",
              "files" : [ {
                "name" : "part-00000-5782bdd3-4729-44e6-b54b-51b557f66792-c000.snappy.parquet",
                "size" : 1473,
                "modifiedTime" : 1585280921507
              }, {
                "name" : "part-00000-e8c8821f-a1b2-4b3b-be9e-687b6fa6d057-c000.snappy.parquet",
                "size" : 1878,
                "modifiedTime" : 1585280853559
              } ],
              "subDirs" : [ ]
            } ]
          } ]
        } ]
      } ]
    } ]
  }
}
```

2. User adds new data and calls `refreshIndex(mode = "quick")`. This will create another intermediate `Content` object similar to above, with `name = "v__=1"`.

3. We can now call `content.root.merge(content2.root)` to deduplicate the directory structure.
```
{
  "root" : {
    "name" : "file:/C:/",
    "files" : [ ],
    "subDirs" : [ {
      "name" : "Users",
      "files" : [ ],
      "subDirs" : [ {
        "name" : "apdave",
        "files" : [ ],
        "subDirs" : [ {
          "name" : "repo2",
          "files" : [ ],
          "subDirs" : [ {
            "name" : "testdata",
            "files" : [ ],
            "subDirs" : [ {
              "name" : "v__=0",
              "files" : [ {
                "name" : "part-00000-5782bdd3-4729-44e6-b54b-51b557f66792-c000.snappy.parquet",
                "size" : 1473,
                "modifiedTime" : 1585280921507
              }, {
                "name" : "part-00000-e8c8821f-a1b2-4b3b-be9e-687b6fa6d057-c000.snappy.parquet",
                "size" : 1878,
                "modifiedTime" : 1585280853559
              } ],
              "subDirs" : [ ]
            }, {
              "name" : "v__=1",
              "files" : [ {
                "name" : "part-00000-abc2bdd3-4729-44e6-b54b-51b557f66456-c000.snappy.parquet",
                "size" : 1473,
                "modifiedTime" : 1585280921507
              }, {
                "name" : "part-00000-abc8821f-a1b2-4b3b-be9e-687b6fa6d123-c000.snappy.parquet",
                "size" : 1878,
                "modifiedTime" : 1585280853559
              } ],
              "subDirs" : [ ]
            }]
          } ]
        } ]
      } ]
    } ]
  }
}
```

### Does this PR introduce _any_ user-facing change?
no
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
unit tests
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
