### PR TITLE
Add Union for FilterIndexRule and non-parquet format - Hybrid Scan

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable.{HashMap, ListBuffer}
 import com.fasterxml.jackson.annotation.JsonIgnore
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path, PathFilter}
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.types.{DataType, StructType}
 
 import com.microsoft.hyperspace.actions.Constants
@@ -318,6 +319,12 @@ case class IndexLogEntry(
       .flatMap(_.data.properties.content.fileInfos)
       .toSet
   }
+
+  def bucketSpec: BucketSpec =
+    BucketSpec(
+      numBuckets = numBuckets,
+      bucketColumnNames = indexedColumns,
+      sortColumnNames = indexedColumns)
 
   override def equals(o: Any): Boolean = o match {
     case that: IndexLogEntry =>

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -22,13 +22,11 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
-import org.apache.spark.sql.types.StructType
 
 import com.microsoft.hyperspace.{ActiveSparkSession, Hyperspace}
 import com.microsoft.hyperspace.index.IndexLogEntry
 import com.microsoft.hyperspace.telemetry.{AppInfo, HyperspaceEventLogging, HyperspaceIndexUsageEvent}
-import com.microsoft.hyperspace.util.ResolverUtils
+import com.microsoft.hyperspace.util.{HyperspaceConf, ResolverUtils}
 
 /**
  * FilterIndex rule looks for opportunities in a logical plan to replace
@@ -50,85 +48,33 @@ object FilterIndexRule
     //  1. The index covers all columns from the filter predicate and output columns list, and
     //  2. Filter predicate's columns include the first 'indexed' column of the index.
     plan transformDown {
-      case ExtractFilterNode(
-          originalPlan,
-          filter,
-          outputColumns,
-          filterColumns,
-          logicalRelation,
-          fsRelation) =>
+      case ExtractFilterNode(originalPlan, filter, outputColumns, filterColumns, _, fsRelation) =>
         try {
-          val transformedPlan = replaceWithIndexIfPlanCovered(
-            filter,
-            outputColumns,
-            filterColumns,
-            logicalRelation,
-            fsRelation)
-
-          originalPlan match {
-            case p @ Project(_, _) =>
-              p.copy(child = transformedPlan)
-            case _ =>
-              transformedPlan
+          val candidateIndexes =
+            findCoveringIndexes(filter, outputColumns, filterColumns, fsRelation)
+          rank(candidateIndexes) match {
+            case Some(index) =>
+              // Do not set BucketSpec to avoid limiting Spark's degree of parallelism
+              val replacedPlan =
+                RuleUtils.getReplacementPlan(spark, index, originalPlan, useBucketSpec = false)
+              logEvent(
+                HyperspaceIndexUsageEvent(
+                  AppInfo(
+                    sparkContext.sparkUser,
+                    sparkContext.applicationId,
+                    sparkContext.appName),
+                  Seq(index),
+                  filter.toString,
+                  replacedPlan.toString,
+                  "Filter index rule applied."))
+              replacedPlan
+            case None => originalPlan
           }
         } catch {
           case e: Exception =>
             logWarning("Non fatal exception in running filter index rule: " + e.getMessage)
             originalPlan
         }
-    }
-  }
-
-  /**
-   * For a given relation, check its available indexes and replace it with the top-ranked index
-   * (according to cost model).
-   *
-   * @param filter Filter node in the subplan that is being optimized.
-   * @param outputColumns List of output columns in subplan.
-   * @param filterColumns List of columns in filter predicate.
-   * @param logicalRelation child logical relation in the subplan.
-   * @param fsRelation Input relation in the subplan.
-   * @return transformed logical plan in which original fsRelation is replaced by
-   *         the top-ranked index.
-   */
-  private def replaceWithIndexIfPlanCovered(
-      filter: Filter,
-      outputColumns: Seq[String],
-      filterColumns: Seq[String],
-      logicalRelation: LogicalRelation,
-      fsRelation: HadoopFsRelation): Filter = {
-    val candidateIndexes =
-      findCoveringIndexes(filter, outputColumns, filterColumns, fsRelation)
-    rank(candidateIndexes) match {
-      case Some(index) =>
-        val spark = fsRelation.sparkSession
-        val newLocation = new InMemoryFileIndex(spark, index.content.files, Map(), None)
-
-        val newRelation = HadoopFsRelation(
-          newLocation,
-          new StructType(),
-          StructType(index.schema.filter(fsRelation.schema.contains)),
-          None, // Do not set BucketSpec to avoid limiting Spark's degree of parallelism
-          new ParquetFileFormat,
-          Map())(spark)
-
-        val newOutput =
-          logicalRelation.output.filter(attr => index.schema.fieldNames.contains(attr.name))
-
-        val updatedPlan =
-          filter.copy(child = logicalRelation.copy(relation = newRelation, output = newOutput))
-
-        logEvent(
-          HyperspaceIndexUsageEvent(
-            AppInfo(sparkContext.sparkUser, sparkContext.applicationId, sparkContext.appName),
-            Seq(index),
-            filter.toString,
-            updatedPlan.toString,
-            "Filter index rule applied."))
-
-        updatedPlan
-
-      case None => filter // No candidate index found
     }
   }
 
@@ -147,12 +93,14 @@ object FilterIndexRule
       outputColumns: Seq[String],
       filterColumns: Seq[String],
       fsRelation: HadoopFsRelation): Seq[IndexLogEntry] = {
+    val indexManager = Hyperspace
+      .getContext(spark)
+      .indexCollectionManager
+    val hybridScanEnabled = HyperspaceConf.hybridScanEnabled(spark)
     RuleUtils.getLogicalRelation(filter) match {
       case Some(r) =>
-        val indexManager = Hyperspace
-          .getContext(spark)
-          .indexCollectionManager
-        val candidateIndexes = RuleUtils.getCandidateIndexes(indexManager, r)
+        val candidateIndexes =
+          RuleUtils.getCandidateIndexes(indexManager, r, hybridScanEnabled)
 
         candidateIndexes.filter { index =>
           indexCoversPlan(

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -21,18 +21,16 @@ import scala.util.Try
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.analysis.CleanupAliases
-import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, AttributeReference, AttributeSet, EqualTo, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InMemoryFileIndex, LogicalRelation}
-import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.execution.datasources.LogicalRelation
 
 import com.microsoft.hyperspace.{ActiveSparkSession, Hyperspace}
 import com.microsoft.hyperspace.index._
 import com.microsoft.hyperspace.index.rankers.JoinIndexRanker
 import com.microsoft.hyperspace.telemetry.{AppInfo, HyperspaceEventLogging, HyperspaceIndexUsageEvent}
+import com.microsoft.hyperspace.util.HyperspaceConf
 import com.microsoft.hyperspace.util.ResolverUtils._
 
 /**
@@ -63,7 +61,9 @@ object JoinIndexRule
           .map {
             case (lIndex, rIndex) =>
               val updatedPlan = join
-                .copy(left = getReplacementPlan(lIndex, l), right = getReplacementPlan(rIndex, r))
+                .copy(
+                  left = RuleUtils.getReplacementPlan(spark, lIndex, l, useBucketSpec = true),
+                  right = RuleUtils.getReplacementPlan(spark, rIndex, r, useBucketSpec = true))
 
               logEvent(
                 HyperspaceIndexUsageEvent(
@@ -106,59 +106,24 @@ object JoinIndexRule
     val indexManager = Hyperspace
       .getContext(spark)
       .indexCollectionManager
-
+    val hybridScanEnabled = HyperspaceConf.hybridScanEnabled(spark)
     val lIndexes =
-      RuleUtils.getLogicalRelation(left).map(RuleUtils.getCandidateIndexes(indexManager, _))
+      RuleUtils
+        .getLogicalRelation(left)
+        .map(RuleUtils.getCandidateIndexes(indexManager, _, hybridScanEnabled))
     if (lIndexes.isEmpty || lIndexes.get.isEmpty) {
       return None
     }
 
     val rIndexes =
-      RuleUtils.getLogicalRelation(right).map(RuleUtils.getCandidateIndexes(indexManager, _))
+      RuleUtils
+        .getLogicalRelation(right)
+        .map(RuleUtils.getCandidateIndexes(indexManager, _, hybridScanEnabled))
     if (rIndexes.isEmpty || rIndexes.get.isEmpty) {
       return None
     }
 
     getBestIndexPair(left, right, condition, lIndexes.get, rIndexes.get)
-  }
-
-  /**
-   * Get replacement plan for current plan. The replacement plan reads data from indexes
-   *
-   * Pre-requisites
-   * - We know for sure the index which can be used to replace the plan.
-   *
-   * NOTE: This method currently only supports replacement of Scan Nodes i.e. Logical relations
-   *
-   * @param index index used in replacement plan
-   * @param plan current plan
-   * @return replacement plan
-   */
-  private def getReplacementPlan(index: IndexLogEntry, plan: LogicalPlan): LogicalPlan = {
-    // Here we can't replace the plan completely with the index. This will create problems.
-    // For e.g. if Project(A,B) -> Filter(C = 10) -> Scan (A,B,C,D,E)
-    // if we replace this plan with index Scan (A,B,C), we lose the Filter(C=10) and it will
-    // lead to wrong results. So we only replace the base relation.
-    plan transform {
-      case baseRelation @ LogicalRelation(_: HadoopFsRelation, baseOutput, _, _) =>
-        val bucketSpec = BucketSpec(
-          numBuckets = index.numBuckets,
-          bucketColumnNames = index.indexedColumns,
-          sortColumnNames = index.indexedColumns)
-
-        val location = new InMemoryFileIndex(spark, index.content.files, Map(), None)
-        val relation = HadoopFsRelation(
-          location,
-          new StructType(),
-          StructType(index.schema.filter(baseRelation.schema.contains(_))),
-          Some(bucketSpec),
-          new ParquetFileFormat,
-          Map())(spark)
-
-        val updatedOutput =
-          baseOutput.filter(attr => relation.schema.fieldNames.contains(attr.name))
-        baseRelation.copy(relation = relation, output = updatedOutput)
-    }
   }
 
   /**
@@ -438,11 +403,13 @@ object JoinIndexRule
     extractConditions(condition).map {
       case EqualTo(attr1: AttributeReference, attr2: AttributeReference) =>
         Try {
-          (resolve(spark, attr1.name, leftBaseAttrs).get,
+          (
+            resolve(spark, attr1.name, leftBaseAttrs).get,
             resolve(spark, attr2.name, rightBaseAttrs).get)
         }.getOrElse {
           Try {
-            (resolve(spark, attr2.name, leftBaseAttrs).get,
+            (
+              resolve(spark, attr2.name, leftBaseAttrs).get,
               resolve(spark, attr1.name, rightBaseAttrs).get)
           }.getOrElse {
             throw new IllegalStateException("Unexpected exception while using join rule")

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -18,11 +18,18 @@ package com.microsoft.hyperspace.index.rules
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation, PartitioningAwareFileIndex}
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project, RepartitionByExpression}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InMemoryFileIndex, LogicalRelation, PartitioningAwareFileIndex}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.types.StructType
 
 import com.microsoft.hyperspace.actions.Constants
-import com.microsoft.hyperspace.index.{FileInfo, IndexLogEntry, IndexManager, LogicalPlanSignatureProvider, PlanSignatureProvider}
+import com.microsoft.hyperspace.index.{FileInfo, IndexLogEntry, IndexManager, LogicalPlanSignatureProvider}
+import com.microsoft.hyperspace.index.plans.logical.BucketUnion
+import com.microsoft.hyperspace.util.HyperspaceConf
 
 object RuleUtils {
 
@@ -37,7 +44,7 @@ object RuleUtils {
   def getCandidateIndexes(
       indexManager: IndexManager,
       plan: LogicalPlan,
-      hybridScanEnabled: Boolean = false): Seq[IndexLogEntry] = {
+      hybridScanEnabled: Boolean): Seq[IndexLogEntry] = {
     // Map of a signature provider to a signature generated for the given plan.
     val signatureMap = mutable.Map[String, Option[String]]()
 
@@ -104,6 +111,248 @@ object RuleUtils {
       Some(lrs.head)
     } else {
       None // logicalPlan is non-linear or it has no LogicalRelation.
+    }
+  }
+
+  /**
+   * Get replacement plan for current plan. The replacement plan reads data from indexes.
+   * If HybridScan is enabled, additional logical plans for the appended data would be
+   * generated and merged with index data plan. Refer [[getComplementIndexPlan]].
+   *
+   * Pre-requisites
+   * - We know for sure the index which can be used to replace the plan.
+   *
+   * NOTE: This method currently only supports replacement of Scan Nodes i.e. Logical relations
+   *
+   * @param spark Spark session.
+   * @param index Index used in replacement plan.
+   * @param plan Current logical plan.
+   * @param useBucketSpec Option whether to use BucketSpec for reading index data.
+   * @return Replacement plan.
+   */
+  def getReplacementPlan(
+      spark: SparkSession,
+      index: IndexLogEntry,
+      plan: LogicalPlan,
+      useBucketSpec: Boolean): LogicalPlan = {
+    if (HyperspaceConf.hybridScanEnabled(spark)) {
+      getHybridScanIndexPlan(spark, index, plan, useBucketSpec)
+    } else {
+      getIndexPlan(spark, index, plan, useBucketSpec)
+    }
+  }
+
+  /**
+   * Get alternative logical plan of the current plan using the given index.
+   *
+   * @param spark Spark session.
+   * @param index Index used in replacement plan.
+   * @param plan Current logical plan.
+   * @param useBucketSpec Option whether to use BucketSpec for reading index data.
+   * @return Alternative logical plan.
+   */
+  private def getIndexPlan(
+      spark: SparkSession,
+      index: IndexLogEntry,
+      plan: LogicalPlan,
+      useBucketSpec: Boolean): LogicalPlan = {
+    // Here we can't replace the plan completely with the index. This will create problems.
+    // For e.g. if Project(A,B) -> Filter(C = 10) -> Scan (A,B,C,D,E)
+    // if we replace this plan with index Scan (A,B,C), we lose the Filter(C=10) and it will
+    // lead to wrong results. So we only replace the base relation.
+    plan transformDown {
+      case baseRelation @ LogicalRelation(_: HadoopFsRelation, baseOutput, _, _) =>
+        val location =
+          new InMemoryFileIndex(spark, index.content.files, Map(), None)
+        val relation = HadoopFsRelation(
+          location,
+          new StructType(),
+          StructType(index.schema.filter(baseRelation.schema.contains(_))),
+          if (useBucketSpec) Some(index.bucketSpec) else None,
+          new ParquetFileFormat,
+          Map())(spark)
+
+        val updatedOutput =
+          baseOutput.filter(attr => relation.schema.fieldNames.contains(attr.name))
+        baseRelation.copy(relation = relation, output = updatedOutput)
+    }
+  }
+
+  /**
+   * Get alternative logical plan of the current plan using the given index.
+   * With HybridScan, indexes with newly appended files to its source relation are also
+   * eligible and we reconstruct new plans for the appended files so as to merge into
+   * the index data.
+   *
+   * @param spark Spark session.
+   * @param index Index used in replacement plan.
+   * @param plan Current logical plan.
+   * @param useBucketSpec Option whether to use BucketSpec for reading index data.
+   * @return Alternative logical plan.
+   */
+  private def getHybridScanIndexPlan(
+      spark: SparkSession,
+      index: IndexLogEntry,
+      plan: LogicalPlan,
+      useBucketSpec: Boolean): LogicalPlan = {
+    // Other than "parquet" format, we cannot read source files along with index data
+    // files in parquet format with 1 FileScan node. In this case, we need to read the
+    // appended source files by another FileScan node and merge into the index data.
+    // Though BucketUnion (using BucketSpec and on-the-fly Shuffle) is used to merge
+    // them for now, we will try to optimize these plans with Union operator.
+    val useBucketUnion = useBucketSpec || !index.relations.head.fileFormat.equals("parquet")
+    val replacedPlan = plan transformDown {
+      case baseRelation @ LogicalRelation(
+            _ @HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _),
+            baseOutput,
+            _,
+            _) =>
+        val curFileSet = location.allFiles
+          .map(f => FileInfo(f.getPath.toString, f.getLen, f.getModificationTime))
+          .toSet
+
+        // if BucketSpec of index data isn't used, we could read appended data from
+        // source files directly.
+        val readPaths = {
+          if (useBucketUnion) {
+            index.content.files
+          } else {
+            val filesAppended =
+              (curFileSet -- index.allSourceFileInfos).map(f => new Path(f.name)).toSeq
+            index.content.files ++ filesAppended
+          }
+        }
+
+        val newLocation = new InMemoryFileIndex(spark, readPaths, Map(), None)
+        val relation = HadoopFsRelation(
+          newLocation,
+          new StructType(),
+          StructType(index.schema.filter(baseRelation.schema.contains(_))),
+          if (useBucketUnion) Some(index.bucketSpec) else None,
+          new ParquetFileFormat,
+          Map())(spark)
+
+        val updatedOutput =
+          baseOutput.filter(attr => relation.schema.fieldNames.contains(attr.name))
+        baseRelation.copy(relation = relation, output = updatedOutput)
+    }
+    if (useBucketUnion) {
+      // if BucketSpec of the index is used to read the index data, we need to shuffle
+      // the appended data in the same way to avoid additional shuffle of index data.
+      getComplementIndexPlan(spark, index, plan, replacedPlan)
+    } else {
+      replacedPlan
+    }
+  }
+
+  /**
+   * Get complement plan for an index with appended data.
+   *
+   * This method consists of the following steps
+   * 1) Get a plan from originalPlan by replacing data location with appended data
+   * 2) On-the-fly shuffle for the appended data, using indexedColumns & numBuckets.
+   *   - Shuffle is located before Project to utilize Push-down Filters
+   *     - Shuffle => Project => Filter => Relation
+   *   - if Project filters indexedColumns, then Shuffle should be located after the node
+   *     - Project => Shuffle => Filter => Relation
+   * 3) Bucket-aware union both indexPlan and complementPlan to avoid repartitioning index data
+   *
+   * NOTE: This method currently only supports replacement of Scan Nodes i.e. Logical relations
+   *
+   * @param spark Spark session
+   * @param index index used in replacement plan
+   * @param originalPlan original plan
+   * @param indexPlan replaced plan with index
+   * @return complementIndexPlan integrated plan of indexPlan and complementPlan
+   */
+  private def getComplementIndexPlan(
+      spark: SparkSession,
+      index: IndexLogEntry,
+      originalPlan: LogicalPlan,
+      indexPlan: LogicalPlan): LogicalPlan = {
+    // 1) Replace the location of LogicalRelation with appended files
+    val complementIndexPlan = originalPlan transformDown {
+      case baseRelation @ LogicalRelation(
+            fsRelation @ HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _),
+            baseOutput,
+            _,
+            _) =>
+        // Set the same output schema with the index plan to merge them using BucketUnion
+        val updatedOutput =
+          baseOutput.filter(attr => index.schema.fieldNames.contains(attr.name))
+
+        val filesAppended = (location.allFiles
+          .map(f => FileInfo(f.getPath.toString, f.getLen, f.getModificationTime))
+          .toSet -- index.allSourceFileInfos).toSeq.map(f => new Path(f.name))
+
+        if (filesAppended.nonEmpty) {
+          val newLocation =
+            new InMemoryFileIndex(spark, filesAppended, Map(), None)
+          val newRelation =
+            fsRelation.copy(
+              location = newLocation,
+              dataSchema = StructType(index.schema.filter(baseRelation.schema.contains(_))))(
+              spark)
+          baseRelation.copy(relation = newRelation, output = updatedOutput)
+        } else {
+          baseRelation
+        }
+    }
+
+    if (!originalPlan.equals(complementIndexPlan)) {
+      // Remove sort order because we cannot guarantee the ordering of source files
+      val bucketSpec = index.bucketSpec.copy(sortColumnNames = Seq())
+
+      object ExtractTopLevelPlanForShuffle {
+        type returnType = (LogicalPlan, Seq[Option[Attribute]], Boolean)
+        def unapply(plan: LogicalPlan): Option[returnType] = plan match {
+          case project @ Project(
+                _,
+                Filter(_, LogicalRelation(HadoopFsRelation(_, _, _, _, _, _), _, _, _))) =>
+            val indexedAttrs = getIndexedAttrs(project, index.indexedColumns)
+            Some(project, indexedAttrs, true)
+          case project @ Project(
+                _,
+                LogicalRelation(HadoopFsRelation(_, _, _, _, _, _), _, _, _)) =>
+            val indexedAttrs = getIndexedAttrs(project, index.indexedColumns)
+            Some(project, indexedAttrs, true)
+          case filter @ Filter(_, LogicalRelation(HadoopFsRelation(_, _, _, _, _, _), _, _, _)) =>
+            val indexedAttrs = getIndexedAttrs(filter, index.indexedColumns)
+            Some(filter, indexedAttrs, false)
+          case relation @ LogicalRelation(HadoopFsRelation(_, _, _, _, _, _), _, _, _) =>
+            val indexedAttrs = getIndexedAttrs(relation, index.indexedColumns)
+            Some(relation, indexedAttrs, false)
+        }
+        def getIndexedAttrs(
+            plan: LogicalPlan,
+            indexedColumns: Seq[String]): Seq[Option[Attribute]] = {
+          val attrMap = plan.output.attrs.map(attr => (attr.name, attr)).toMap
+          indexedColumns.map(colName => attrMap.get(colName))
+        }
+      }
+
+      // 2) Perform on-the-fly Shuffle with the same partition structure of index
+      // so that we could avoid incurring Shuffle of whole index data at merge stage.
+      // In order to utilize push-down filters, we would locate Shuffle node after
+      // Project or Filter node. (Case 1)
+      // However, if Project node excludes any of indexedColumns, Shuffle will be
+      // converted to RoundRobinPartitioning which can cause wrong result issues.
+      // So Shuffle should be located before Project node in that case. (Case 2)
+      // Case 1) Shuffle => Project => Filter => Relation (Project&Filter will be pushed down)
+      // Case 2) Project => Shuffle => Filter => Relation (Filter will be pushed down)
+      var shuffleInjected = false
+      val shuffled = complementIndexPlan transformDown {
+        case p if shuffleInjected => p
+        case ExtractTopLevelPlanForShuffle(plan, indexedAttr, isProject)
+            if !isProject || indexedAttr.forall(_.isDefined) =>
+          shuffleInjected = true
+          RepartitionByExpression(indexedAttr.flatten, plan, index.numBuckets)
+      }
+      // 3) Merge index plan & newly shuffled plan by using bucket-aware union.
+      // Currently, BucketUnion does not keep the sort order within a bucket.
+      BucketUnion(Seq(indexPlan, shuffled), bucketSpec)
+    } else {
+      indexPlan
     }
   }
 }

