### PR TITLE
Modify logical plan to merge newly appended files and index data

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable.{HashMap, ListBuffer}
 import com.fasterxml.jackson.annotation.JsonIgnore
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path, PathFilter}
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.types.{DataType, StructType}
 
 import com.microsoft.hyperspace.actions.Constants
@@ -318,6 +319,12 @@ case class IndexLogEntry(
       .flatMap(_.data.properties.content.fileInfos)
       .toSet
   }
+
+  def bucketSpec: BucketSpec =
+    BucketSpec(
+      numBuckets = numBuckets,
+      bucketColumnNames = indexedColumns,
+      sortColumnNames = indexedColumns)
 
   override def equals(o: Any): Boolean = o match {
     case that: IndexLogEntry =>

--- a/src/main/scala/com/microsoft/hyperspace/index/execution/BucketUnionExec.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/execution/BucketUnionExec.scala
@@ -112,6 +112,10 @@ private[hyperspace] case class BucketUnionExec(children: Seq[SparkPlan], bucketS
   override def outputPartitioning: Partitioning = {
     assert(children.map(_.outputPartitioning).toSet.size == 1)
     assert(children.head.outputPartitioning.isInstanceOf[HashPartitioning])
+    assert(
+      children.head.outputPartitioning
+        .asInstanceOf[HashPartitioning]
+        .numPartitions == bucketSpec.numBuckets)
     children.head.outputPartitioning
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -56,7 +56,7 @@ object FilterIndexRule
             case Some(index) =>
               // Do not set BucketSpec to avoid limiting Spark's degree of parallelism
               val replacedPlan =
-                RuleUtils.transformPlanWithIndex(spark, index, originalPlan, useBucketSpec = false)
+                RuleUtils.transformPlanToUseIndex(spark, index, originalPlan, useBucketSpec = false)
               logEvent(
                 HyperspaceIndexUsageEvent(
                   AppInfo(

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -56,7 +56,7 @@ object FilterIndexRule
             case Some(index) =>
               // Do not set BucketSpec to avoid limiting Spark's degree of parallelism
               val replacedPlan =
-                RuleUtils.getReplacementPlan(spark, index, originalPlan, useBucketSpec = false)
+                RuleUtils.transformPlanWithIndex(spark, index, originalPlan, useBucketSpec = false)
               logEvent(
                 HyperspaceIndexUsageEvent(
                   AppInfo(

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -56,7 +56,11 @@ object FilterIndexRule
             case Some(index) =>
               // Do not set BucketSpec to avoid limiting Spark's degree of parallelism
               val replacedPlan =
-                RuleUtils.transformPlanToUseIndex(spark, index, originalPlan, useBucketSpec = false)
+                RuleUtils.transformPlanToUseIndex(
+                  spark,
+                  index,
+                  originalPlan,
+                  useBucketSpec = false)
               logEvent(
                 HyperspaceIndexUsageEvent(
                   AppInfo(

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -55,7 +55,7 @@ object FilterIndexRule
           rank(candidateIndexes) match {
             case Some(index) =>
               // Do not set BucketSpec to avoid limiting Spark's degree of parallelism.
-              val replacedPlan =
+              val transformedPlan =
                 RuleUtils.transformPlanToUseIndex(
                   spark,
                   index,
@@ -69,9 +69,9 @@ object FilterIndexRule
                     sparkContext.appName),
                   Seq(index),
                   filter.toString,
-                  replacedPlan.toString,
+                  transformedPlan.toString,
                   "Filter index rule applied."))
-              replacedPlan
+              transformedPlan
             case None => originalPlan
           }
         } catch {

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -54,7 +54,7 @@ object FilterIndexRule
             findCoveringIndexes(filter, outputColumns, filterColumns, fsRelation)
           rank(candidateIndexes) match {
             case Some(index) =>
-              // Do not set BucketSpec to avoid limiting Spark's degree of parallelism
+              // Do not set BucketSpec to avoid limiting Spark's degree of parallelism.
               val replacedPlan =
                 RuleUtils.transformPlanToUseIndex(
                   spark,

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -22,13 +22,11 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
-import org.apache.spark.sql.types.StructType
 
 import com.microsoft.hyperspace.{ActiveSparkSession, Hyperspace}
 import com.microsoft.hyperspace.index.IndexLogEntry
 import com.microsoft.hyperspace.telemetry.{AppInfo, HyperspaceEventLogging, HyperspaceIndexUsageEvent}
-import com.microsoft.hyperspace.util.ResolverUtils
+import com.microsoft.hyperspace.util.{HyperspaceConf, ResolverUtils}
 
 /**
  * FilterIndex rule looks for opportunities in a logical plan to replace
@@ -50,85 +48,33 @@ object FilterIndexRule
     //  1. The index covers all columns from the filter predicate and output columns list, and
     //  2. Filter predicate's columns include the first 'indexed' column of the index.
     plan transformDown {
-      case ExtractFilterNode(
-          originalPlan,
-          filter,
-          outputColumns,
-          filterColumns,
-          logicalRelation,
-          fsRelation) =>
+      case ExtractFilterNode(originalPlan, filter, outputColumns, filterColumns, _, fsRelation) =>
         try {
-          val transformedPlan = replaceWithIndexIfPlanCovered(
-            filter,
-            outputColumns,
-            filterColumns,
-            logicalRelation,
-            fsRelation)
-
-          originalPlan match {
-            case p @ Project(_, _) =>
-              p.copy(child = transformedPlan)
-            case _ =>
-              transformedPlan
+          val candidateIndexes =
+            findCoveringIndexes(filter, outputColumns, filterColumns, fsRelation)
+          rank(candidateIndexes) match {
+            case Some(index) =>
+              // Do not set BucketSpec to avoid limiting Spark's degree of parallelism
+              val replacedPlan =
+                RuleUtils.getReplacementPlan(spark, index, originalPlan, useBucketSpec = false)
+              logEvent(
+                HyperspaceIndexUsageEvent(
+                  AppInfo(
+                    sparkContext.sparkUser,
+                    sparkContext.applicationId,
+                    sparkContext.appName),
+                  Seq(index),
+                  filter.toString,
+                  replacedPlan.toString,
+                  "Filter index rule applied."))
+              replacedPlan
+            case None => originalPlan
           }
         } catch {
           case e: Exception =>
             logWarning("Non fatal exception in running filter index rule: " + e.getMessage)
             originalPlan
         }
-    }
-  }
-
-  /**
-   * For a given relation, check its available indexes and replace it with the top-ranked index
-   * (according to cost model).
-   *
-   * @param filter Filter node in the subplan that is being optimized.
-   * @param outputColumns List of output columns in subplan.
-   * @param filterColumns List of columns in filter predicate.
-   * @param logicalRelation child logical relation in the subplan.
-   * @param fsRelation Input relation in the subplan.
-   * @return transformed logical plan in which original fsRelation is replaced by
-   *         the top-ranked index.
-   */
-  private def replaceWithIndexIfPlanCovered(
-      filter: Filter,
-      outputColumns: Seq[String],
-      filterColumns: Seq[String],
-      logicalRelation: LogicalRelation,
-      fsRelation: HadoopFsRelation): Filter = {
-    val candidateIndexes =
-      findCoveringIndexes(filter, outputColumns, filterColumns, fsRelation)
-    rank(candidateIndexes) match {
-      case Some(index) =>
-        val spark = fsRelation.sparkSession
-        val newLocation = new InMemoryFileIndex(spark, index.content.files, Map(), None)
-
-        val newRelation = HadoopFsRelation(
-          newLocation,
-          new StructType(),
-          StructType(index.schema.filter(fsRelation.schema.contains)),
-          None, // Do not set BucketSpec to avoid limiting Spark's degree of parallelism
-          new ParquetFileFormat,
-          Map())(spark)
-
-        val newOutput =
-          logicalRelation.output.filter(attr => index.schema.fieldNames.contains(attr.name))
-
-        val updatedPlan =
-          filter.copy(child = logicalRelation.copy(relation = newRelation, output = newOutput))
-
-        logEvent(
-          HyperspaceIndexUsageEvent(
-            AppInfo(sparkContext.sparkUser, sparkContext.applicationId, sparkContext.appName),
-            Seq(index),
-            filter.toString,
-            updatedPlan.toString,
-            "Filter index rule applied."))
-
-        updatedPlan
-
-      case None => filter // No candidate index found
     }
   }
 
@@ -147,12 +93,14 @@ object FilterIndexRule
       outputColumns: Seq[String],
       filterColumns: Seq[String],
       fsRelation: HadoopFsRelation): Seq[IndexLogEntry] = {
+    val indexManager = Hyperspace
+      .getContext(spark)
+      .indexCollectionManager
+    val hybridScanEnabled = HyperspaceConf.hybridScanEnabled(spark)
     RuleUtils.getLogicalRelation(filter) match {
       case Some(r) =>
-        val indexManager = Hyperspace
-          .getContext(spark)
-          .indexCollectionManager
-        val candidateIndexes = RuleUtils.getCandidateIndexes(indexManager, r)
+        val candidateIndexes =
+          RuleUtils.getCandidateIndexes(indexManager, r, hybridScanEnabled)
 
         candidateIndexes.filter { index =>
           indexCoversPlan(

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -97,14 +97,13 @@ object FilterIndexRule
       outputColumns: Seq[String],
       filterColumns: Seq[String],
       fsRelation: HadoopFsRelation): Seq[IndexLogEntry] = {
-    val indexManager = Hyperspace
-      .getContext(spark)
-      .indexCollectionManager
-    val hybridScanEnabled = HyperspaceConf.hybridScanEnabled(spark)
     RuleUtils.getLogicalRelation(filter) match {
       case Some(r) =>
+        val indexManager = Hyperspace
+          .getContext(spark)
+          .indexCollectionManager
         val candidateIndexes =
-          RuleUtils.getCandidateIndexes(indexManager, r, hybridScanEnabled)
+          RuleUtils.getCandidateIndexes(indexManager, r, HyperspaceConf.hybridScanEnabled(spark))
 
         candidateIndexes.filter { index =>
           indexCoversPlan(

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -60,10 +60,13 @@ object JoinIndexRule
         getUsableIndexPair(l, r, condition)
           .map {
             case (lIndex, rIndex) =>
-              val updatedPlan = join
-                .copy(
-                  left = RuleUtils.transformPlanToUseIndex(spark, lIndex, l, useBucketSpec = true),
-                  right = RuleUtils.transformPlanToUseIndex(spark, rIndex, r, useBucketSpec = true))
+              val updatedPlan =
+                join
+                  .copy(
+                    left =
+                      RuleUtils.transformPlanToUseIndex(spark, lIndex, l, useBucketSpec = true),
+                    right =
+                      RuleUtils.transformPlanToUseIndex(spark, rIndex, r, useBucketSpec = true))
 
               logEvent(
                 HyperspaceIndexUsageEvent(

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -62,8 +62,8 @@ object JoinIndexRule
             case (lIndex, rIndex) =>
               val updatedPlan = join
                 .copy(
-                  left = RuleUtils.transformPlanWithIndex(spark, lIndex, l, useBucketSpec = true),
-                  right = RuleUtils.transformPlanWithIndex(spark, rIndex, r, useBucketSpec = true))
+                  left = RuleUtils.transformPlanToUseIndex(spark, lIndex, l, useBucketSpec = true),
+                  right = RuleUtils.transformPlanToUseIndex(spark, rIndex, r, useBucketSpec = true))
 
               logEvent(
                 HyperspaceIndexUsageEvent(

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -62,8 +62,8 @@ object JoinIndexRule
             case (lIndex, rIndex) =>
               val updatedPlan = join
                 .copy(
-                  left = RuleUtils.getReplacementPlan(spark, lIndex, l, useBucketSpec = true),
-                  right = RuleUtils.getReplacementPlan(spark, rIndex, r, useBucketSpec = true))
+                  left = RuleUtils.transformPlanWithIndex(spark, lIndex, l, useBucketSpec = true),
+                  right = RuleUtils.transformPlanWithIndex(spark, rIndex, r, useBucketSpec = true))
 
               logEvent(
                 HyperspaceIndexUsageEvent(

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -21,18 +21,16 @@ import scala.util.Try
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.analysis.CleanupAliases
-import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, AttributeReference, AttributeSet, EqualTo, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InMemoryFileIndex, LogicalRelation}
-import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.execution.datasources.LogicalRelation
 
 import com.microsoft.hyperspace.{ActiveSparkSession, Hyperspace}
 import com.microsoft.hyperspace.index._
 import com.microsoft.hyperspace.index.rankers.JoinIndexRanker
 import com.microsoft.hyperspace.telemetry.{AppInfo, HyperspaceEventLogging, HyperspaceIndexUsageEvent}
+import com.microsoft.hyperspace.util.HyperspaceConf
 import com.microsoft.hyperspace.util.ResolverUtils._
 
 /**
@@ -63,7 +61,9 @@ object JoinIndexRule
           .map {
             case (lIndex, rIndex) =>
               val updatedPlan = join
-                .copy(left = getReplacementPlan(lIndex, l), right = getReplacementPlan(rIndex, r))
+                .copy(
+                  left = RuleUtils.getReplacementPlan(spark, lIndex, l, useBucketSpec = true),
+                  right = RuleUtils.getReplacementPlan(spark, rIndex, r, useBucketSpec = true))
 
               logEvent(
                 HyperspaceIndexUsageEvent(
@@ -106,59 +106,24 @@ object JoinIndexRule
     val indexManager = Hyperspace
       .getContext(spark)
       .indexCollectionManager
-
+    val hybridScanEnabled = HyperspaceConf.hybridScanEnabled(spark)
     val lIndexes =
-      RuleUtils.getLogicalRelation(left).map(RuleUtils.getCandidateIndexes(indexManager, _))
+      RuleUtils
+        .getLogicalRelation(left)
+        .map(RuleUtils.getCandidateIndexes(indexManager, _, hybridScanEnabled))
     if (lIndexes.isEmpty || lIndexes.get.isEmpty) {
       return None
     }
 
     val rIndexes =
-      RuleUtils.getLogicalRelation(right).map(RuleUtils.getCandidateIndexes(indexManager, _))
+      RuleUtils
+        .getLogicalRelation(right)
+        .map(RuleUtils.getCandidateIndexes(indexManager, _, hybridScanEnabled))
     if (rIndexes.isEmpty || rIndexes.get.isEmpty) {
       return None
     }
 
     getBestIndexPair(left, right, condition, lIndexes.get, rIndexes.get)
-  }
-
-  /**
-   * Get replacement plan for current plan. The replacement plan reads data from indexes
-   *
-   * Pre-requisites
-   * - We know for sure the index which can be used to replace the plan.
-   *
-   * NOTE: This method currently only supports replacement of Scan Nodes i.e. Logical relations
-   *
-   * @param index index used in replacement plan
-   * @param plan current plan
-   * @return replacement plan
-   */
-  private def getReplacementPlan(index: IndexLogEntry, plan: LogicalPlan): LogicalPlan = {
-    // Here we can't replace the plan completely with the index. This will create problems.
-    // For e.g. if Project(A,B) -> Filter(C = 10) -> Scan (A,B,C,D,E)
-    // if we replace this plan with index Scan (A,B,C), we lose the Filter(C=10) and it will
-    // lead to wrong results. So we only replace the base relation.
-    plan transform {
-      case baseRelation @ LogicalRelation(_: HadoopFsRelation, baseOutput, _, _) =>
-        val bucketSpec = BucketSpec(
-          numBuckets = index.numBuckets,
-          bucketColumnNames = index.indexedColumns,
-          sortColumnNames = index.indexedColumns)
-
-        val location = new InMemoryFileIndex(spark, index.content.files, Map(), None)
-        val relation = HadoopFsRelation(
-          location,
-          new StructType(),
-          StructType(index.schema.filter(baseRelation.schema.contains(_))),
-          Some(bucketSpec),
-          new ParquetFileFormat,
-          Map())(spark)
-
-        val updatedOutput =
-          baseOutput.filter(attr => relation.schema.fieldNames.contains(attr.name))
-        baseRelation.copy(relation = relation, output = updatedOutput)
-    }
   }
 
   /**
@@ -438,11 +403,13 @@ object JoinIndexRule
     extractConditions(condition).map {
       case EqualTo(attr1: AttributeReference, attr2: AttributeReference) =>
         Try {
-          (resolve(spark, attr1.name, leftBaseAttrs).get,
+          (
+            resolve(spark, attr1.name, leftBaseAttrs).get,
             resolve(spark, attr2.name, rightBaseAttrs).get)
         }.getOrElse {
           Try {
-            (resolve(spark, attr2.name, leftBaseAttrs).get,
+            (
+              resolve(spark, attr2.name, leftBaseAttrs).get,
               resolve(spark, attr1.name, rightBaseAttrs).get)
           }.getOrElse {
             throw new IllegalStateException("Unexpected exception while using join rule")

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -281,15 +281,15 @@ object RuleUtils {
    * @param spark Spark session.
    * @param index Index used in replacement plan.
    * @param originalPlan Original plan.
-   * @param indexPlan Replaced plan with index.
+   * @param planWithIndex Replaced plan with index.
    * @param filesAppended Appended files to the source relation.
-   * @return complementIndexPlan integrated plan of indexPlan and complementPlan.
+   * @return Consolidated plan of planWithIndex and a complement plan for filesAppended
    */
   private def getComplementIndexPlan(
       spark: SparkSession,
       index: IndexLogEntry,
       originalPlan: LogicalPlan,
-      indexPlan: LogicalPlan,
+      planWithIndex: LogicalPlan,
       filesAppended: Seq[Path]): LogicalPlan = {
     // 1) Replace the location of LogicalRelation with appended files
     val complementIndexPlan = originalPlan transformDown {
@@ -378,6 +378,6 @@ object RuleUtils {
 
     // 3) Merge index plan & newly shuffled plan by using bucket-aware union.
     // Currently, BucketUnion does not keep the sort order within a bucket.
-    BucketUnion(Seq(indexPlan, shuffled), bucketSpec)
+    BucketUnion(Seq(planWithIndex, shuffled), bucketSpec)
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -18,11 +18,18 @@ package com.microsoft.hyperspace.index.rules
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation, PartitioningAwareFileIndex}
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project, RepartitionByExpression}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InMemoryFileIndex, LogicalRelation, PartitioningAwareFileIndex}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.types.StructType
 
 import com.microsoft.hyperspace.actions.Constants
-import com.microsoft.hyperspace.index.{FileInfo, IndexLogEntry, IndexManager, LogicalPlanSignatureProvider, PlanSignatureProvider}
+import com.microsoft.hyperspace.index.{FileInfo, IndexLogEntry, IndexManager, LogicalPlanSignatureProvider}
+import com.microsoft.hyperspace.index.plans.logical.BucketUnion
+import com.microsoft.hyperspace.util.HyperspaceConf
 
 object RuleUtils {
 
@@ -37,7 +44,7 @@ object RuleUtils {
   def getCandidateIndexes(
       indexManager: IndexManager,
       plan: LogicalPlan,
-      hybridScanEnabled: Boolean = false): Seq[IndexLogEntry] = {
+      hybridScanEnabled: Boolean): Seq[IndexLogEntry] = {
     // Map of a signature provider to a signature generated for the given plan.
     val signatureMap = mutable.Map[String, Option[String]]()
 
@@ -104,6 +111,248 @@ object RuleUtils {
       Some(lrs.head)
     } else {
       None // logicalPlan is non-linear or it has no LogicalRelation.
+    }
+  }
+
+  /**
+   * Get replacement plan for current plan. The replacement plan reads data from indexes.
+   * If HybridScan is enabled, additional logical plans for the appended data would be
+   * generated and merged with index data plan. Refer [[getComplementIndexPlan]].
+   *
+   * Pre-requisites
+   * - We know for sure the index which can be used to replace the plan.
+   *
+   * NOTE: This method currently only supports replacement of Scan Nodes i.e. Logical relations
+   *
+   * @param spark Spark session.
+   * @param index Index used in replacement plan.
+   * @param plan Current logical plan.
+   * @param useBucketSpec Option whether to use BucketSpec for reading index data.
+   * @return Replacement plan.
+   */
+  def getReplacementPlan(
+      spark: SparkSession,
+      index: IndexLogEntry,
+      plan: LogicalPlan,
+      useBucketSpec: Boolean): LogicalPlan = {
+    if (HyperspaceConf.hybridScanEnabled(spark)) {
+      getHybridScanIndexPlan(spark, index, plan, useBucketSpec)
+    } else {
+      getIndexPlan(spark, index, plan, useBucketSpec)
+    }
+  }
+
+  /**
+   * Get alternative logical plan of the current plan using the given index.
+   *
+   * @param spark Spark session.
+   * @param index Index used in replacement plan.
+   * @param plan Current logical plan.
+   * @param useBucketSpec Option whether to use BucketSpec for reading index data.
+   * @return Alternative logical plan.
+   */
+  private def getIndexPlan(
+      spark: SparkSession,
+      index: IndexLogEntry,
+      plan: LogicalPlan,
+      useBucketSpec: Boolean): LogicalPlan = {
+    // Here we can't replace the plan completely with the index. This will create problems.
+    // For e.g. if Project(A,B) -> Filter(C = 10) -> Scan (A,B,C,D,E)
+    // if we replace this plan with index Scan (A,B,C), we lose the Filter(C=10) and it will
+    // lead to wrong results. So we only replace the base relation.
+    plan transformDown {
+      case baseRelation @ LogicalRelation(_: HadoopFsRelation, baseOutput, _, _) =>
+        val location =
+          new InMemoryFileIndex(spark, index.content.files, Map(), None)
+        val relation = HadoopFsRelation(
+          location,
+          new StructType(),
+          StructType(index.schema.filter(baseRelation.schema.contains(_))),
+          if (useBucketSpec) Some(index.bucketSpec) else None,
+          new ParquetFileFormat,
+          Map())(spark)
+
+        val updatedOutput =
+          baseOutput.filter(attr => relation.schema.fieldNames.contains(attr.name))
+        baseRelation.copy(relation = relation, output = updatedOutput)
+    }
+  }
+
+  /**
+   * Get alternative logical plan of the current plan using the given index.
+   * With HybridScan, indexes with newly appended files to its source relation are also
+   * eligible and we reconstruct new plans for the appended files so as to merge into
+   * the index data.
+   *
+   * @param spark Spark session.
+   * @param index Index used in replacement plan.
+   * @param plan Current logical plan.
+   * @param useBucketSpec Option whether to use BucketSpec for reading index data.
+   * @return Alternative logical plan.
+   */
+  private def getHybridScanIndexPlan(
+      spark: SparkSession,
+      index: IndexLogEntry,
+      plan: LogicalPlan,
+      useBucketSpec: Boolean): LogicalPlan = {
+    // Other than "parquet" format, we cannot read source files along with index data
+    // files in parquet format with 1 FileScan node. In this case, we need to read the
+    // appended source files by another FileScan node and merge into the index data.
+    // Though BucketUnion (using BucketSpec and on-the-fly Shuffle) is used to merge
+    // them for now, we will try to optimize these plans with Union operator.
+    val useBucketUnion = useBucketSpec || !index.relations.head.fileFormat.equals("parquet")
+    val replacedPlan = plan transformDown {
+      case baseRelation @ LogicalRelation(
+            _ @HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _),
+            baseOutput,
+            _,
+            _) =>
+        val curFileSet = location.allFiles
+          .map(f => FileInfo(f.getPath.toString, f.getLen, f.getModificationTime))
+          .toSet
+
+        // if BucketSpec of index data isn't used, we could read appended data from
+        // source files directly.
+        val readPaths = {
+          if (useBucketUnion) {
+            index.content.files
+          } else {
+            val filesAppended =
+              (curFileSet -- index.allSourceFileInfos).map(f => new Path(f.name)).toSeq
+            index.content.files ++ filesAppended
+          }
+        }
+
+        val newLocation = new InMemoryFileIndex(spark, readPaths, Map(), None)
+        val relation = HadoopFsRelation(
+          newLocation,
+          new StructType(),
+          StructType(index.schema.filter(baseRelation.schema.contains(_))),
+          if (useBucketUnion) Some(index.bucketSpec) else None,
+          new ParquetFileFormat,
+          Map())(spark)
+
+        val updatedOutput =
+          baseOutput.filter(attr => relation.schema.fieldNames.contains(attr.name))
+        baseRelation.copy(relation = relation, output = updatedOutput)
+    }
+    if (useBucketUnion) {
+      // if BucketSpec of the index is used to read the index data, we need to shuffle
+      // the appended data in the same way to avoid additional shuffle of index data.
+      getComplementIndexPlan(spark, index, plan, replacedPlan)
+    } else {
+      replacedPlan
+    }
+  }
+
+  /**
+   * Get complement plan for an index with appended data.
+   *
+   * This method consists of the following steps
+   * 1) Get a plan from originalPlan by replacing data location with appended data
+   * 2) On-the-fly shuffle for the appended data, using indexedColumns & numBuckets.
+   *   - Shuffle is located before Project to utilize Push-down Filters
+   *     - Shuffle => Project => Filter => Relation
+   *   - if Project filters indexedColumns, then Shuffle should be located after the node
+   *     - Project => Shuffle => Filter => Relation
+   * 3) Bucket-aware union both indexPlan and complementPlan to avoid repartitioning index data
+   *
+   * NOTE: This method currently only supports replacement of Scan Nodes i.e. Logical relations
+   *
+   * @param spark Spark session
+   * @param index index used in replacement plan
+   * @param originalPlan original plan
+   * @param indexPlan replaced plan with index
+   * @return complementIndexPlan integrated plan of indexPlan and complementPlan
+   */
+  private def getComplementIndexPlan(
+      spark: SparkSession,
+      index: IndexLogEntry,
+      originalPlan: LogicalPlan,
+      indexPlan: LogicalPlan): LogicalPlan = {
+    // 1) Replace the location of LogicalRelation with appended files
+    val complementIndexPlan = originalPlan transformDown {
+      case baseRelation @ LogicalRelation(
+            fsRelation @ HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _),
+            baseOutput,
+            _,
+            _) =>
+        // Set the same output schema with the index plan to merge them using BucketUnion
+        val updatedOutput =
+          baseOutput.filter(attr => index.schema.fieldNames.contains(attr.name))
+
+        val filesAppended = (location.allFiles
+          .map(f => FileInfo(f.getPath.toString, f.getLen, f.getModificationTime))
+          .toSet -- index.allSourceFileInfos).toSeq.map(f => new Path(f.name))
+
+        if (filesAppended.nonEmpty) {
+          val newLocation =
+            new InMemoryFileIndex(spark, filesAppended, Map(), None)
+          val newRelation =
+            fsRelation.copy(
+              location = newLocation,
+              dataSchema = StructType(index.schema.filter(baseRelation.schema.contains(_))))(
+              spark)
+          baseRelation.copy(relation = newRelation, output = updatedOutput)
+        } else {
+          baseRelation
+        }
+    }
+
+    if (!originalPlan.equals(complementIndexPlan)) {
+      // Remove sort order because we cannot guarantee the ordering of source files
+      val bucketSpec = index.bucketSpec.copy(sortColumnNames = Seq())
+
+      object ExtractTopLevelPlanForShuffle {
+        type returnType = (LogicalPlan, Seq[Option[Attribute]], Boolean)
+        def unapply(plan: LogicalPlan): Option[returnType] = plan match {
+          case project @ Project(
+                _,
+                Filter(_, LogicalRelation(HadoopFsRelation(_, _, _, _, _, _), _, _, _))) =>
+            val indexedAttrs = getIndexedAttrs(project, index.indexedColumns)
+            Some(project, indexedAttrs, true)
+          case project @ Project(
+                _,
+                LogicalRelation(HadoopFsRelation(_, _, _, _, _, _), _, _, _)) =>
+            val indexedAttrs = getIndexedAttrs(project, index.indexedColumns)
+            Some(project, indexedAttrs, true)
+          case filter @ Filter(_, LogicalRelation(HadoopFsRelation(_, _, _, _, _, _), _, _, _)) =>
+            val indexedAttrs = getIndexedAttrs(filter, index.indexedColumns)
+            Some(filter, indexedAttrs, false)
+          case relation @ LogicalRelation(HadoopFsRelation(_, _, _, _, _, _), _, _, _) =>
+            val indexedAttrs = getIndexedAttrs(relation, index.indexedColumns)
+            Some(relation, indexedAttrs, false)
+        }
+        def getIndexedAttrs(
+            plan: LogicalPlan,
+            indexedColumns: Seq[String]): Seq[Option[Attribute]] = {
+          val attrMap = plan.output.attrs.map(attr => (attr.name, attr)).toMap
+          indexedColumns.map(colName => attrMap.get(colName))
+        }
+      }
+
+      // 2) Perform on-the-fly Shuffle with the same partition structure of index
+      // so that we could avoid incurring Shuffle of whole index data at merge stage.
+      // In order to utilize push-down filters, we would locate Shuffle node after
+      // Project or Filter node. (Case 1)
+      // However, if Project node excludes any of indexedColumns, Shuffle will be
+      // converted to RoundRobinPartitioning which can cause wrong result issues.
+      // So Shuffle should be located before Project node in that case. (Case 2)
+      // Case 1) Shuffle => Project => Filter => Relation (Project&Filter will be pushed down)
+      // Case 2) Project => Shuffle => Filter => Relation (Filter will be pushed down)
+      var shuffleInjected = false
+      val shuffled = complementIndexPlan transformDown {
+        case p if shuffleInjected => p
+        case ExtractTopLevelPlanForShuffle(plan, indexedAttr, isProject)
+            if !isProject || indexedAttr.forall(_.isDefined) =>
+          shuffleInjected = true
+          RepartitionByExpression(indexedAttr.flatten, plan, index.numBuckets)
+      }
+      // 3) Merge index plan & newly shuffled plan by using bucket-aware union.
+      // Currently, BucketUnion does not keep the sort order within a bucket.
+      BucketUnion(Seq(indexPlan, shuffled), bucketSpec)
+    } else {
+      indexPlan
     }
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -154,11 +154,11 @@ object RuleUtils {
   }
 
   /**
-   * Transform the current plan to utilize index
+   * Transform the current plan to utilize index.
    * The transformed plan reads data from indexes instead of the source relations.
    * Bucketing information of the index is retained if useBucketSpec is true.
    *
-   * NOTE: This method currently only supports replacement of Scan Nodes i.e. Logical relations
+   * NOTE: This method currently only supports replacement of Scan Nodes i.e. Logical relations.
    *
    * @param spark Spark session.
    * @param index Index used in replacement plan.
@@ -233,7 +233,7 @@ object RuleUtils {
         // along with the index data.
         val readPaths = {
           if (useBucketSpec || !isParquetSourceFormat) {
-            // FilterIndexRule: since the index data is in "parquet" format, we cannot read
+            // FilterIndexRule: Since the index data is in "parquet" format, we cannot read
             // source files in formats other than "parquet" using 1 FileScan node as the
             // operator requires files in one homogenous format. To address this, we need
             // to read the appended source files using another FileScan node injected into
@@ -332,7 +332,7 @@ object RuleUtils {
   /**
    * Transform the plan to perform on-the-fly Shuffle the data based on bucketSpec.
    *
-   * Pre-requisites
+   * Pre-requisite
    * - The plan should be linear and include 1 LogicalRelation.
    *
    * @param bucketSpec Bucket specification used for Shuffle.
@@ -343,7 +343,7 @@ object RuleUtils {
       bucketSpec: BucketSpec,
       plan: LogicalPlan): LogicalPlan = {
     // Extract top level plan including all required columns for shuffle in its output.
-    // This is located inside this function because of bucketSpec.bucketColumnNames
+    // This is located inside this function because of bucketSpec.bucketColumnNames.
     object ExtractTopLevelPlanForShuffle {
       type returnType = (LogicalPlan, Seq[Option[Attribute]], Boolean)
       def unapply(plan: LogicalPlan): Option[returnType] = plan match {

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -213,9 +213,11 @@ object RuleUtils {
             baseOutput,
             _,
             _) =>
-        val curFileSet = location.allFiles
+        lazy val curFileSet = location.allFiles
           .map(f => FileInfo(f.getPath.toString, f.getLen, f.getModificationTime))
           .toSet
+        lazy val filesAppended =
+          (curFileSet -- index.allSourceFileInfos).map(f => new Path(f.name)).toSeq
 
         // if BucketSpec of index data isn't used (e.g., in the case of FilterIndex currently),
         // we could read appended data from source files along with the index data.
@@ -223,8 +225,6 @@ object RuleUtils {
           if (useBucketUnion) {
             index.content.files
           } else {
-            val filesAppended =
-              (curFileSet -- index.allSourceFileInfos).map(f => new Path(f.name)).toSeq
             index.content.files ++ filesAppended
           }
         }

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -239,7 +239,7 @@ object RuleUtils {
             index.content.files
           } else {
             // If BucketSpec of index data isn't used (e.g., in the case of FilterIndex currently)
-            // aud the source format is parquet, we could read the appended files along
+            // and the source format is parquet, we could read the appended files along
             // with the index data.
             val files = index.content.files ++ filesAppended
             files
@@ -275,7 +275,9 @@ object RuleUtils {
         // If Bucketing information of the index is used to read the index data, we need to
         // shuffle the appended data in the same way to correctly merge with bucketed index data.
 
-        // Clear sortColumnNames as BucketUnion does not keep the sort order within a bucket.
+        // Although only numBuckets of BucketSpec is used in BucketUnion*, bucketColumnNames
+        // and sortColumnNames are shown in plan string. So remove sortColumnNames to avoid
+        // misunderstanding.
         val bucketSpec = index.bucketSpec.copy(sortColumnNames = Nil)
 
         // Merge index plan & newly shuffled plan by using bucket-aware union.

--- a/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InMemoryFileIndex, LogicalRelation}
 
 import com.microsoft.hyperspace.{Hyperspace, Implicits, SampleData}
+import com.microsoft.hyperspace.index.execution.BucketUnionStrategy
 import com.microsoft.hyperspace.index.rules.{FilterIndexRule, JoinIndexRule}
 import com.microsoft.hyperspace.util.PathUtils
 
@@ -68,20 +69,30 @@ class E2EHyperspaceRulesTests extends HyperspaceSuite with SQLHelper {
 
   test("verify enableHyperspace()/disableHyperspace() plug in/out optimization rules.") {
     val expectedOptimizationRuleBatch = Seq(JoinIndexRule, FilterIndexRule)
+    val expectedOptimizationStrategy = Seq(BucketUnionStrategy)
 
     assert(
       !spark.sessionState.experimentalMethods.extraOptimizations
         .containsSlice(expectedOptimizationRuleBatch))
+    assert(
+      !spark.sessionState.experimentalMethods.extraStrategies
+        .containsSlice(expectedOptimizationStrategy))
 
     spark.enableHyperspace()
     assert(
       spark.sessionState.experimentalMethods.extraOptimizations
         .containsSlice(expectedOptimizationRuleBatch))
+    assert(
+      spark.sessionState.experimentalMethods.extraStrategies
+        .containsSlice(expectedOptimizationStrategy))
 
     spark.disableHyperspace()
     assert(
       !spark.sessionState.experimentalMethods.extraOptimizations
         .containsSlice(expectedOptimizationRuleBatch))
+    assert(
+      !spark.sessionState.experimentalMethods.extraStrategies
+        .containsSlice(expectedOptimizationStrategy))
   }
 
   test(

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
@@ -19,17 +19,18 @@ package com.microsoft.hyperspace.index
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Project, RepartitionByExpression, Union}
 import org.apache.spark.sql.execution.{FileSourceScanExec, ProjectExec, UnionExec}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.DataSourceRegister
+
 import com.microsoft.hyperspace.{Hyperspace, Implicits, SampleData}
 import com.microsoft.hyperspace.index.execution.BucketUnionExec
 import com.microsoft.hyperspace.index.plans.logical.BucketUnion
 import com.microsoft.hyperspace.util.FileUtils
-import org.apache.spark.sql.catalyst.expressions.Attribute
 
 class HybridScanTest extends QueryTest with HyperspaceSuite {
   override val systemPath = new Path("src/test/resources/hybridScanTest")

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
@@ -21,9 +21,10 @@ import scala.util.Try
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, QueryTest}
-import org.apache.spark.sql.execution.{FileSourceScanExec, InputAdapter, ProjectExec, WholeStageCodegenExec}
+import org.apache.spark.sql.catalyst.plans.logical.Union
+import org.apache.spark.sql.execution.{FileSourceScanExec, InputAdapter, ProjectExec, UnionExec, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.exchange.{ReusedExchangeExec, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.exchange.{Exchange, ReusedExchangeExec, ShuffleExchangeExec}
 
 import com.microsoft.hyperspace.{Hyperspace, Implicits, SampleData}
 import com.microsoft.hyperspace.index.execution.BucketUnionExec
@@ -203,27 +204,22 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
           assert(appendedFileCnt === 1 || indexFileCnt === 4)
           assert(appendedFileCnt * indexFileCnt === 0)
           p
-        case p @ BucketUnion(_, _) => p
+        case p @ Union(_) => p
       }
       assert(nodes.count(p => p.isInstanceOf[LogicalRelation]) === 2)
-      assert(nodes.count(p => p.isInstanceOf[BucketUnion]) === 1)
+      assert(nodes.count(p => p.isInstanceOf[Union]) === 1)
+      // Make sure there is no shuffle.
+      planWithHybridScan.foreach(f => assert(Try(f.asInstanceOf[Exchange]).isFailure))
 
       spark.enableHyperspace()
       val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
 
       val execNodes = execPlan collect {
-        case p @ BucketUnionExec(children, bucketSpec) =>
+        case p @ UnionExec(children) =>
           assert(children.size === 2)
           // head is always the index plan.
           assert(Try(children.head.asInstanceOf[WholeStageCodegenExec]).isSuccess)
           assert(Try(children.last.asInstanceOf[WholeStageCodegenExec]).isSuccess)
-          children.last match {
-            case WholeStageCodegenExec(
-                ProjectExec(_, InputAdapter(ShuffleExchangeExec(partitioning, _, _)))) =>
-              assert(partitioning.numPartitions === 200)
-            case _ => fail("Unexpected type of child of BucketUnion")
-          }
-          assert(bucketSpec.numBuckets === 200)
           p
         case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
           // Check filter pushed down properly.
@@ -231,7 +227,9 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
           p
       }
 
-      assert(execNodes.count(p => p.isInstanceOf[BucketUnionExec]) === 1)
+      // Make sure there is no shuffle.
+      execPlan.foreach(p => assert(Try(p.asInstanceOf[ShuffleExchangeExec]).isFailure))
+      assert(execNodes.count(p => p.isInstanceOf[UnionExec]) === 1)
       // 1 of index, 1 of appended file
       assert(execNodes.count(p => p.isInstanceOf[FileSourceScanExec]) === 2)
 

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
@@ -87,8 +87,9 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
     FileUtils.delete(new Path(sampleJsonDataLocation))
   }
 
-  test("Append-only: filter index & parquet format, " +
-    "index relation should include appended file paths") {
+  test(
+    "Append-only: filter index & parquet format, " +
+      "index relation should include appended file paths") {
     df = spark.read.parquet(sampleParquetDataLocation)
     val query = df.filter(df("clicks") <= 2000).select(df("query"))
 
@@ -119,8 +120,9 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
     }
   }
 
-  test("Append-only: join index, appended data should be shuffled with indexed columns " +
-    "and merged by BucketUnion") {
+  test(
+    "Append-only: join index, appended data should be shuffled with indexed columns " +
+      "and merged by BucketUnion") {
     df = spark.read.parquet(sampleParquetDataLocation)
     val query = df.filter(df("clicks") >= 2000).select(df("clicks"), df("query"))
     val query2 = df.filter(df("clicks") <= 4000).select(df("clicks"), df("query"))
@@ -180,8 +182,9 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
     }
   }
 
-  test("Append-only: filter rule & json format, " +
-    "appended data should be shuffled and merged by BucketUnion") {
+  test(
+    "Append-only: filter rule & json format, " +
+      "appended data should be shuffled and merged by Union") {
     df = spark.read.json(sampleJsonDataLocation)
     val query = df.filter(df("clicks") <= 2000).select(df("query"))
 

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
@@ -16,65 +16,73 @@
 
 package com.microsoft.hyperspace.index
 
-import scala.util.Try
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, QueryTest}
-import org.apache.spark.sql.catalyst.plans.logical.Union
-import org.apache.spark.sql.execution.{FileSourceScanExec, InputAdapter, ProjectExec, UnionExec, WholeStageCodegenExec}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, Project, RepartitionByExpression, Union}
+import org.apache.spark.sql.execution.{FileSourceScanExec, ProjectExec, UnionExec}
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.exchange.{Exchange, ReusedExchangeExec, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.DataSourceRegister
 
 import com.microsoft.hyperspace.{Hyperspace, Implicits, SampleData}
 import com.microsoft.hyperspace.index.execution.BucketUnionExec
 import com.microsoft.hyperspace.index.plans.logical.BucketUnion
-import com.microsoft.hyperspace.index.rules.{FilterIndexRule, JoinIndexRule}
 import com.microsoft.hyperspace.util.FileUtils
 
 class HybridScanTest extends QueryTest with HyperspaceSuite {
   override val systemPath = new Path("src/test/resources/hybridScanTest")
 
   private val sampleData = SampleData.testData
-  private val sampleParquetDataLocation = "src/test/resources/sampleparquet2"
-  private val sampleJsonDataLocation = "src/test/resources/samplejson"
-  private var df: DataFrame = _
+  private val sampleDataRoot = "src/test/resources/data/"
+  private val sampleParquetDataLocation = sampleDataRoot + "sampleparquet2"
+  private val sampleParquetDataLocation2 = sampleDataRoot + "sampleparquet3"
+  private val sampleJsonDataLocation = sampleDataRoot + "samplejson"
   private var hyperspace: Hyperspace = _
   private val indexConfig1 = IndexConfig("index1", Seq("clicks"), Seq("query"))
   private val indexConfig2 = IndexConfig("index2", Seq("clicks"), Seq("query"))
+  private val indexConfig3 = IndexConfig("index3", Seq("clicks"), Seq("Date"))
 
   private def copyFirstFile(df: DataFrame): Unit = {
-    val files = df.queryExecution.optimizedPlan.collect {
-      case LogicalRelation(
-          HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _),
-          _,
-          _,
-          _) =>
-        location.allFiles
-    }.flatten
-    val sourcePath = files.head.getPath
-    val destPath = new Path(files.head.getPath + ".copy")
-    sourcePath.getFileSystem(new Configuration).copyToLocalFile(sourcePath, destPath)
+    val file = df.inputFiles.head
+    val sourcePath = new Path(file)
+    val destPath = new Path(file + ".copy")
+    systemPath.getFileSystem(new Configuration).copyToLocalFile(sourcePath, destPath)
   }
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val sparkSession = spark
-    import sparkSession.implicits._
+    import spark.implicits._
     hyperspace = new Hyperspace(spark)
     FileUtils.delete(new Path(sampleParquetDataLocation))
     FileUtils.delete(new Path(sampleJsonDataLocation))
     val dfFromSample = sampleData.toDF("Date", "RGUID", "Query", "imprs", "clicks")
     dfFromSample.write.parquet(sampleParquetDataLocation)
+    dfFromSample.write.parquet(sampleParquetDataLocation2)
     dfFromSample.write.json(sampleJsonDataLocation)
 
-    df = spark.read.parquet(sampleParquetDataLocation)
-    hyperspace.createIndex(df, indexConfig1)
-    copyFirstFile(df)
+    {
+      val df = spark.read.parquet(sampleParquetDataLocation)
+      hyperspace.createIndex(df, indexConfig1)
+      copyFirstFile(df)
+    }
 
-    df = spark.read.json(sampleJsonDataLocation)
-    hyperspace.createIndex(df, indexConfig2)
-    copyFirstFile(df)
+    {
+      val df = spark.read.parquet(sampleParquetDataLocation2)
+      hyperspace.createIndex(df, indexConfig3)
+      copyFirstFile(df)
+    }
+
+    {
+      val df = spark.read.json(sampleJsonDataLocation)
+      hyperspace.createIndex(df, indexConfig2)
+      copyFirstFile(df)
+    }
+  }
+
+  before {
+    spark.enableHyperspace()
   }
 
   after {
@@ -83,101 +91,122 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
 
   override def afterAll(): Unit = {
     super.afterAll()
-    FileUtils.delete(new Path(sampleParquetDataLocation))
-    FileUtils.delete(new Path(sampleJsonDataLocation))
+    FileUtils.delete(new Path(sampleDataRoot))
   }
 
   test(
     "Append-only: filter index & parquet format, " +
       "index relation should include appended file paths") {
-    df = spark.read.parquet(sampleParquetDataLocation)
-    val query = df.filter(df("clicks") <= 2000).select(df("query"))
+    val df = spark.read.parquet(sampleParquetDataLocation)
+    def filterQuery: DataFrame =
+      df.filter(df("clicks") <= 2000).select(df("query"))
+    val baseQuery = filterQuery
 
     withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "false") {
-      val transformed = FilterIndexRule(query.queryExecution.optimizedPlan)
-      assert(transformed.equals(query.queryExecution.optimizedPlan), "No plan transformation.")
+      val filter = filterQuery
+      assert(baseQuery.queryExecution.optimizedPlan.equals(filter.queryExecution.optimizedPlan))
     }
 
     withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "true") {
-      val planWithHybridScan = FilterIndexRule(query.queryExecution.optimizedPlan)
-      assert(
-        !planWithHybridScan.equals(query.queryExecution.optimizedPlan),
-        "Plan should be transformed.")
+      val filter = filterQuery
+      val planWithHybridScan = filter.queryExecution.optimizedPlan
+      assert(!baseQuery.queryExecution.optimizedPlan.equals(planWithHybridScan))
 
       // Check appended file is added to relation node or not.
       val nodes = planWithHybridScan collect {
         case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
+          // Verify appended file is included or not.
           assert(fsRelation.location.inputFiles.count(_.contains(".copy")) === 1)
+          // Verify number of index data files.
           assert(fsRelation.location.inputFiles.count(_.contains("index1")) === 4)
           p
       }
+      // Filter Index and Parquet format source file can be handled with 1 LogicalRelation
       assert(nodes.length === 1)
-
-      spark.enableHyperspace()
-      val query2 = df.filter(df("clicks") <= 2000).select(df("query"))
-
-      checkAnswer(query2, query)
+      checkAnswer(baseQuery, filter)
     }
   }
 
   test(
     "Append-only: join index, appended data should be shuffled with indexed columns " +
       "and merged by BucketUnion") {
-    df = spark.read.parquet(sampleParquetDataLocation)
-    val query = df.filter(df("clicks") >= 2000).select(df("clicks"), df("query"))
-    val query2 = df.filter(df("clicks") <= 4000).select(df("clicks"), df("query"))
-    val join = query.join(query2, "clicks")
+    val df1 = spark.read.parquet(sampleParquetDataLocation)
+    val df2 = spark.read.parquet(sampleParquetDataLocation2)
+    def joinQuery(): DataFrame = {
+      val query = df1.filter(df1("clicks") >= 2000).select(df1("clicks"), df1("query"))
+      val query2 = df2.filter(df2("clicks") <= 4000).select(df2("clicks"), df2("Date"))
+      query.join(query2, "clicks")
+    }
+    val baseQuery = joinQuery()
 
     withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "-1") {
       withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "false") {
-        val transformed = JoinIndexRule(join.queryExecution.optimizedPlan)
-        assert(transformed.equals(join.queryExecution.optimizedPlan), "No plan transformation.")
+        val join = joinQuery()
+        assert(join.queryExecution.optimizedPlan.equals(baseQuery.queryExecution.optimizedPlan))
       }
 
       withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "true") {
-        val planWithHybridScan = JoinIndexRule(join.queryExecution.optimizedPlan)
-        assert(
-          !planWithHybridScan.equals(join.queryExecution.optimizedPlan),
-          "Plan should be transformed.")
+        val join = joinQuery()
+        val planWithHybridScan = join.queryExecution.optimizedPlan
+        assert(!baseQuery.queryExecution.optimizedPlan.equals(planWithHybridScan))
 
         // Check appended file is added to relation node or not.
         val nodes = planWithHybridScan collect {
-          case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
-            val appendedFileCnt = fsRelation.location.inputFiles.count(_.contains(".copy"))
-            val indexFileCnt = fsRelation.location.inputFiles.count(_.contains("index1"))
-            assert(appendedFileCnt === 1 || indexFileCnt === 4)
-            assert(appendedFileCnt * indexFileCnt === 0)
-            p
-          case p @ BucketUnion(_, _) => p
-        }
-        assert(nodes.count(p => p.isInstanceOf[LogicalRelation]) === 4)
-        assert(nodes.count(p => p.isInstanceOf[BucketUnion]) === 2)
-
-        spark.enableHyperspace()
-        val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
-        val execNodes = execPlan collect {
-          case p @ BucketUnionExec(children, bucketSpec) =>
-            assert(children.size === 2)
-            // head is always the index plan.
-            assert(Try(children.head.asInstanceOf[WholeStageCodegenExec]).isSuccess)
-            assert(
-              Try(children.last.asInstanceOf[ShuffleExchangeExec]).isSuccess || Try(
-                children.last.asInstanceOf[ReusedExchangeExec]).isSuccess)
+          case b @ BucketUnion(children, bucketSpec) =>
             assert(bucketSpec.numBuckets === 200)
-            p
-          case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
-            // Check filter pushed down properly.
             assert(
-              dataFilters.toString.contains(" >= 2000)") && dataFilters.toString.contains(
-                " <= 4000)"))
-            p
-        }
-        assert(execNodes.count(p => p.isInstanceOf[BucketUnionExec]) === 2)
-        // 2 of index, 1 of appended file (1 is reused)
-        assert(execNodes.count(p => p.isInstanceOf[FileSourceScanExec]) === 3)
+              bucketSpec.bucketColumnNames.size == 1 && bucketSpec.bucketColumnNames.head
+                .equals("clicks"))
 
-        val join2 = query.join(query2, "clicks")
-        checkAnswer(join2, join)
+            val childNodes = children collect {
+              case r @ RepartitionByExpression(
+                    _,
+                    Project(_, Filter(_, LogicalRelation(fsRelation: HadoopFsRelation, _, _, _))),
+                    numBucket: Int) =>
+                // Check 1 appended file.
+                assert(fsRelation.location.inputFiles.count(_.contains(".copy")) === 1)
+                assert(numBucket === 200)
+                r
+              case p @ Project(
+                    _,
+                    Filter(_, LogicalRelation(fsRelation: HadoopFsRelation, _, _, _))) =>
+                // Check 4 of index data files.
+                assert(fsRelation.location.inputFiles.count(_.contains("index")) === 4)
+                p
+            }
+
+            // BucketUnion has 2 children.
+            assert(childNodes.size === 2)
+            assert(childNodes.count(_.isInstanceOf[Project]) == 1)
+            assert(childNodes.count(_.isInstanceOf[RepartitionByExpression]) == 1)
+            b
+        }
+        // 2 BucketUnion in Join Rule v1.
+        assert(nodes.count(_.isInstanceOf[BucketUnion]) === 2)
+
+        withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false") {
+          val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
+          val execNodes = execPlan collect {
+            case p @ BucketUnionExec(children, bucketSpec) =>
+              assert(children.size === 2)
+              // children.head is always the index plan.
+              assert(children.head.isInstanceOf[ProjectExec])
+              assert(children.last.isInstanceOf[ShuffleExchangeExec])
+              assert(bucketSpec.numBuckets === 200)
+              p
+            case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
+              // Check filter pushed down properly.
+              assert(
+                dataFilters.toString.contains(" >= 2000)") && dataFilters.toString.contains(
+                  " <= 4000)"))
+              p
+          }
+          assert(execNodes.count(_.isInstanceOf[BucketUnionExec]) === 2)
+          // 2 of index, 2 of appended file
+          assert(execNodes.count(_.isInstanceOf[FileSourceScanExec]) === 4)
+
+          checkAnswer(join, baseQuery)
+        }
       }
     }
   }
@@ -185,59 +214,72 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
   test(
     "Append-only: filter rule & json format, " +
       "appended data should be shuffled and merged by Union") {
-    df = spark.read.json(sampleJsonDataLocation)
-    val query = df.filter(df("clicks") <= 2000).select(df("query"))
+    val df = spark.read.json(sampleJsonDataLocation)
+    def filterQuery: DataFrame = df.filter(df("clicks") <= 2000).select(df("query"))
+    val baseQuery = filterQuery
 
     withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "false") {
-      val transformed = FilterIndexRule(query.queryExecution.optimizedPlan)
-      assert(transformed.equals(query.queryExecution.optimizedPlan), "No plan transformation.")
+      val filter = filterQuery
+      assert(baseQuery.queryExecution.optimizedPlan.equals(filter.queryExecution.optimizedPlan))
     }
 
     withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "true") {
-      val planWithHybridScan = FilterIndexRule(query.queryExecution.optimizedPlan)
-      assert(
-        !planWithHybridScan.equals(query.queryExecution.optimizedPlan),
-        "Plan should be transformed.")
+      val filter = filterQuery
+      val planWithHybridScan = filter.queryExecution.optimizedPlan
+      assert(!baseQuery.queryExecution.optimizedPlan.equals(planWithHybridScan))
 
       // Check appended file is added to relation node or not.
       val nodes = planWithHybridScan collect {
-        case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
-          val appendedFileCnt = fsRelation.location.inputFiles.count(_.contains(".copy"))
-          val indexFileCnt = fsRelation.location.inputFiles.count(_.contains("index2"))
-          assert(appendedFileCnt === 1 || indexFileCnt === 4)
-          assert(appendedFileCnt * indexFileCnt === 0)
-          p
-        case p @ Union(_) => p
-      }
-      assert(nodes.count(p => p.isInstanceOf[LogicalRelation]) === 2)
-      assert(nodes.count(p => p.isInstanceOf[Union]) === 1)
-      // Make sure there is no shuffle.
-      planWithHybridScan.foreach(f => assert(Try(f.asInstanceOf[Exchange]).isFailure))
+        case u @ Union(children) =>
+          val formats = children collect {
+            case Project(_, Filter(_, LogicalRelation(fsRelation: HadoopFsRelation, _, _, _))) =>
+              val fileFormatName = fsRelation.fileFormat match {
+                case d: DataSourceRegister => d.shortName
+                case _ => fail("Unexpected file format")
+              }
+              fileFormatName match {
+                case "parquet" =>
+                  // Check 4 of index data files.
+                  assert(fsRelation.location.inputFiles.count(_.contains("index")) === 4)
+                case "json" =>
+                  // Check 1 appended file.
+                  assert(fsRelation.location.inputFiles.count(_.contains(".copy")) === 1)
+                case _ => fail("Unexpected file format")
+              }
+              fileFormatName
+          }
 
-      spark.enableHyperspace()
-      val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
-
-      val execNodes = execPlan collect {
-        case p @ UnionExec(children) =>
-          assert(children.size === 2)
-          // head is always the index plan.
-          assert(Try(children.head.asInstanceOf[WholeStageCodegenExec]).isSuccess)
-          assert(Try(children.last.asInstanceOf[WholeStageCodegenExec]).isSuccess)
-          p
-        case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
-          // Check filter pushed down properly.
-          assert(dataFilters.toString.contains(" <= 2000)"))
-          p
+          // Union has 2 children.
+          assert(formats.size === 2)
+          assert(formats.contains("parquet") && formats.contains("json"))
+          u
       }
+      assert(nodes.count(_.isInstanceOf[Union]) === 1)
 
       // Make sure there is no shuffle.
-      execPlan.foreach(p => assert(Try(p.asInstanceOf[ShuffleExchangeExec]).isFailure))
-      assert(execNodes.count(p => p.isInstanceOf[UnionExec]) === 1)
-      // 1 of index, 1 of appended file
-      assert(execNodes.count(p => p.isInstanceOf[FileSourceScanExec]) === 2)
+      planWithHybridScan.foreach(p => assert(!p.isInstanceOf[RepartitionByExpression]))
 
-      val query2 = df.filter(df("clicks") <= 2000).select(df("query"))
-      checkAnswer(query, query2)
+      withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false") {
+        val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
+        val execNodes = execPlan collect {
+          case p @ UnionExec(children) =>
+            assert(children.size === 2)
+            assert(children.head.isInstanceOf[ProjectExec]) // index data
+            assert(children.last.isInstanceOf[ProjectExec]) // appended data
+            p
+          case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
+            // Check filter pushed down properly.
+            assert(dataFilters.toString.contains(" <= 2000)"))
+            p
+        }
+        assert(execNodes.count(_.isInstanceOf[UnionExec]) === 1)
+        // 1 of index, 1 of appended file
+        assert(execNodes.count(_.isInstanceOf[FileSourceScanExec]) === 2)
+        // Make sure there is no shuffle.
+        execPlan.foreach(p => assert(!p.isInstanceOf[ShuffleExchangeExec]))
+
+        checkAnswer(baseQuery, filter)
+      }
     }
   }
 }

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
@@ -102,7 +102,7 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
         !planWithHybridScan.equals(query.queryExecution.optimizedPlan),
         "Plan should be transformed.")
 
-      // check appended file is added to relation node or not
+      // Check appended file is added to relation node or not.
       val nodes = planWithHybridScan collect {
         case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
           assert(fsRelation.location.inputFiles.count(_.contains(".copy")) === 1)
@@ -137,7 +137,7 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
           !planWithHybridScan.equals(join.queryExecution.optimizedPlan),
           "Plan should be transformed.")
 
-        // check appended file is added to relation node or not
+        // Check appended file is added to relation node or not.
         val nodes = planWithHybridScan collect {
           case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
             val appendedFileCnt = fsRelation.location.inputFiles.count(_.contains(".copy"))
@@ -155,7 +155,7 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
         val execNodes = execPlan collect {
           case p @ BucketUnionExec(children, bucketSpec) =>
             assert(children.size === 2)
-            // head is always the index plan
+            // head is always the index plan.
             assert(Try(children.head.asInstanceOf[WholeStageCodegenExec]).isSuccess)
             assert(
               Try(children.last.asInstanceOf[ShuffleExchangeExec]).isSuccess || Try(
@@ -163,7 +163,7 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
             assert(bucketSpec.numBuckets === 200)
             p
           case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
-            // check filter pushed down properly
+            // Check filter pushed down properly.
             assert(
               dataFilters.toString.contains(" >= 2000)") && dataFilters.toString.contains(
                 " <= 4000)"))
@@ -195,7 +195,7 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
         !planWithHybridScan.equals(query.queryExecution.optimizedPlan),
         "Plan should be transformed.")
 
-      // check appended file is added to relation node or not
+      // Check appended file is added to relation node or not.
       val nodes = planWithHybridScan collect {
         case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
           val appendedFileCnt = fsRelation.location.inputFiles.count(_.contains(".copy"))
@@ -214,7 +214,7 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
       val execNodes = execPlan collect {
         case p @ BucketUnionExec(children, bucketSpec) =>
           assert(children.size === 2)
-          // head is always the index plan
+          // head is always the index plan.
           assert(Try(children.head.asInstanceOf[WholeStageCodegenExec]).isSuccess)
           assert(Try(children.last.asInstanceOf[WholeStageCodegenExec]).isSuccess)
           children.last match {
@@ -226,7 +226,7 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
           assert(bucketSpec.numBuckets === 200)
           p
         case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
-          // check filter pushed down properly
+          // Check filter pushed down properly.
           assert(dataFilters.toString.contains(" <= 2000)"))
           p
       }

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
@@ -147,8 +147,8 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
             p
           case p @ BucketUnion(_, _) => p
         }
-        assert(nodes.count(p => p.getClass.toString.contains("LogicalRelation")) === 4)
-        assert(nodes.count(p => p.getClass.toString.contains("BucketUnion")) === 2)
+        assert(nodes.count(p => p.isInstanceOf[LogicalRelation]) === 4)
+        assert(nodes.count(p => p.isInstanceOf[BucketUnion]) === 2)
 
         spark.enableHyperspace()
         val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
@@ -169,9 +169,9 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
                 " <= 4000)"))
             p
         }
-        assert(execNodes.count(p => p.getClass.toString.contains("BucketUnionExec")) === 2)
+        assert(execNodes.count(p => p.isInstanceOf[BucketUnionExec]) === 2)
         // 2 of index, 1 of appended file (1 is reused)
-        assert(execNodes.count(p => p.getClass.toString.contains("FileSourceScanExec")) === 3)
+        assert(execNodes.count(p => p.isInstanceOf[FileSourceScanExec]) === 3)
 
         val join2 = query.join(query2, "clicks")
         checkAnswer(join2, join)
@@ -205,8 +205,8 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
           p
         case p @ BucketUnion(_, _) => p
       }
-      assert(nodes.count(p => p.getClass.toString.contains("LogicalRelation")) === 2)
-      assert(nodes.count(p => p.getClass.toString.contains("BucketUnion")) === 1)
+      assert(nodes.count(p => p.isInstanceOf[LogicalRelation]) === 2)
+      assert(nodes.count(p => p.isInstanceOf[BucketUnion]) === 1)
 
       spark.enableHyperspace()
       val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
@@ -231,9 +231,9 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
           p
       }
 
-      assert(execNodes.count(p => p.getClass.toString.contains("BucketUnionExec")) === 1)
+      assert(execNodes.count(p => p.isInstanceOf[BucketUnionExec]) === 1)
       // 1 of index, 1 of appended file
-      assert(execNodes.count(p => p.getClass.toString.contains("FileSourceScanExec")) === 2)
+      assert(execNodes.count(p => p.isInstanceOf[FileSourceScanExec]) === 2)
 
       val query2 = df.filter(df("clicks") <= 2000).select(df("query"))
       checkAnswer(query, query2)

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
@@ -86,7 +86,8 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
     FileUtils.delete(new Path(sampleJsonDataLocation))
   }
 
-  test("HybridScan filter rule test") {
+  test("Append-only: filter index & parquet format, " +
+    "index relation should include appended file paths") {
     df = spark.read.parquet(sampleParquetDataLocation)
     val query = df.filter(df("clicks") <= 2000).select(df("query"))
 
@@ -117,7 +118,8 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
     }
   }
 
-  test("HybridScan join rule test") {
+  test("Append-only: join index, appended data should be shuffled with indexed columns " +
+    "and merged by BucketUnion") {
     df = spark.read.parquet(sampleParquetDataLocation)
     val query = df.filter(df("clicks") >= 2000).select(df("clicks"), df("query"))
     val query2 = df.filter(df("clicks") <= 4000).select(df("clicks"), df("query"))
@@ -177,7 +179,8 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
     }
   }
 
-  test("HybridScan filter rule test with Json input") {
+  test("Append-only: filter rule & json format, " +
+    "appended data should be shuffled and merged by BucketUnion") {
     df = spark.read.json(sampleJsonDataLocation)
     val query = df.filter(df("clicks") <= 2000).select(df("query"))
     val expectedResult = query.collect

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
@@ -1,0 +1,252 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index
+
+import scala.util.Try
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.execution.{FileSourceScanExec, InputAdapter, ProjectExec, WholeStageCodegenExec}
+import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.exchange.{ReusedExchangeExec, ShuffleExchangeExec}
+
+import com.microsoft.hyperspace.{Hyperspace, Implicits, SampleData}
+import com.microsoft.hyperspace.index.execution.BucketUnionExec
+import com.microsoft.hyperspace.index.plans.logical.BucketUnion
+import com.microsoft.hyperspace.index.rules.{FilterIndexRule, JoinIndexRule}
+import com.microsoft.hyperspace.util.FileUtils
+
+class HybridScanTest extends QueryTest with HyperspaceSuite {
+  override val systemPath = new Path("src/test/resources/hybridScanTest")
+
+  private val sampleData = SampleData.testData
+  private val sampleParquetDataLocation = "src/test/resources/sampleparquet2"
+  private val sampleJsonDataLocation = "src/test/resources/samplejson"
+  private var df: DataFrame = _
+  private var hyperspace: Hyperspace = _
+  private val indexConfig1 = IndexConfig("index1", Seq("clicks"), Seq("query"))
+  private val indexConfig2 = IndexConfig("index2", Seq("clicks"), Seq("query"))
+
+  private def copyFirstFile(df: DataFrame): Unit = {
+    val files = df.queryExecution.optimizedPlan.collect {
+      case LogicalRelation(
+          HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _),
+          _,
+          _,
+          _) =>
+        location.allFiles
+    }.flatten
+    val sourcePath = files.head.getPath
+    val destPath = new Path(files.head.getPath + ".copy")
+    sourcePath.getFileSystem(new Configuration).copyToLocalFile(sourcePath, destPath)
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    val sparkSession = spark
+    import sparkSession.implicits._
+    hyperspace = new Hyperspace(spark)
+    FileUtils.delete(new Path(sampleParquetDataLocation))
+    FileUtils.delete(new Path(sampleJsonDataLocation))
+    val dfFromSample = sampleData.toDF("Date", "RGUID", "Query", "imprs", "clicks")
+    dfFromSample.write.parquet(sampleParquetDataLocation)
+    dfFromSample.write.json(sampleJsonDataLocation)
+
+    df = spark.read.parquet(sampleParquetDataLocation)
+    hyperspace.createIndex(df, indexConfig1)
+    copyFirstFile(df)
+
+    df = spark.read.json(sampleJsonDataLocation)
+    hyperspace.createIndex(df, indexConfig2)
+    copyFirstFile(df)
+  }
+
+  after {
+    spark.disableHyperspace()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    FileUtils.delete(new Path(sampleParquetDataLocation))
+    FileUtils.delete(new Path(sampleJsonDataLocation))
+  }
+
+  test("HybridScan filter rule test") {
+    df = spark.read.parquet(sampleParquetDataLocation)
+    val query = df.filter(df("clicks") <= 2000).select(df("query"))
+    val expectedResult = query.collect
+
+    withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "false") {
+      val transformed = FilterIndexRule(query.queryExecution.optimizedPlan)
+      assert(transformed.equals(query.queryExecution.optimizedPlan), "No plan transformation.")
+    }
+
+    withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "true") {
+      val planWithHybridScan = FilterIndexRule(query.queryExecution.optimizedPlan)
+      assert(
+        !planWithHybridScan.equals(query.queryExecution.optimizedPlan),
+        "Plan should be transformed.")
+
+      // check appended file is added to relation node or not
+      val nodes = planWithHybridScan collect {
+        case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
+          assert(fsRelation.location.inputFiles.count(_.contains(".copy")) === 1)
+          assert(fsRelation.location.inputFiles.count(_.contains("index1")) === 4)
+          p
+      }
+      assert(nodes.length === 1)
+
+      spark.enableHyperspace()
+      val query2 = df.filter(df("clicks") <= 2000).select(df("query"))
+      val res = query2.collect()
+
+      assert(expectedResult.nonEmpty)
+      assert(res.nonEmpty)
+      assert(expectedResult.sortBy(_.toString).toSeq === res.sortBy(_.toString).toSeq)
+    }
+  }
+
+  test("HybridScan join rule test") {
+    df = spark.read.parquet(sampleParquetDataLocation)
+    val query = df.filter(df("clicks") >= 2000).select(df("clicks"), df("query"))
+    val query2 = df.filter(df("clicks") <= 4000).select(df("clicks"), df("query"))
+    val join = query.join(query2, "clicks")
+    val expectedResult = join.collect()
+
+    withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "-1") {
+      withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "false") {
+        val transformed = JoinIndexRule(join.queryExecution.optimizedPlan)
+        assert(transformed.equals(join.queryExecution.optimizedPlan), "No plan transformation.")
+      }
+
+      withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "true") {
+        val planWithHybridScan = JoinIndexRule(join.queryExecution.optimizedPlan)
+        assert(
+          !planWithHybridScan.equals(join.queryExecution.optimizedPlan),
+          "Plan should be transformed.")
+
+        // check appended file is added to relation node or not
+        val nodes = planWithHybridScan collect {
+          case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
+            val appendedFileCnt = fsRelation.location.inputFiles.count(_.contains(".copy"))
+            val indexFileCnt = fsRelation.location.inputFiles.count(_.contains("index1"))
+            assert(appendedFileCnt === 1 || indexFileCnt === 4)
+            assert(appendedFileCnt * indexFileCnt === 0)
+            p
+          case p @ BucketUnion(_, _) => p
+        }
+        assert(nodes.count(p => p.getClass.toString.contains("LogicalRelation")) === 4)
+        assert(nodes.count(p => p.getClass.toString.contains("BucketUnion")) === 2)
+
+        spark.enableHyperspace()
+        val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
+        val execNodes = execPlan collect {
+          case p @ BucketUnionExec(children, bucketSpec) =>
+            assert(children.size === 2)
+            // head is always the index plan
+            assert(Try(children.head.asInstanceOf[WholeStageCodegenExec]).isSuccess)
+            assert(
+              Try(children.last.asInstanceOf[ShuffleExchangeExec]).isSuccess || Try(
+                children.last.asInstanceOf[ReusedExchangeExec]).isSuccess)
+            assert(bucketSpec.numBuckets === 200)
+            p
+          case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
+            // check filter pushed down properly
+            assert(
+              dataFilters.toString.contains(" >= 2000)") && dataFilters.toString.contains(
+                " <= 4000)"))
+            p
+        }
+        assert(execNodes.count(p => p.getClass.toString.contains("BucketUnionExec")) === 2)
+        // 2 of index, 1 of appended file (1 is reused)
+        assert(execNodes.count(p => p.getClass.toString.contains("FileSourceScanExec")) === 3)
+
+        val join2 = query.join(query2, "clicks")
+        val res = join2.collect()
+
+        assert(expectedResult.nonEmpty)
+        assert(res.nonEmpty)
+        assert(expectedResult.sortBy(_.toString).toSeq === res.sortBy(_.toString).toSeq)
+      }
+    }
+  }
+
+  test("HybridScan filter rule test with Json input") {
+    df = spark.read.json(sampleJsonDataLocation)
+    val query = df.filter(df("clicks") <= 2000).select(df("query"))
+    val expectedResult = query.collect
+
+    withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "false") {
+      val transformed = FilterIndexRule(query.queryExecution.optimizedPlan)
+      assert(transformed.equals(query.queryExecution.optimizedPlan), "No plan transformation.")
+    }
+
+    withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "true") {
+      val planWithHybridScan = FilterIndexRule(query.queryExecution.optimizedPlan)
+      assert(
+        !planWithHybridScan.equals(query.queryExecution.optimizedPlan),
+        "Plan should be transformed.")
+
+      // check appended file is added to relation node or not
+      val nodes = planWithHybridScan collect {
+        case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
+          val appendedFileCnt = fsRelation.location.inputFiles.count(_.contains(".copy"))
+          val indexFileCnt = fsRelation.location.inputFiles.count(_.contains("index2"))
+          assert(appendedFileCnt === 1 || indexFileCnt === 4)
+          assert(appendedFileCnt * indexFileCnt === 0)
+          p
+        case p @ BucketUnion(_, _) => p
+      }
+      assert(nodes.count(p => p.getClass.toString.contains("LogicalRelation")) === 2)
+      assert(nodes.count(p => p.getClass.toString.contains("BucketUnion")) === 1)
+
+      spark.enableHyperspace()
+      val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
+
+      val execNodes = execPlan collect {
+        case p @ BucketUnionExec(children, bucketSpec) =>
+          assert(children.size === 2)
+          // head is always the index plan
+          assert(Try(children.head.asInstanceOf[WholeStageCodegenExec]).isSuccess)
+          assert(Try(children.last.asInstanceOf[WholeStageCodegenExec]).isSuccess)
+          children.last match {
+            case WholeStageCodegenExec(
+                ProjectExec(_, InputAdapter(ShuffleExchangeExec(partitioning, _, _)))) =>
+              assert(partitioning.numPartitions === 200)
+            case _ => fail("Unexpected type of child of BucketUnion")
+          }
+          assert(bucketSpec.numBuckets === 200)
+          p
+        case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
+          // check filter pushed down properly
+          assert(dataFilters.toString.contains(" <= 2000)"))
+          p
+      }
+
+      assert(execNodes.count(p => p.getClass.toString.contains("BucketUnionExec")) === 1)
+      // 1 of index, 1 of appended file
+      assert(execNodes.count(p => p.getClass.toString.contains("FileSourceScanExec")) === 2)
+
+      val query2 = df.filter(df("clicks") <= 2000).select(df("query"))
+      val res = query2.collect()
+      assert(expectedResult.nonEmpty)
+      assert(res.nonEmpty)
+      assert(expectedResult.sortBy(_.toString).toSeq === res.sortBy(_.toString).toSeq)
+    }
+  }
+}

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
@@ -183,7 +183,6 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
     "appended data should be shuffled and merged by BucketUnion") {
     df = spark.read.json(sampleJsonDataLocation)
     val query = df.filter(df("clicks") <= 2000).select(df("query"))
-    val expectedResult = query.collect
 
     withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "false") {
       val transformed = FilterIndexRule(query.queryExecution.optimizedPlan)
@@ -237,10 +236,7 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
       assert(execNodes.count(p => p.getClass.toString.contains("FileSourceScanExec")) === 2)
 
       val query2 = df.filter(df("clicks") <= 2000).select(df("query"))
-      val res = query2.collect()
-      assert(expectedResult.nonEmpty)
-      assert(res.nonEmpty)
-      assert(expectedResult.sortBy(_.toString).toSeq === res.sortBy(_.toString).toSeq)
+      checkAnswer(query, query2)
     }
   }
 }

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -152,7 +152,6 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
         verify(optimizedPlan, hybridScanEnabled = true, expectCandidateIndex = true)
       }
 
-      /* Disabled delete scenario until the feature is delivered.
       // Scenario #2: Delete 1 file.
       {
         val readDf = spark.read.parquet(dataPath)
@@ -168,12 +167,12 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
           case _ =>
         }
       }
-       */
 
       {
         val optimizedPlan = spark.read.parquet(dataPath).queryExecution.optimizedPlan
         verify(optimizedPlan, hybridScanEnabled = false, expectCandidateIndex = false)
-        verify(optimizedPlan, hybridScanEnabled = true, expectCandidateIndex = true)
+        // TODO: expectedCandidateIndex = true for delete dataset support.
+        verify(optimizedPlan, hybridScanEnabled = true, expectCandidateIndex = false)
       }
 
       // Scenario #3: Replace all files.

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -88,13 +88,13 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
   test("Verify indexes are matched by signature correctly.") {
     val indexManager = IndexCollectionManager(spark)
 
-    assert(RuleUtils.getCandidateIndexes(indexManager, t1ProjectNode).length === 3)
-    assert(RuleUtils.getCandidateIndexes(indexManager, t2ProjectNode).length === 2)
+    assert(RuleUtils.getCandidateIndexes(indexManager, t1ProjectNode, false).length === 3)
+    assert(RuleUtils.getCandidateIndexes(indexManager, t2ProjectNode, false).length === 2)
 
     // Delete an index for t1ProjectNode
     indexManager.delete("t1i1")
 
-    assert(RuleUtils.getCandidateIndexes(indexManager, t1ProjectNode).length === 2)
+    assert(RuleUtils.getCandidateIndexes(indexManager, t1ProjectNode, false).length === 2)
   }
 
   test("Verify get logical relation for single logical relation node plan.") {

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -228,7 +228,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
     assert(shuffled2.collect {
       case Project(
           _,
-          RepartitionByExpression(attrs: Seq[Expression], _: Filter, numBuckets: Int)) =>
+          RepartitionByExpression(attrs, _: Filter, numBuckets)) =>
         assert(numBuckets == 100)
         assert(attrs.size == 1)
         assert(attrs.head.asInstanceOf[Attribute].name.contains("age"))

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -19,7 +19,7 @@ package com.microsoft.hyperspace.index.rules
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileUtil, Path}
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, IsNotNull, LessThanOrEqual}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, IsNotNull}
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Join, LogicalPlan, Project, RepartitionByExpression}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InMemoryFileIndex, LogicalRelation, NoopCache, PartitioningAwareFileIndex}
@@ -191,7 +191,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
     val df = spark.read.parquet(dataPath)
     val query = df.filter(df("id") >= 3).select("id", "name")
     val bucketSpec = BucketSpec(100, Seq("id"), Seq())
-    val shuffled = RuleUtils.transformPlanToShuffleUsingIndexSpec(
+    val shuffled = RuleUtils.transformPlanToShuffleUsingBucketSpec(
       bucketSpec,
       query.queryExecution.optimizedPlan)
 
@@ -222,7 +222,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
     val bucketSpec2 = BucketSpec(100, Seq("age"), Seq())
     val query2 = df.filter(df("id") <= 3).select("id", "name")
     val shuffled2 =
-      RuleUtils.transformPlanToShuffleUsingIndexSpec(
+      RuleUtils.transformPlanToShuffleUsingBucketSpec(
         bucketSpec2,
         query2.queryExecution.optimizedPlan)
     assert(shuffled2.collect {

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -152,6 +152,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
         verify(optimizedPlan, hybridScanEnabled = true, expectCandidateIndex = true)
       }
 
+      /* Disabled delete scenario until the feature is delivered.
       // Scenario #2: Delete 1 file.
       {
         val readDf = spark.read.parquet(dataPath)
@@ -167,6 +168,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
           case _ =>
         }
       }
+       */
 
       {
         val optimizedPlan = spark.read.parquet(dataPath).queryExecution.optimizedPlan

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -171,7 +171,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
       {
         val optimizedPlan = spark.read.parquet(dataPath).queryExecution.optimizedPlan
         verify(optimizedPlan, hybridScanEnabled = false, expectCandidateIndex = false)
-        // TODO: expectedCandidateIndex = true for delete dataset support.
+        // TODO: expectedCandidateIndex = true once delete dataset is supported.
         verify(optimizedPlan, hybridScanEnabled = true, expectCandidateIndex = false)
       }
 

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -16,10 +16,10 @@
 
 package com.microsoft.hyperspace.index.rules
 
-import org.apache.hadoop.fs.{FileUtil, Path}
+import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, IsNotNull}
-import org.apache.spark.sql.catalyst.plans.JoinType
+import org.apache.spark.sql.catalyst.plans.{JoinType, SQLHelper}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Join, LogicalPlan, Project, RepartitionByExpression}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InMemoryFileIndex, LogicalRelation, NoopCache}
 import org.apache.spark.sql.types.{IntegerType, StringType}
@@ -27,7 +27,7 @@ import org.apache.spark.sql.types.{IntegerType, StringType}
 import com.microsoft.hyperspace.index.{IndexCollectionManager, IndexConfig}
 import com.microsoft.hyperspace.util.{FileUtils, PathUtils}
 
-class RuleUtilsTest extends HyperspaceRuleTestSuite {
+class RuleUtilsTest extends HyperspaceRuleTestSuite with SQLHelper {
   override val systemPath = PathUtils.makeAbsolute("src/test/resources/ruleUtilsTest")
 
   val t1c1 = AttributeReference("t1c1", IntegerType)()
@@ -112,10 +112,10 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
   }
 
   test("Verify getCandidateIndex for hybrid scan") {
-    withTempDir { tempDir =>
+    withTempPath { tempPath =>
       val indexManager = IndexCollectionManager(spark)
       val df = spark.range(1, 5).toDF("id")
-      val dataPath = tempDir.toString + "/table"
+      val dataPath = tempPath.getAbsolutePath
       df.write.parquet(dataPath)
 
       withIndex("index1") {
@@ -179,8 +179,8 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
   }
 
   test("Verify the location of injected shuffle for Hybrid Scan.") {
-    withTempDir { tempDir =>
-      val dataPath = tempDir.toString + "/table"
+    withTempPath { tempPath =>
+      val dataPath = tempPath.getAbsolutePath
       import spark.implicits._
       Seq((1, "name1", 12), (2, "name2", 10))
         .toDF("id", "name", "age")

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -191,7 +191,9 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
     val df = spark.read.parquet(dataPath)
     val query = df.filter(df("id") >= 3).select("id", "name")
     val bucketSpec = BucketSpec(100, Seq("id"), Seq())
-    val shuffled = RuleUtils.shuffleUsingIndexSpec(bucketSpec, query.queryExecution.optimizedPlan)
+    val shuffled = RuleUtils.transformPlanToShuffleUsingIndexSpec(
+      bucketSpec,
+      query.queryExecution.optimizedPlan)
 
     assert((shuffled collect {
       case RepartitionByExpression(attrs: Seq[Expression], p: Project, numBuckets: Int) =>
@@ -206,7 +208,9 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
     val bucketSpec2 = BucketSpec(100, Seq("age"), Seq())
     val query2 = df.filter(df("id") <= 3).select("id", "name")
     val shuffled2 =
-      RuleUtils.shuffleUsingIndexSpec(bucketSpec2, query2.queryExecution.optimizedPlan)
+      RuleUtils.transformPlanToShuffleUsingIndexSpec(
+        bucketSpec2,
+        query2.queryExecution.optimizedPlan)
     assert((shuffled2 collect {
       case Project(
           _,

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -115,7 +115,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
     withTempDir { tempDir =>
       val indexManager = IndexCollectionManager(spark)
       val df = spark.range(1, 5).toDF("id")
-      val dataPath = tempDir + "/hbtable"
+      val dataPath = tempDir.toString
       df.write.parquet(dataPath)
 
       withIndex("index1") {
@@ -180,7 +180,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
 
   test("Verify the location of injected shuffle for Hybrid Scan.") {
     withTempDir { tempDir =>
-      val dataPath = tempDir + "/hbtable"
+      val dataPath = tempDir.toString
       import spark.implicits._
       Seq((1, "name1", 12), (2, "name2", 10))
         .toDF("id", "name", "age")

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -115,7 +115,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
     withTempDir { tempDir =>
       val indexManager = IndexCollectionManager(spark)
       val df = spark.range(1, 5).toDF("id")
-      val dataPath = tempDir.toString
+      val dataPath = tempDir.toString + "/table"
       df.write.parquet(dataPath)
 
       withIndex("index1") {
@@ -180,7 +180,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
 
   test("Verify the location of injected shuffle for Hybrid Scan.") {
     withTempDir { tempDir =>
-      val dataPath = tempDir.toString
+      val dataPath = tempDir.toString + "/table"
       import spark.implicits._
       Seq((1, "name1", 12), (2, "name2", 10))
         .toDF("id", "name", "age")


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->

This PR allows users to use the hybrid scan for append-only dataset. 

In order to support Hybrid Scan for append-only dataset, we need to merge the newly appended files and index data properly. Currently we have the following cases:

- **_Case 1_)** Filter Index Rule & parquet source format
  - In this case, we can just add the file list of appended files to the file list of the index relation (i.e. index data). It's because: 
    - it's guaranteed that newly appended source files always have the all columns in the index data (except for lineage).
    - Filter Index Rule does not utilize bucketing information for now; able to read both index data & newly appended data with 1 FileScan node. See below `InMemoryFileIndex`
```
...
<----:- *(1) Project [name#1, id#0]---->
<----:  +- *(1) Filter (isnotnull(id#0) && (id#0 >= 1))---->
<----:     +- *(1) FileScan parquet [id#0,name#1] Batched: true, Format: Parquet, 
                     Location: InMemoryFileIndex[<list of index data files> , <list of newly appended files>], PartitionFilters: [], PushedFilters: [IsNotNull(id), GreaterThanOrEqual(id,1)], ReadSchema: struct<id:int,name:string>---->
...
```
- **_Case 2_)** Filter Index Rule  & non-parquet source format
  - In this case, We could use Union instead of BucketUnion. Please refer #145.  
- **_Case 3_)** Join Index Rule
  - We can utilize BucketUnion (#151) to merge index data and appended data. In this way, we can retain the bucketing information of index, which enables to avoid unnecessary shuffling of index data.
```
 +- BucketUnion 200 buckets, bucket columns: [l_orderkey]      <===== merge both plans
            :- Project [l_orderkey#21L]                        <===== original index plan
            :  +- Filter ((isnotnull(l_commitdate#32) && isnotnull(l_receiptdate#33)) && (l_commitdate#32 < l_receiptdate#33))
            :     +- Relation[l_orderkey#21L,l_partkey#22L,l_suppkey#23L,l_quantity#25,l_extendedprice#26,l_discount#27,l_returnflag#29,l_shipdate#31,l_commitdate#32,l_receiptdate#33,l_shipmode#35] parquet
            +- RepartitionByExpression [l_orderkey#21L], 200   <===== on-the-fly shuffle with index spec
               +- Project [l_orderkey#21L]                     <===== newly appended data
                  +- Filter ((isnotnull(l_commitdate#32) && isnotnull(l_receiptdate#33)) && (l_commitdate#32 < l_receiptdate#33))
                     +- Relation[l_orderkey#21L,l_partkey#22L,l_suppkey#23L,l_quantity#25,l_extendedprice#26,l_discount#27,l_returnflag#29,l_shipdate#31,l_commitdate#32,l_receiptdate#33,l_shipmode#35] parquet
```

- `transformPlanToUseIndex` returns the transformed plan to utilize the given index.
- `transformPlanToUsePureIndex`:  if `hybridScanEnbaled=false`, it replaces the source location with the index data location same as before.
- `transformPlanToUseHybridIndexDataScan`: if `hybridScanEnabled=true`, it firstly creates the plan with the index location similar to  `transformPlanToUsePureIndex`
  - and if there is appended data,
    - if _Case1_, add appended file lists to the location along with index data files, and then return.
    - if _Case3_, create on-the-fly shuffle for the appended data and do BucketUnion.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To support Hybrid Scan for append-only dataset. (#150)


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, if a user turns on Hybrid Scan (`spark.hyperspace.index.hybridscan.enabled=true`), outdated indexes whose dataset got appended new files could be a candidate for both FilterIndexRule & JoinIndexRule.
The query plan is modified in optimizer to support this and the changed plan can be checked with `hs.explain()` API.

FilterRule - _Case1_
```
scala> hs.explain(query)
=============================================================
Plan with indexes:
=============================================================
Project [id#0, name#1]
+- Filter (isnotnull(id#0) && (id#0 = 1))
   <----+- FileScan parquet [id#0,name#1] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/spark-warehouse/indexes/index33/v__=..., PartitionFilters: [], PushedFilters: [IsNotNull(id), EqualTo(id,1)], ReadSchema: struct<id:int,name:string>---->

=============================================================
Plan without indexes:
=============================================================
Project [id#0, name#1]
+- Filter (isnotnull(id#0) && (id#0 = 1))
   <----+- FileScan parquet [id#0,name#1] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/table], PartitionFilters: [], PushedFilters: [IsNotNull(id), EqualTo(id,1)], ReadSchema: struct<id:int,name:string>---->

=============================================================
Indexes used:
=============================================================
index33:file:/C:/Users/eunsong/IdeaProjects/spark2/spark-warehouse/indexes/index33/v__=0
```
FilterRule - _Case2_
```
=============================================================
Plan with indexes:
=============================================================
<----Union---->
<----:- *(1) Project [id#75L, name#76]---->
<----:  +- *(1) Filter (isnotnull(id#75L) && (id#75L = 1))---->
<----:     +- *(1) FileScan parquet [id#75L,name#76] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/spark-warehouse/indexes/indexjj/v__=..., PartitionFilters: [], PushedFilters: [IsNotNull(id), EqualTo(id,1)], ReadSchema: struct<id:bigint,name:string>, SelectedBucketsCount: 1 out of 200---->
<----+- *(2) Project [id#75L, name#76]---->
   <----+- *(2) Filter (isnotnull(id#75L) && (id#75L = 1))---->
      <----+- *(2) FileScan json [id#75L,name#76] Batched: false, Format: JSON, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/tablej/part-00000-b6853714-dc1b-450b..., PartitionFilters: [], PushedFilters: [IsNotNull(id), EqualTo(id,1)], ReadSchema: struct<id:bigint,name:string>---->
```

JoinRule - BroadcastHashJoin
```
=============================================================
Plan with indexes:
=============================================================
Project [id#0, name#1, name#40]
+- BroadcastHashJoin [id#0], [id#39], Inner, BuildRight
   <----:- BucketUnion 200 buckets, bucket columns: [id]---->
   <----:  :- *(1) Project [id#0, name#1]---->
   <----:  :  +- *(1) Filter ((isnotnull(id#0) && (id#0 = 1)) && (id#0 >= 1))---->
   <----:  :     +- *(1) FileScan parquet [id#0,name#1] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/spark-warehouse/indexes/index33/v__=..., PartitionFilters: [], PushedFilters: [IsNotNull(id), EqualTo(id,1), GreaterThanOrEqual(id,1)], ReadSchema: struct<id:int,name:string>, SelectedBucketsCount: 1 out of 200---->
   <----:  +- Exchange hashpartitioning(id#0, 200)---->
   <----:     +- *(2) Project [id#0, name#1]---->
   <----:        +- *(2) Filter ((isnotnull(id#0) && (id#0 = 1)) && (id#0 >= 1))---->
   <----:           +- *(2) FileScan parquet [id#0,name#1] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/table/part-00003-0fc50086-fd6e-4527-..., PartitionFilters: [], PushedFilters: [IsNotNull(id), EqualTo(id,1), GreaterThanOrEqual(id,1)], ReadSchema: struct<id:int,name:string>---->
   +- BroadcastExchange HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)))
      <----+- BucketUnion 200 buckets, bucket columns: [id]---->
         <----:- *(3) Project [id#39, name#40]---->
         <----:  +- *(3) Filter ((isnotnull(id#39) && (id#39 >= 1)) && (id#39 = 1))---->
         <----:     +- *(3) FileScan parquet [id#39,name#40] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/spark-warehouse/indexes/index33/v__=..., PartitionFilters: [], PushedFilters: [IsNotNull(id), GreaterThanOrEqual(id,1), EqualTo(id,1)], ReadSchema: struct<id:int,name:string>, SelectedBucketsCount: 1 out of 200---->
         <----+- Exchange hashpartitioning(id#39, 200)---->
            <----+- *(4) Project [id#39, name#40]---->
               <----+- *(4) Filter ((isnotnull(id#39) && (id#39 >= 1)) && (id#39 = 1))---->
                  <----+- *(4) FileScan parquet [id#39,name#40] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/table/part-00003-0fc50086-fd6e-4527-..., PartitionFilters: [], PushedFilters: [IsNotNull(id), GreaterThanOrEqual(id,1), EqualTo(id,1)], ReadSchema: struct<id:int,name:string>---->

=============================================================
Plan without indexes:
=============================================================
Project [id#0, name#1, name#40]
+- BroadcastHashJoin [id#0], [id#39], Inner, BuildRight
   <----:- Project [id#0, name#1]---->
   <----:  +- Filter ((isnotnull(id#0) && (id#0 = 1)) && (id#0 >= 1))---->
   <----:     +- FileScan parquet [id#0,name#1] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/table], PartitionFilters: [], PushedFilters: [IsNotNull(id), EqualTo(id,1), GreaterThanOrEqual(id,1)], ReadSchema: struct<id:int,name:string>---->
   +- BroadcastExchange HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)))
      <----+- *(1) Project [id#39, name#40]---->
         <----+- *(1) Filter ((isnotnull(id#39) && (id#39 >= 1)) && (id#39 = 1))---->
            <----+- *(1) FileScan parquet [id#39,name#40] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/table], PartitionFilters: [], PushedFilters: [IsNotNull(id), GreaterThanOrEqual(id,1), EqualTo(id,1)], ReadSchema: struct<id:int,name:string>---->

=============================================================
Indexes used:
=============================================================
index33:file:/C:/Users/eunsong/IdeaProjects/spark2/spark-warehouse/indexes/index33/v__=0
```
Join Rule - Sort Merge Join
```
=============================================================
Plan with indexes:
=============================================================
Project [id#69, name#70, name#103]
+- SortMergeJoin [id#69], [id#102], Inner
   :- *(3) Sort [id#69 ASC NULLS FIRST], false, 0
   <----:  +- BucketUnion 200 buckets, bucket columns: [id]---->
   <----:     :- *(1) Project [id#69, name#70]---->
   <----:     :  +- *(1) Filter ((isnotnull(id#69) && (id#69 = 1)) && (id#69 >= 1))---->
   <----:     :     +- *(1) FileScan parquet [id#69,name#70] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/spark-warehouse/indexes/index33/v__=..., PartitionFilters: [], PushedFilters: [IsNotNull(id), EqualTo(id,1), GreaterThanOrEqual(id,1)], ReadSchema: struct<id:int,name:string>, SelectedBucketsCount: 1 out of 200---->
   <----:     +- Exchange hashpartitioning(id#69, 200)---->
   <----:        +- *(2) Project [id#69, name#70]---->
   <----:           +- *(2) Filter ((isnotnull(id#69) && (id#69 = 1)) && (id#69 >= 1))---->
   <----:              +- *(2) FileScan parquet [id#69,name#70] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/table/part-00003-0fc50086-fd6e-4527-..., PartitionFilters: [], PushedFilters: [IsNotNull(id), EqualTo(id,1), GreaterThanOrEqual(id,1)], ReadSchema: struct<id:int,name:string>---->
   +- *(6) Sort [id#102 ASC NULLS FIRST], false, 0
      <----+- BucketUnion 200 buckets, bucket columns: [id]---->
         <----:- *(4) Project [id#102, name#103]---->
         <----:  +- *(4) Filter ((isnotnull(id#102) && (id#102 >= 1)) && (id#102 = 1))---->
         <----:     +- *(4) FileScan parquet [id#102,name#103] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/spark-warehouse/indexes/index33/v__=..., PartitionFilters: [], PushedFilters: [IsNotNull(id), GreaterThanOrEqual(id,1), EqualTo(id,1)], ReadSchema: struct<id:int,name:string>, SelectedBucketsCount: 1 out of 200---->
         <----+- Exchange hashpartitioning(id#102, 200)---->
            <----+- *(5) Project [id#102, name#103]---->
               <----+- *(5) Filter ((isnotnull(id#102) && (id#102 >= 1)) && (id#102 = 1))---->
                  <----+- *(5) FileScan parquet [id#102,name#103] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/table/part-00003-0fc50086-fd6e-4527-..., PartitionFilters: [], PushedFilters: [IsNotNull(id), GreaterThanOrEqual(id,1), EqualTo(id,1)], ReadSchema: struct<id:int,name:string>---->

=============================================================
Plan without indexes:
=============================================================
Project [id#69, name#70, name#103]
+- SortMergeJoin [id#69], [id#102], Inner
   :- *(2) Sort [id#69 ASC NULLS FIRST], false, 0
   <----:  +- Exchange hashpartitioning(id#69, 200)---->
   <----:     +- *(1) Project [id#69, name#70]---->
   <----:        +- *(1) Filter ((isnotnull(id#69) && (id#69 = 1)) && (id#69 >= 1))---->
   <----:           +- *(1) FileScan parquet [id#69,name#70] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/table], PartitionFilters: [], PushedFilters: [IsNotNull(id), EqualTo(id,1), GreaterThanOrEqual(id,1)], ReadSchema: struct<id:int,name:string>---->
   +- *(4) Sort [id#102 ASC NULLS FIRST], false, 0
      <----+- Exchange hashpartitioning(id#102, 200)---->
         <----+- *(3) Project [id#102, name#103]---->
            <----+- *(3) Filter ((isnotnull(id#102) && (id#102 >= 1)) && (id#102 = 1))---->
               <----+- *(3) FileScan parquet [id#102,name#103] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/table], PartitionFilters: [], PushedFilters: [IsNotNull(id), GreaterThanOrEqual(id,1), EqualTo(id,1)], ReadSchema: struct<id:int,name:string>---->

=============================================================
Indexes used:
=============================================================
index33:file:/C:/Users/eunsong/IdeaProjects/spark2/spark-warehouse/indexes/index33/v__=0
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test & TPCH validation