--- a/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InMemoryFileIndex, LogicalRelation}
 
 import com.microsoft.hyperspace.{Hyperspace, Implicits, SampleData}
+import com.microsoft.hyperspace.index.execution.BucketUnionStrategy
 import com.microsoft.hyperspace.index.rules.{FilterIndexRule, JoinIndexRule}
 import com.microsoft.hyperspace.util.PathUtils
 
@@ -68,20 +69,30 @@ class E2EHyperspaceRulesTests extends HyperspaceSuite with SQLHelper {
 
   test("verify enableHyperspace()/disableHyperspace() plug in/out optimization rules.") {
     val expectedOptimizationRuleBatch = Seq(JoinIndexRule, FilterIndexRule)
+    val expectedOptimizationStrategy = Seq(BucketUnionStrategy)
 
     assert(
       !spark.sessionState.experimentalMethods.extraOptimizations
         .containsSlice(expectedOptimizationRuleBatch))
+    assert(
+      !spark.sessionState.experimentalMethods.extraStrategies
+        .containsSlice(expectedOptimizationStrategy))
 
     spark.enableHyperspace()
     assert(
       spark.sessionState.experimentalMethods.extraOptimizations
         .containsSlice(expectedOptimizationRuleBatch))
+    assert(
+      spark.sessionState.experimentalMethods.extraStrategies
+        .containsSlice(expectedOptimizationStrategy))
 
     spark.disableHyperspace()
     assert(
       !spark.sessionState.experimentalMethods.extraOptimizations
         .containsSlice(expectedOptimizationRuleBatch))
+    assert(
+      !spark.sessionState.experimentalMethods.extraStrategies
+        .containsSlice(expectedOptimizationStrategy))
   }
 
   test(

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
@@ -86,7 +86,8 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
     FileUtils.delete(new Path(sampleJsonDataLocation))
   }
 
-  test("HybridScan filter rule test") {
+  test("Append-only: filter index & parquet format, " +
+    "index relation should include appended file paths") {
     df = spark.read.parquet(sampleParquetDataLocation)
     val query = df.filter(df("clicks") <= 2000).select(df("query"))
 
@@ -117,7 +118,8 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
     }
   }
 
-  test("HybridScan join rule test") {
+  test("Append-only: join index, appended data should be shuffled with indexed columns " +
+    "and merged by BucketUnion") {
     df = spark.read.parquet(sampleParquetDataLocation)
     val query = df.filter(df("clicks") >= 2000).select(df("clicks"), df("query"))
     val query2 = df.filter(df("clicks") <= 4000).select(df("clicks"), df("query"))
@@ -177,7 +179,8 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
     }
   }
 
-  test("HybridScan filter rule test with Json input") {
+  test("Append-only: filter rule & json format, " +
+    "appended data should be shuffled and merged by BucketUnion") {
     df = spark.read.json(sampleJsonDataLocation)
     val query = df.filter(df("clicks") <= 2000).select(df("query"))
     val expectedResult = query.collect

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
@@ -1,0 +1,252 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index
+
+import scala.util.Try
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.execution.{FileSourceScanExec, InputAdapter, ProjectExec, WholeStageCodegenExec}
+import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.exchange.{ReusedExchangeExec, ShuffleExchangeExec}
+
+import com.microsoft.hyperspace.{Hyperspace, Implicits, SampleData}
+import com.microsoft.hyperspace.index.execution.BucketUnionExec
+import com.microsoft.hyperspace.index.plans.logical.BucketUnion
+import com.microsoft.hyperspace.index.rules.{FilterIndexRule, JoinIndexRule}
+import com.microsoft.hyperspace.util.FileUtils
+
+class HybridScanTest extends QueryTest with HyperspaceSuite {
+  override val systemPath = new Path("src/test/resources/hybridScanTest")
+
+  private val sampleData = SampleData.testData
+  private val sampleParquetDataLocation = "src/test/resources/sampleparquet2"
+  private val sampleJsonDataLocation = "src/test/resources/samplejson"
+  private var df: DataFrame = _
+  private var hyperspace: Hyperspace = _
+  private val indexConfig1 = IndexConfig("index1", Seq("clicks"), Seq("query"))
+  private val indexConfig2 = IndexConfig("index2", Seq("clicks"), Seq("query"))
+
+  private def copyFirstFile(df: DataFrame): Unit = {
+    val files = df.queryExecution.optimizedPlan.collect {
+      case LogicalRelation(
+          HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _),
+          _,
+          _,
+          _) =>
+        location.allFiles
+    }.flatten
+    val sourcePath = files.head.getPath
+    val destPath = new Path(files.head.getPath + ".copy")
+    sourcePath.getFileSystem(new Configuration).copyToLocalFile(sourcePath, destPath)
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    val sparkSession = spark
+    import sparkSession.implicits._
+    hyperspace = new Hyperspace(spark)
+    FileUtils.delete(new Path(sampleParquetDataLocation))
+    FileUtils.delete(new Path(sampleJsonDataLocation))
+    val dfFromSample = sampleData.toDF("Date", "RGUID", "Query", "imprs", "clicks")
+    dfFromSample.write.parquet(sampleParquetDataLocation)
+    dfFromSample.write.json(sampleJsonDataLocation)
+
+    df = spark.read.parquet(sampleParquetDataLocation)
+    hyperspace.createIndex(df, indexConfig1)
+    copyFirstFile(df)
+
+    df = spark.read.json(sampleJsonDataLocation)
+    hyperspace.createIndex(df, indexConfig2)
+    copyFirstFile(df)
+  }
+
+  after {
+    spark.disableHyperspace()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    FileUtils.delete(new Path(sampleParquetDataLocation))
+    FileUtils.delete(new Path(sampleJsonDataLocation))
+  }
+
+  test("HybridScan filter rule test") {
+    df = spark.read.parquet(sampleParquetDataLocation)
+    val query = df.filter(df("clicks") <= 2000).select(df("query"))
+    val expectedResult = query.collect
+
+    withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "false") {
+      val transformed = FilterIndexRule(query.queryExecution.optimizedPlan)
+      assert(transformed.equals(query.queryExecution.optimizedPlan), "No plan transformation.")
+    }
+
+    withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "true") {
+      val planWithHybridScan = FilterIndexRule(query.queryExecution.optimizedPlan)
+      assert(
+        !planWithHybridScan.equals(query.queryExecution.optimizedPlan),
+        "Plan should be transformed.")
+
+      // check appended file is added to relation node or not
+      val nodes = planWithHybridScan collect {
+        case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
+          assert(fsRelation.location.inputFiles.count(_.contains(".copy")) === 1)
+          assert(fsRelation.location.inputFiles.count(_.contains("index1")) === 4)
+          p
+      }
+      assert(nodes.length === 1)
+
+      spark.enableHyperspace()
+      val query2 = df.filter(df("clicks") <= 2000).select(df("query"))
+      val res = query2.collect()
+
+      assert(expectedResult.nonEmpty)
+      assert(res.nonEmpty)
+      assert(expectedResult.sortBy(_.toString).toSeq === res.sortBy(_.toString).toSeq)
+    }
+  }
+
+  test("HybridScan join rule test") {
+    df = spark.read.parquet(sampleParquetDataLocation)
+    val query = df.filter(df("clicks") >= 2000).select(df("clicks"), df("query"))
+    val query2 = df.filter(df("clicks") <= 4000).select(df("clicks"), df("query"))
+    val join = query.join(query2, "clicks")
+    val expectedResult = join.collect()
+
+    withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "-1") {
+      withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "false") {
+        val transformed = JoinIndexRule(join.queryExecution.optimizedPlan)
+        assert(transformed.equals(join.queryExecution.optimizedPlan), "No plan transformation.")
+      }
+
+      withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "true") {
+        val planWithHybridScan = JoinIndexRule(join.queryExecution.optimizedPlan)
+        assert(
+          !planWithHybridScan.equals(join.queryExecution.optimizedPlan),
+          "Plan should be transformed.")
+
+        // check appended file is added to relation node or not
+        val nodes = planWithHybridScan collect {
+          case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
+            val appendedFileCnt = fsRelation.location.inputFiles.count(_.contains(".copy"))
+            val indexFileCnt = fsRelation.location.inputFiles.count(_.contains("index1"))
+            assert(appendedFileCnt === 1 || indexFileCnt === 4)
+            assert(appendedFileCnt * indexFileCnt === 0)
+            p
+          case p @ BucketUnion(_, _) => p
+        }
+        assert(nodes.count(p => p.getClass.toString.contains("LogicalRelation")) === 4)
+        assert(nodes.count(p => p.getClass.toString.contains("BucketUnion")) === 2)
+
+        spark.enableHyperspace()
+        val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
+        val execNodes = execPlan collect {
+          case p @ BucketUnionExec(children, bucketSpec) =>
+            assert(children.size === 2)
+            // head is always the index plan
+            assert(Try(children.head.asInstanceOf[WholeStageCodegenExec]).isSuccess)
+            assert(
+              Try(children.last.asInstanceOf[ShuffleExchangeExec]).isSuccess || Try(
+                children.last.asInstanceOf[ReusedExchangeExec]).isSuccess)
+            assert(bucketSpec.numBuckets === 200)
+            p
+          case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
+            // check filter pushed down properly
+            assert(
+              dataFilters.toString.contains(" >= 2000)") && dataFilters.toString.contains(
+                " <= 4000)"))
+            p
+        }
+        assert(execNodes.count(p => p.getClass.toString.contains("BucketUnionExec")) === 2)
+        // 2 of index, 1 of appended file (1 is reused)
+        assert(execNodes.count(p => p.getClass.toString.contains("FileSourceScanExec")) === 3)
+
+        val join2 = query.join(query2, "clicks")
+        val res = join2.collect()
+
+        assert(expectedResult.nonEmpty)
+        assert(res.nonEmpty)
+        assert(expectedResult.sortBy(_.toString).toSeq === res.sortBy(_.toString).toSeq)
+      }
+    }
+  }
+
+  test("HybridScan filter rule test with Json input") {
+    df = spark.read.json(sampleJsonDataLocation)
+    val query = df.filter(df("clicks") <= 2000).select(df("query"))
+    val expectedResult = query.collect
+
+    withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "false") {
+      val transformed = FilterIndexRule(query.queryExecution.optimizedPlan)
+      assert(transformed.equals(query.queryExecution.optimizedPlan), "No plan transformation.")
+    }
+
+    withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "true") {
+      val planWithHybridScan = FilterIndexRule(query.queryExecution.optimizedPlan)
+      assert(
+        !planWithHybridScan.equals(query.queryExecution.optimizedPlan),
+        "Plan should be transformed.")
+
+      // check appended file is added to relation node or not
+      val nodes = planWithHybridScan collect {
+        case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
+          val appendedFileCnt = fsRelation.location.inputFiles.count(_.contains(".copy"))
+          val indexFileCnt = fsRelation.location.inputFiles.count(_.contains("index2"))
+          assert(appendedFileCnt === 1 || indexFileCnt === 4)
+          assert(appendedFileCnt * indexFileCnt === 0)
+          p
+        case p @ BucketUnion(_, _) => p
+      }
+      assert(nodes.count(p => p.getClass.toString.contains("LogicalRelation")) === 2)
+      assert(nodes.count(p => p.getClass.toString.contains("BucketUnion")) === 1)
+
+      spark.enableHyperspace()
+      val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
+
+      val execNodes = execPlan collect {
+        case p @ BucketUnionExec(children, bucketSpec) =>
+          assert(children.size === 2)
+          // head is always the index plan
+          assert(Try(children.head.asInstanceOf[WholeStageCodegenExec]).isSuccess)
+          assert(Try(children.last.asInstanceOf[WholeStageCodegenExec]).isSuccess)
+          children.last match {
+            case WholeStageCodegenExec(
+                ProjectExec(_, InputAdapter(ShuffleExchangeExec(partitioning, _, _)))) =>
+              assert(partitioning.numPartitions === 200)
+            case _ => fail("Unexpected type of child of BucketUnion")
+          }
+          assert(bucketSpec.numBuckets === 200)
+          p
+        case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
+          // check filter pushed down properly
+          assert(dataFilters.toString.contains(" <= 2000)"))
+          p
+      }
+
+      assert(execNodes.count(p => p.getClass.toString.contains("BucketUnionExec")) === 1)
+      // 1 of index, 1 of appended file
+      assert(execNodes.count(p => p.getClass.toString.contains("FileSourceScanExec")) === 2)
+
+      val query2 = df.filter(df("clicks") <= 2000).select(df("query"))
+      val res = query2.collect()
+      assert(expectedResult.nonEmpty)
+      assert(res.nonEmpty)
+      assert(expectedResult.sortBy(_.toString).toSeq === res.sortBy(_.toString).toSeq)
+    }
+  }
+}

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -88,13 +88,13 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite {
   test("Verify indexes are matched by signature correctly.") {
     val indexManager = IndexCollectionManager(spark)
 
-    assert(RuleUtils.getCandidateIndexes(indexManager, t1ProjectNode).length === 3)
-    assert(RuleUtils.getCandidateIndexes(indexManager, t2ProjectNode).length === 2)
+    assert(RuleUtils.getCandidateIndexes(indexManager, t1ProjectNode, false).length === 3)
+    assert(RuleUtils.getCandidateIndexes(indexManager, t2ProjectNode, false).length === 2)
 
     // Delete an index for t1ProjectNode
     indexManager.delete("t1i1")
 
-    assert(RuleUtils.getCandidateIndexes(indexManager, t1ProjectNode).length === 2)
+    assert(RuleUtils.getCandidateIndexes(indexManager, t1ProjectNode, false).length === 2)
   }
 
   test("Verify get logical relation for single logical relation node plan.") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->
>**Note to reviewers:** 
> This PR is based on the pending PR (#165), **so please check just the last commit**. I'll only update the last commit (by amend + force push) until the dependent PR is merged. 


### What is the context for this pull request?
<!--
Please clarify the context for the changes you are contributing. The purpose of this section is to outline information information to help reviewers have enough context.
-->

 - **Tracking Issue**: #145 
 - **Parent Issue**: #150 
 - **Dependencies**: #165 

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.

The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->
Introduce Union instead of BucketUnion for FilterIndexRule and non-parquet source files.
In this way, we could remove the unnecessary shuffle.

```
Union => Project => Filter => Relation (index)
      |=> Project => Filter => Relation (appended data)
``` 

```
BucketUnion => Project => Filter => Relation (index)
            |=> Shuffle => Project => Filter => Relation (appended data)
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, the plan changed for Filter Index + non-parquet format
```
scala> hs.explain(query)
=============================================================
Plan with indexes:
=============================================================
<----Union---->
<----:- *(1) Project [id#75L, name#76]---->
<----:  +- *(1) Filter (isnotnull(id#75L) && (id#75L = 1))---->
<----:     +- *(1) FileScan parquet [id#75L,name#76] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/spark-warehouse/indexes/indexjj/v__=..., PartitionFilters: [], PushedFilters: [IsNotNull(id), EqualTo(id,1)], ReadSchema: struct<id:bigint,name:string>, SelectedBucketsCount: 1 out of 200---->
<----+- *(2) Project [id#75L, name#76]---->
   <----+- *(2) Filter (isnotnull(id#75L) && (id#75L = 1))---->
      <----+- *(2) FileScan json [id#75L,name#76] Batched: false, Format: JSON, Location: InMemoryFileIndex[file:/C:/Users/eunsong/IdeaProjects/spark2/tablej/part-00000-b6853714-dc1b-450b..., PartitionFilters: [], PushedFilters: [IsNotNull(id), EqualTo(id,1)], ReadSchema: struct<id:bigint,name:string>---->
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test