### PR TITLE
Inject push-down filter to exclude indexed rows from deleted files

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -27,8 +27,18 @@ object IndexConstants {
   val INDEX_SEARCH_PATHS = "spark.hyperspace.index.search.paths"
   val INDEX_NUM_BUCKETS = "spark.hyperspace.index.num.buckets"
 
+  // This config enables Hybrid scan on mutable dataset at query time.
+  // Currently, this config allows to perform Hybrid scan on append-only dataset.
+  // For delete dataset, "spark.hyperspace.index.hybridscan.delete.enabled" is
+  // also needed to be set.
   val INDEX_HYBRID_SCAN_ENABLED = "spark.hyperspace.index.hybridscan.enabled"
   val INDEX_HYBRID_SCAN_ENABLED_DEFAULT = "false"
+
+  // This is a temporary config to support Hybrid scan on both append & delete dataset.
+  // The config does not work without the Hybrid scan config
+  // "spark.hyperspace.index.hybridscan.enabled"
+  // and will be removed after performance validation and optimization.
+  // See https://github.com/microsoft/hyperspace/issues/184
   val INDEX_HYBRID_SCAN_DELETE_ENABLED = "spark.hyperspace.index.hybridscan.delete.enabled"
   val INDEX_HYBRID_SCAN_DELETE_ENABLED_DEFAULT = "false"
 

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -29,6 +29,8 @@ object IndexConstants {
 
   val INDEX_HYBRID_SCAN_ENABLED = "spark.hyperspace.index.hybridscan.enabled"
   val INDEX_HYBRID_SCAN_ENABLED_DEFAULT = "false"
+  val INDEX_HYBRID_SCAN_DELETE_ENABLED = "spark.hyperspace.index.hybridscan.delete.enabled"
+  val INDEX_HYBRID_SCAN_DELETE_ENABLED_DEFAULT = "false"
 
   // Default number of buckets is set the default value of "spark.sql.shuffle.partitions".
   val INDEX_NUM_BUCKETS_DEFAULT: Int = SQLConf.SHUFFLE_PARTITIONS.defaultValue.get

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -103,7 +103,7 @@ object FilterIndexRule
           .getContext(spark)
           .indexCollectionManager
         val candidateIndexes =
-          RuleUtils.getCandidateIndexes(indexManager, r, HyperspaceConf.hybridScanEnabled(spark))
+          RuleUtils.getCandidateIndexes(spark, indexManager, r)
 
         candidateIndexes.filter { index =>
           indexCoversPlan(

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -109,11 +109,10 @@ object JoinIndexRule
     val indexManager = Hyperspace
       .getContext(spark)
       .indexCollectionManager
-    val hybridScanEnabled = HyperspaceConf.hybridScanEnabled(spark)
     val lIndexes =
       RuleUtils
         .getLogicalRelation(left)
-        .map(RuleUtils.getCandidateIndexes(indexManager, _, hybridScanEnabled))
+        .map(RuleUtils.getCandidateIndexes(spark, indexManager, _))
     if (lIndexes.isEmpty || lIndexes.get.isEmpty) {
       return None
     }
@@ -121,7 +120,7 @@ object JoinIndexRule
     val rIndexes =
       RuleUtils
         .getLogicalRelation(right)
-        .map(RuleUtils.getCandidateIndexes(indexManager, _, hybridScanEnabled))
+        .map(RuleUtils.getCandidateIndexes(spark, indexManager, _))
     if (rIndexes.isEmpty || rIndexes.get.isEmpty) {
       return None
     }

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -224,9 +224,8 @@ object RuleUtils {
 
     // Get transformed plan with index data and appended files if applicable.
     val indexPlan = plan transformUp {
-      // Use transformUp here since only 1 Logical Relation is pre-requisite condition.
-      // Otherwise, we need additional handling of injected Filter-Not-In condition for
-      // Hybrid Scan Delete support.
+      // Use transformUp here as currently 1 Logical Relation is allowed (pre-requisite).
+      // Otherwise, we need additional check not to process newly injected Filter-Not-In nodes.
       case baseRelation @ LogicalRelation(
             _ @HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _),
             baseOutput,

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -236,8 +236,9 @@ object RuleUtils {
     // Get transformed plan with index data and appended files if applicable.
     val indexPlan = plan transformUp {
       // Use transformUp here as currently one Logical Relation is allowed (pre-requisite).
-      // With transformDown, the transformed plan will be matched and transformed recursively
-      // which causes Stack overflow exception.
+      // The transformed plan will have LogicalRelation as a child; for example, LogicalRelation
+      // can be transformed to 'Project -> Filter -> Logical Relation'. Thus, with transformDown,
+      // it will be matched again and transformed recursively which causes stack overflow exception.
       case baseRelation @ LogicalRelation(
             _ @HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _),
             baseOutput,
@@ -273,7 +274,7 @@ object RuleUtils {
             // merge the data into the index data. Please refer below [[Union]] operation.
             // In case there are both deleted and appended files, we cannot handle the appended
             // files along with deleted files as source files do not have the lineage column which
-            // requires for excluding the index data from deleted files.
+            // is required for excluding the index data from deleted files.
             unhandledAppendedFiles = filesAppended
             index.content.files
           } else {

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -74,15 +74,14 @@ object RuleUtils {
       //  support arbitrary source plans at index creation.
       //  See https://github.com/microsoft/hyperspace/issues/158
 
-      // Find the number of common files and deleted files between the source relations
-      // & index source files.
+      // Find the number of common files between the source relations & index source files.
       val commonCnt = inputSourceFiles.count(entry.allSourceFileInfos.contains)
-      val deletedCnt = entry.allSourceFileInfos.size - commonCnt
 
       if (hybridScanDeleteEnabled && entry.hasLineageColumn(spark)) {
         commonCnt > 0
       } else {
-        // For append-only dataset.
+        // For append-only Hybrid Scan, deleted files are not allowed.
+        val deletedCnt = entry.allSourceFileInfos.size - commonCnt
         deletedCnt == 0 && commonCnt > 0
       }
     }

--- a/src/main/scala/com/microsoft/hyperspace/util/HyperspaceConf.scala
+++ b/src/main/scala/com/microsoft/hyperspace/util/HyperspaceConf.scala
@@ -32,6 +32,14 @@ object HyperspaceConf {
       .toBoolean
   }
 
+  def hybridScanDeleteEnabled(spark: SparkSession): Boolean = {
+    spark.conf
+      .get(
+        IndexConstants.INDEX_HYBRID_SCAN_DELETE_ENABLED,
+        IndexConstants.INDEX_HYBRID_SCAN_DELETE_ENABLED_DEFAULT)
+      .toBoolean
+  }
+
   def refreshDeleteEnabled(spark: SparkSession): Boolean = {
     spark.conf
       .get(IndexConstants.REFRESH_DELETE_ENABLED,

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
@@ -19,9 +19,9 @@ package com.microsoft.hyperspace.index
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, QueryTest}
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, In, Literal, Not}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Project, RepartitionByExpression, Union}
-import org.apache.spark.sql.execution.{FileSourceScanExec, ProjectExec, UnionExec}
+import org.apache.spark.sql.execution.{FileSourceScanExec, InputAdapter, ProjectExec, UnionExec, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.internal.SQLConf
@@ -39,21 +39,33 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
   private val sampleDataLocationRoot = "src/test/resources/data/"
   private val sampleParquetDataLocationAppend = sampleDataLocationRoot + "sampleparquet0"
   private val sampleParquetDataLocationAppend2 = sampleDataLocationRoot + "sampleparquet1"
+  private val sampleParquetDataLocationDelete = sampleDataLocationRoot + "sampleparquet2"
+  private val sampleParquetDataLocationDelete2 = sampleDataLocationRoot + "sampleparquet3"
+  private val sampleParquetDataLocationDelete3 = sampleDataLocationRoot + "sampleparquet4"
+  private val sampleParquetDataLocationBoth = sampleDataLocationRoot + "sampleparquet5"
   private val sampleJsonDataLocationAppend = sampleDataLocationRoot + "samplejson1"
+  private val sampleJsonDataLocationDelete = sampleDataLocationRoot + "samplejson2"
   private var hyperspace: Hyperspace = _
 
   // Creates an index with given 'df' and 'indexConfig' and copies the first 'appendCnt'
   // number of input files from 'df'.
-  def setupIndexAndAppendData(df: DataFrame, indexConfig: IndexConfig, appendCnt: Int): Unit = {
+  def setupIndexAndChangeData(
+      df: DataFrame,
+      indexConfig: IndexConfig,
+      appendCnt: Int,
+      deleteCnt: Int): Unit = {
     hyperspace.createIndex(df, indexConfig)
     val inputFiles = df.inputFiles
-    assert(appendCnt < inputFiles.length)
+    assert(appendCnt + deleteCnt < inputFiles.length)
 
     val fs = systemPath.getFileSystem(new Configuration)
     for (i <- 0 until appendCnt) {
       val sourcePath = new Path(inputFiles(i))
       val destPath = new Path(inputFiles(i) + ".copy")
       fs.copyToLocalFile(sourcePath, destPath)
+    }
+    for (i <- 1 to deleteCnt) {
+      fs.delete(new Path(inputFiles(inputFiles.length - i)))
     }
   }
 
@@ -65,22 +77,59 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
     val dfFromSample = sampleData.toDF("Date", "RGUID", "Query", "imprs", "clicks")
     dfFromSample.write.parquet(sampleParquetDataLocationAppend)
     dfFromSample.write.parquet(sampleParquetDataLocationAppend2)
+    dfFromSample.write.parquet(sampleParquetDataLocationDelete)
+    dfFromSample.write.parquet(sampleParquetDataLocationDelete2)
+    dfFromSample.write.parquet(sampleParquetDataLocationDelete3)
+    dfFromSample.write.parquet(sampleParquetDataLocationBoth)
     dfFromSample.write.json(sampleJsonDataLocationAppend)
+    dfFromSample.write.json(sampleJsonDataLocationDelete)
 
     val indexConfig1 = IndexConfig("index1", Seq("clicks"), Seq("query"))
     val indexConfig2 = IndexConfig("index11", Seq("clicks"), Seq("Date"))
-    setupIndexAndAppendData(
+
+    setupIndexAndChangeData(
       spark.read.parquet(sampleParquetDataLocationAppend),
       indexConfig1,
-      appendCnt = 1)
-    setupIndexAndAppendData(
+      appendCnt = 1,
+      deleteCnt = 0)
+    setupIndexAndChangeData(
       spark.read.parquet(sampleParquetDataLocationAppend2),
       indexConfig2,
-      appendCnt = 1)
-    setupIndexAndAppendData(
+      appendCnt = 1,
+      deleteCnt = 0)
+    setupIndexAndChangeData(
       spark.read.json(sampleJsonDataLocationAppend),
       indexConfig1.copy(indexName = "index4"),
-      appendCnt = 1)
+      appendCnt = 1,
+      deleteCnt = 0)
+
+    withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
+      setupIndexAndChangeData(
+        spark.read.parquet(sampleParquetDataLocationDelete),
+        indexConfig1.copy(indexName = "index2"),
+        appendCnt = 0,
+        deleteCnt = 2)
+      setupIndexAndChangeData(
+        spark.read.parquet(sampleParquetDataLocationDelete3),
+        indexConfig2.copy(indexName = "index6"),
+        appendCnt = 0,
+        deleteCnt = 2)
+      setupIndexAndChangeData(
+        spark.read.parquet(sampleParquetDataLocationBoth),
+        indexConfig1.copy(indexName = "index3"),
+        appendCnt = 1,
+        deleteCnt = 1)
+      setupIndexAndChangeData(
+        spark.read.json(sampleJsonDataLocationDelete),
+        indexConfig1.copy(indexName = "index5"),
+        appendCnt = 0,
+        deleteCnt = 2)
+    }
+    setupIndexAndChangeData(
+      spark.read.parquet(sampleParquetDataLocationDelete2),
+      indexConfig1.copy(indexName = "index22"),
+      appendCnt = 0,
+      deleteCnt = 2)
   }
 
   before {
@@ -288,6 +337,333 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
         execPlan.foreach(p => assert(!p.isInstanceOf[ShuffleExchangeExec]))
 
         checkAnswer(baseQuery, filter)
+      }
+    }
+  }
+
+  test(
+    "Delete-only: filter index & parquet format, " +
+      "Hybrid Scan for delete support doesn't work without linage column") {
+    val df = spark.read.parquet(sampleParquetDataLocationDelete2)
+    def filterQuery: DataFrame =
+      df.filter(df("clicks") <= 2000).select(df("query"))
+    val baseQuery = filterQuery
+
+    withSQLConf(
+      "spark.hyperspace.index.hybridscan.enabled" -> "true",
+      "spark.hyperspace.index.hybridscan.delete.enabled" -> "false") {
+      val filter = filterQuery
+      assert(baseQuery.queryExecution.optimizedPlan.equals(filter.queryExecution.optimizedPlan))
+    }
+
+    withSQLConf(
+      "spark.hyperspace.index.hybridscan.enabled" -> "true",
+      "spark.hyperspace.index.hybridscan.delete.enabled" -> "true") {
+      val filter = filterQuery
+      assert(baseQuery.queryExecution.optimizedPlan.equals(filter.queryExecution.optimizedPlan))
+    }
+  }
+
+  test(
+    "Delete-only: filter index & parquet, json format, " +
+      "index relation should have additional filter for deleted files") {
+
+    Seq(
+      (sampleParquetDataLocationDelete, "index2", "parquet"),
+      (sampleJsonDataLocationDelete, "index5", "json")) foreach {
+      case (dataPath, indexName, dataFormat) =>
+        val df = spark.read.format(dataFormat).load(dataPath)
+        def filterQuery: DataFrame =
+          df.filter(df("clicks") <= 2000).select(df("query"))
+        val baseQuery = filterQuery
+
+        withSQLConf(
+          "spark.hyperspace.index.hybridscan.enabled" -> "true",
+          "spark.hyperspace.index.hybridscan.delete.enabled" -> "false") {
+          val filter = filterQuery
+          assert(
+            baseQuery.queryExecution.optimizedPlan.equals(filter.queryExecution.optimizedPlan))
+        }
+
+        withSQLConf(
+          "spark.hyperspace.index.hybridscan.enabled" -> "true",
+          "spark.hyperspace.index.hybridscan.delete.enabled" -> "true") {
+          val filter = filterQuery
+          val planWithHybridScan = filter.queryExecution.optimizedPlan
+          assert(!baseQuery.queryExecution.optimizedPlan.equals(planWithHybridScan))
+
+          val deletedFilesList = planWithHybridScan collect {
+            case Filter(
+                Not(In(attr, deletedFileNames)),
+                LogicalRelation(fsRelation: HadoopFsRelation, _, _, _)) =>
+              // Check new filter condition on linage column.
+              assert(attr.toString.contains(IndexConstants.DATA_FILE_NAME_COLUMN))
+              val deleted = deletedFileNames.map(_.toString)
+              assert(deleted.length == 2)
+              assert(deleted.distinct.length == deleted.length)
+              assert(deleted.forall(f => !df.inputFiles.contains(f)))
+              // Check the location is replaced with index data files properly.
+              assert(fsRelation.location.inputFiles.forall(_.contains(indexName)))
+              assert(fsRelation.location.inputFiles.length === 4)
+              deleted
+          }
+          assert(deletedFilesList.length === 1)
+          val deletedFiles = deletedFilesList.flatten
+          assert(deletedFiles.length === 2)
+
+          val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
+          val execNodes = execPlan collect {
+            case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
+              // Check filter pushed down properly.
+              val filterStr = dataFilters.toString
+              assert(filterStr.contains(" <= 2000)"))
+              // Check deleted files.
+              assert(deletedFiles.forall(filterStr.contains))
+              p
+          }
+          assert(execNodes.count(_.isInstanceOf[FileSourceScanExec]) === 1)
+
+          checkAnswer(baseQuery, filter)
+        }
+    }
+  }
+
+  test("Delete-only: join index, deleted files should be excluded from each index relation.") {
+    val df1 = spark.read.parquet(sampleParquetDataLocationDelete)
+    val df2 = spark.read.parquet(sampleParquetDataLocationDelete3)
+    def joinQuery(): DataFrame = {
+      val query = df1.filter(df1("clicks") >= 2000).select(df1("clicks"), df1("query"))
+      val query2 = df2.filter(df2("clicks") <= 4000).select(df2("clicks"), df2("Date"))
+      query.join(query2, "clicks")
+    }
+    val baseQuery = joinQuery
+
+    withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "-1") {
+      withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "false") {
+        val join = joinQuery()
+        assert(join.queryExecution.optimizedPlan.equals(baseQuery.queryExecution.optimizedPlan))
+      }
+
+      withSQLConf(
+        "spark.hyperspace.index.hybridscan.enabled" -> "true",
+        "spark.hyperspace.index.hybridscan.delete.enabled" -> "true") {
+        val join = joinQuery()
+        val planWithHybridScan = join.queryExecution.optimizedPlan
+        assert(!baseQuery.queryExecution.optimizedPlan.equals(planWithHybridScan))
+
+        val deletedFilesList = planWithHybridScan collect {
+          case Filter(
+              Not(In(attr, deletedFileNames)),
+              LogicalRelation(fsRelation: HadoopFsRelation, _, _, _)) =>
+            // Check new filter condition on linage column.
+            assert(attr.toString.contains(IndexConstants.DATA_FILE_NAME_COLUMN))
+            val deleted = deletedFileNames.map(_.toString)
+            assert(deleted.length == 2)
+            assert(deleted.distinct.length == deleted.length)
+            assert(deleted.forall(f => !df1.inputFiles.contains(f)))
+            assert(deleted.forall(f => !df2.inputFiles.contains(f)))
+            assert(fsRelation.location.inputFiles.forall(_.contains("index")))
+            assert(fsRelation.location.inputFiles.length === 4)
+            deleted
+        }
+        assert(deletedFilesList.length === 2)
+        assert(deletedFilesList.flatten.length === 4)
+
+        var deletedFiles = deletedFilesList.flatten
+
+        val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
+        val execNodes = execPlan collect {
+          case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
+            // Check filter pushed down properly.
+            val filterStr = dataFilters.toString
+            assert(filterStr.contains(" >= 2000)") && filterStr.contains(" <= 4000)"))
+            // Check deleted files in the push down condition and remove from the list.
+            deletedFiles = deletedFiles.filterNot(filterStr.contains(_))
+            p
+        }
+        assert(deletedFiles.isEmpty)
+        assert(execNodes.count(_.isInstanceOf[FileSourceScanExec]) === 2)
+
+        checkAnswer(join, baseQuery)
+      }
+    }
+  }
+
+  test(
+    "Append+Delete: filter index & parquet format, " +
+      "appended files should be handled with additional plan and merged by Union.") {
+    val df = spark.read.parquet(sampleParquetDataLocationBoth)
+    def filterQuery: DataFrame =
+      df.filter(df("clicks") <= 2000).select(df("query"))
+    val baseQuery = filterQuery
+
+    withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "false") {
+      val filter = filterQuery
+      assert(baseQuery.queryExecution.optimizedPlan.equals(filter.queryExecution.optimizedPlan))
+    }
+
+    withSQLConf(
+      "spark.hyperspace.index.hybridscan.enabled" -> "true",
+      "spark.hyperspace.index.hybridscan.delete.enabled" -> "true") {
+      val filter = filterQuery
+      val planWithHybridScan = filter.queryExecution.optimizedPlan
+      assert(!baseQuery.queryExecution.optimizedPlan.equals(planWithHybridScan))
+
+      var deletedFilesList: Seq[Seq[String]] = Nil
+      val nodes = planWithHybridScan collect {
+        case p @ Filter(
+              Not(In(attr, deletedFileNames)),
+              LogicalRelation(fsRelation: HadoopFsRelation, _, _, _)) =>
+          // Check new filter condition on linage column.
+          assert(attr.toString.contains(IndexConstants.DATA_FILE_NAME_COLUMN))
+          val deleted = deletedFileNames.map(_.toString)
+          assert(deleted.length == 1)
+          assert(deleted.distinct.length == deleted.length)
+          assert(deleted.forall(f => !df.inputFiles.contains(f)))
+          assert(fsRelation.location.inputFiles.forall(_.contains("index3")))
+          assert(fsRelation.location.inputFiles.length === 4)
+          deletedFilesList = deletedFilesList :+ deleted
+          p
+        case p @ Union(_) =>
+          p
+        case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
+          if (fsRelation.location.inputFiles.exists(_.contains(".copy"))) {
+            assert(fsRelation.location.inputFiles.length === 1)
+          } else {
+            assert(fsRelation.location.inputFiles.forall(_.contains("index3")))
+            assert(fsRelation.location.inputFiles.length === 4)
+          }
+          p
+      }
+      assert(nodes.count(_.isInstanceOf[Filter]) === 1)
+      assert(nodes.count(_.isInstanceOf[Union]) === 1)
+      assert(nodes.count(_.isInstanceOf[LogicalRelation]) === 2)
+
+      withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false") {
+        val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
+        var deletePushDownFilterFound = false
+        val execNodes = execPlan collect {
+          case p @ UnionExec(children) =>
+            assert(children.size === 2)
+            assert(children.head.isInstanceOf[ProjectExec]) // index data
+            assert(children.last.isInstanceOf[ProjectExec]) // appended data
+            p
+          case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
+            // Check filter pushed down properly.
+            val filterStr = dataFilters.toString
+            assert(filterStr.contains(" <= 2000)"))
+            if (filterStr.contains(IndexConstants.DATA_FILE_NAME_COLUMN)) {
+              assert(deletedFilesList.flatten.forall(filterStr.contains(_)))
+              deletePushDownFilterFound = true
+            }
+            p
+        }
+
+        // Make sure there is no shuffle.
+        execPlan.foreach(p => assert(!p.isInstanceOf[ShuffleExchangeExec]))
+        assert(execNodes.count(_.isInstanceOf[UnionExec]) === 1)
+        // 1 of index, 1 of appended file
+        assert(execNodes.count(_.isInstanceOf[FileSourceScanExec]) === 2)
+        assert(deletePushDownFilterFound)
+
+        checkAnswer(baseQuery, filter)
+      }
+    }
+  }
+
+  test(
+    "Append+Delete: join index, appended data should be shuffled with indexed columns " +
+      "and merged by BucketUnion and deleted files are handled with index data.") {
+    val df1 = spark.read.parquet(sampleParquetDataLocationBoth)
+    val df2 = spark.read.parquet(sampleParquetDataLocationDelete3)
+    def joinQuery(): DataFrame = {
+      val query = df1.filter(df1("clicks") >= 2000).select(df1("clicks"), df1("query"))
+      val query2 = df2.filter(df2("clicks") <= 4000).select(df2("clicks"), df2("Date"))
+      query.join(query2, "clicks")
+    }
+    val baseQuery = joinQuery
+
+    withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "-1") {
+      withSQLConf("spark.hyperspace.index.hybridscan.enabled" -> "false") {
+        val join = joinQuery()
+        assert(join.queryExecution.optimizedPlan.equals(baseQuery.queryExecution.optimizedPlan))
+      }
+
+      withSQLConf(
+        "spark.hyperspace.index.hybridscan.enabled" -> "true",
+        "spark.hyperspace.index.hybridscan.delete.enabled" -> "true") {
+        val join = joinQuery()
+        val planWithHybridScan = join.queryExecution.optimizedPlan
+        assert(!baseQuery.queryExecution.optimizedPlan.equals(planWithHybridScan))
+
+        var deletedFilesList: Seq[Seq[String]] = Nil
+        val nodes = planWithHybridScan collect {
+          case p @ Filter(
+                Not(In(attr, deletedFileNames)),
+                LogicalRelation(fsRelation: HadoopFsRelation, _, _, _)) =>
+            // Check new filter condition on linage column.
+            assert(attr.toString.contains(IndexConstants.DATA_FILE_NAME_COLUMN))
+            assert(deletedFileNames.length == 1 || deletedFileNames.length == 2)
+            val deleted = deletedFileNames.map(_.toString)
+            assert(deleted.distinct.length == deleted.length)
+            assert(deleted.forall(f => !df1.inputFiles.contains(f)))
+            assert(deleted.forall(f => !df2.inputFiles.contains(f)))
+            assert(fsRelation.location.inputFiles.forall(_.contains("index")))
+            assert(fsRelation.location.inputFiles.length === 4)
+            deletedFilesList = deletedFilesList :+ deleted
+            p
+          case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
+            val appendedFileCnt = fsRelation.location.inputFiles.count(_.contains(".copy"))
+            val indexFileCnt = fsRelation.location.inputFiles.count(_.contains("index"))
+            if (appendedFileCnt > 0) {
+              assert(appendedFileCnt === 1)
+              assert(fsRelation.location.inputFiles.length === 1)
+            } else {
+              assert(indexFileCnt === 4)
+              assert(fsRelation.location.inputFiles.length === 4)
+            }
+            p
+          case p @ BucketUnion(_, _) => p
+        }
+        assert(nodes.count(_.isInstanceOf[LogicalRelation]) === 3)
+        assert(nodes.count(_.isInstanceOf[BucketUnion]) === 1)
+        assert(nodes.count(_.isInstanceOf[Filter]) === 2)
+        assert(deletedFilesList.length === 2)
+        var deletedFiles = deletedFilesList.flatten
+        assert(deletedFiles.length === 3)
+
+        withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false") {
+          val execPlan = spark.sessionState.executePlan(planWithHybridScan).executedPlan
+          var deleteFilesPushDownFilterCnt = 0
+          val execNodes = execPlan collect {
+            case p @ BucketUnionExec(children, bucketSpec) =>
+              assert(children.size === 2)
+              // children.head is always the index plan.
+              assert(children.head.isInstanceOf[ProjectExec]) // index data
+              assert(children.last.isInstanceOf[ShuffleExchangeExec]) // appended data
+              assert(bucketSpec.bucketColumnNames.length === 1)
+              assert(bucketSpec.bucketColumnNames.head.equals("clicks"))
+              assert(bucketSpec.numBuckets === 200)
+              p
+            case p @ FileSourceScanExec(_, _, _, _, _, dataFilters, _) =>
+              // Check filter pushed down properly.
+              val filterStr = dataFilters.toString
+              assert(filterStr.contains(" >= 2000)") && filterStr.contains(" <= 4000)"))
+              // Check deleted files.
+              if (filterStr.contains(IndexConstants.DATA_FILE_NAME_COLUMN)) {
+                deletedFiles = deletedFiles.filterNot(filterStr.contains(_))
+                deleteFilesPushDownFilterCnt += 1
+              }
+              p
+          }
+          assert(deletedFiles.isEmpty)
+          assert(execNodes.count(_.isInstanceOf[BucketUnionExec]) === 1)
+          // 2 of index, 1 of appended file
+          assert(execNodes.count(_.isInstanceOf[FileSourceScanExec]) === 3)
+          assert(deleteFilesPushDownFilterCnt == 2)
+
+          checkAnswer(baseQuery, join)
+        }
       }
     }
   }

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
@@ -346,7 +346,7 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
 
   test(
     "Delete-only: filter index & parquet format, " +
-      "Hybrid Scan for delete support doesn't work without linage column") {
+      "Hybrid Scan for delete support doesn't work without lineage column") {
     val df = spark.read.parquet(sampleParquetDataLocationDelete2)
     def filterQuery: DataFrame =
       df.filter(df("clicks") <= 2000).select(df("query"))
@@ -399,7 +399,7 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
             case Filter(
                 Not(In(attr, deletedFileNames)),
                 LogicalRelation(fsRelation: HadoopFsRelation, _, _, _)) =>
-              // Check new filter condition on linage column.
+              // Check new filter condition on lineage column.
               assert(attr.toString.contains(IndexConstants.DATA_FILE_NAME_COLUMN))
               val deleted = deletedFileNames.map(_.toString)
               assert(deleted.length == 2)
@@ -458,7 +458,7 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
           case Filter(
               Not(In(attr, deletedFileNames)),
               LogicalRelation(fsRelation: HadoopFsRelation, _, _, _)) =>
-            // Check new filter condition on linage column.
+            // Check new filter condition on lineage column.
             assert(attr.toString.contains(IndexConstants.DATA_FILE_NAME_COLUMN))
             val deleted = deletedFileNames.map(_.toString)
             assert(deleted.length == 2)
@@ -519,7 +519,7 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
         case p @ Filter(
               Not(In(attr, deletedFileNames)),
               LogicalRelation(fsRelation: HadoopFsRelation, _, _, _)) =>
-          // Check new filter condition on linage column.
+          // Check new filter condition on lineage column.
           assert(attr.toString.contains(IndexConstants.DATA_FILE_NAME_COLUMN))
           val deleted = deletedFileNames.map(_.toString)
           assert(deleted.length == 1)
@@ -610,7 +610,7 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
           case p @ Filter(
                 Not(In(attr, deletedFileNames)),
                 LogicalRelation(fsRelation: HadoopFsRelation, _, _, _)) =>
-            // Check new filter condition on linage column.
+            // Check new filter condition on lineage column.
             assert(attr.toString.contains(IndexConstants.DATA_FILE_NAME_COLUMN))
             assert(deletedFileNames.length == 1 || deletedFileNames.length == 2)
             val deleted = deletedFileNames.map(_.toString)

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -123,7 +123,6 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite with SQLHelper {
 
       withIndex("index1") {
         val readDf = spark.read.parquet(dataPath)
-        val sourceFile = readDf.inputFiles.head
         withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
           indexManager.create(readDf, IndexConfig("index1", Seq("id")))
         }
@@ -183,7 +182,7 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite with SQLHelper {
         }
 
         // Scenario #2: Delete 1 file.
-        FileUtils.delete(new Path(sourceFile))
+        FileUtils.delete(new Path(readDf.inputFiles.head))
 
         {
           val optimizedPlan = spark.read.parquet(dataPath).queryExecution.optimizedPlan

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -121,7 +121,9 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite with SQLHelper {
       withIndex("index1") {
         val readDf = spark.read.parquet(dataPath)
         val sourceFile = readDf.inputFiles.head
-        indexManager.create(readDf, IndexConfig("index1", Seq("id")))
+        withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
+          indexManager.create(readDf, IndexConfig("index1", Seq("id")))
+        }
 
         def verify(
             plan: LogicalPlan,
@@ -191,6 +193,11 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite with SQLHelper {
             hybridScanEnabled = true,
             hybridScanDeleteEnabled = false,
             expectCandidateIndex = false)
+          verify(
+            optimizedPlan,
+            hybridScanEnabled = true,
+            hybridScanDeleteEnabled = true,
+            expectCandidateIndex = true)
         }
 
         // Scenario #3: Replace all files.


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What is the context for this pull request?
<!--
Please clarify the context for the changes you are contributing. The purpose of this section is to outline information information to help reviewers have enough context.
-->

 - **Tracking Issue**: #150
 - **Parent Issue**: #150
 - **Dependencies**: #165

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.

The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->
With lineage column in the index data, we could exclude the deleted rows from the index data at query time, by injecting `Filter(Not(In(<lineage column>, <deleted files>)))`.
I added additional config `spark.hyperspace.index.hybridscan.delete.enabled` for enabling/disabling hybrid scan for delete dataset until performance validation and optimization.
- `spark.hyperspace.index.hybridscan.enabled = true/ spark.hyperspace.index.hybridscan.delete.enabled = false` => hybrid scan only for appended dataset; if there are deleted files in source relation, the index won't be applied.
- `spark.hyperspace.index.hybridscan.enabled = false / spark.hyperspace.index.hybridscan.delete.enabled = true` won't work

To support this, additional project & filter node is injected to LogicalRelation plan of index data. Reading the index data with the lineage column and filter the deleted files, and then exclude the lineage column as it shouldn't be shown in the result.
```
   :  :- Project [clicks#456, query#454]
   :  :  +- Filter ((isnotnull(clicks#456) && (clicks#456 >= 2000)) && (clicks#456 <= 4000))
   :  :     +- Project [Query#454, clicks#456]
   :  :        +- Filter NOT _data_file_name#474 IN  (file:/C:/Users/eunsong/repo/hyperspace2/src/test/resources/data/sampleparquet4/part-00003-3b411cdd-be12-4dad-a6a0-23fd244bd6e4-c000.snappy.parquet)
```

Note that the injected Project & Fitler is optimized by Spark so that there's no extra stage for them:
```
   :     +- BucketUnion 200 buckets, bucket columns: [clicks]
   :        :- *(1) Project [clicks#456, query#454]
   :        :  +- *(1) Filter ((((isnotnull(_data_file_name#474) && NOT (_data_file_name#474 = file:/C:/Users/eunsong/repo/hyperspace2/src/test/resources/data/sampleparquet4/part-00003-3b411cdd-be12-4dad-a6a0-23fd244bd6e4-c000.snappy.parquet)) && isnotnull(clicks#456)) && (clicks#456 >= 2000)) && (clicks#456 <= 4000))
   :        :     +- *(1) FileScan parquet [clicks#456,Query#454,_data_file_name#474] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/repo/hyperspace2/src/test/resources/hybridScanTest/index..., PartitionFilters: [], PushedFilters: [IsNotNull(_data_file_name), Not(EqualTo(_data_file_name,file:/C:/Users/eunsong/repo/hyperspace2/..., ReadSchema: struct<clicks:int,Query:string,_data_file_name:string>, Sele
ctedBucketsCount: 200 out of 200
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, if a user enabled Hybrid Scan delete support, indexes invalidated by "deleted files" from its source relation can be still utilized with modified plan.

The followings are the logical & physical plan for Join plan, with both appended and deleted files.

Logical plan
```
Project [clicks#456, query#454, query#468]
+- Join Inner, (clicks#456 = clicks#470)
   :- BucketUnion 200 buckets, bucket columns: [clicks]
   :  :- Project [clicks#456, query#454]
   :  :  +- Filter ((isnotnull(clicks#456) && (clicks#456 >= 2000)) && (clicks#456 <= 4000))
   :  :     +- Project [Query#454, clicks#456]
   :  :        +- Filter NOT _data_file_name#474 IN (file:/C:/Users/eunsong/repo/hyperspace2/src/test/resources/data/sampleparquet4/part-00003-3b411cdd-be12-4dad-a6a0-23fd244bd6e4-c000.snappy.parquet)
   :  :           +- Relation[Query#454,clicks#456,_data_file_name#474] parquet
   :  +- RepartitionByExpression [clicks#456], 200
   :     +- Project [clicks#456, query#454]
   :        +- Filter ((isnotnull(clicks#456) && (clicks#456 >= 2000)) && (clicks#456 <= 4000))
   :           +- Relation[Query#454,clicks#456] parquet
   +- BucketUnion 200 buckets, bucket columns: [clicks]
      :- Project [clicks#470, query#468]
      :  +- Filter ((isnotnull(clicks#470) && (clicks#470 <= 4000)) && (clicks#470 >= 2000))
      :     +- Project [Query#468, clicks#470]
      :        +- Filter NOT _data_file_name#475 IN (file:/C:/Users/eunsong/repo/hyperspace2/src/test/resources/data/sampleparquet4/part-00003-3b411cdd-be12-4dad-a6a0-23fd244bd6e4-c000.snappy.parquet)
      :           +- Relation[Query#468,clicks#470,_data_file_name#475] parquet
      +- RepartitionByExpression [clicks#470], 200
         +- Project [clicks#470, query#468]
            +- Filter ((isnotnull(clicks#470) && (clicks#470 <= 4000)) && (clicks#470 >= 2000))
               +- Relation[Query#468,clicks#470] parquet
```

Physical plan
```
*(7) Project [clicks#456, query#454, query#468]
+- *(7) SortMergeJoin [clicks#456], [clicks#470], Inner
   :- *(3) Sort [clicks#456 ASC NULLS FIRST], false, 0
   :  +- *(3) Filter isnotnull(clicks#456)
   :     +- BucketUnion 200 buckets, bucket columns: [clicks]
   :        :- *(1) Project [clicks#456, query#454]
   :        :  +- *(1) Filter ((((isnotnull(_data_file_name#474) && NOT (_data_file_name#474 = file:/C:/Users/eunsong/repo/hyperspace2/src/test/resources/data/sampleparquet4/part-00003-3b411cdd-be12-4dad-a6a0-23fd244bd6e4-c000.snappy.parquet)) && isnotnull(clicks#456)) && (clicks#456 >= 2000)) && (clicks#456 <= 4000))
   :        :     +- *(1) FileScan parquet [clicks#456,Query#454,_data_file_name#474] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/repo/hyperspace2/src/test/resources/hybridScanTest/index..., PartitionFilters: [], PushedFilters: [IsNotNull(_data_file_name), Not(EqualTo(_data_file_name,file:/C:/Users/eunsong/repo/hyperspace2/..., ReadSchema: struct<clicks:int,Query:string,_data_file_name:string>, Sele
ctedBucketsCount: 200 out of 200
   :        +- Exchange hashpartitioning(clicks#456, 200)
   :           +- *(2) Project [clicks#456, query#454]
   :              +- *(2) Filter ((isnotnull(clicks#456) && (clicks#456 >= 2000)) && (clicks#456 <= 4000))
   :                 +- *(2) FileScan parquet [clicks#456,Query#454] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/repo/hyperspace2/src/test/resources/data/sampleparquet4/..., PartitionFilters: [], PushedFilters: [IsNotNull(clicks), GreaterThanOrEqual(clicks,2000), LessThanOrEqual(clicks,4000)], ReadSchema: struct<clicks:int,Query:string>
   +- *(6) Sort [clicks#470 ASC NULLS FIRST], false, 0
      +- *(6) Filter isnotnull(clicks#470)
         +- BucketUnion 200 buckets, bucket columns: [clicks]
            :- *(4) Project [clicks#470, query#468]
            :  +- *(4) Filter ((((isnotnull(_data_file_name#475) && NOT (_data_file_name#475 = file:/C:/Users/eunsong/repo/hyperspace2/src/test/resources/data/sampleparquet4/part-00003-3b411cdd-be12-4dad-a6a0-23fd244bd6e4-c000.snappy.parquet)) && isnotnull(clicks#470)) && (clicks#470 <= 4000)) && (clicks#470 >= 2000))
            :     +- *(4) FileScan parquet [clicks#470,Query#468,_data_file_name#475] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/Users/eunsong/repo/hyperspace2/src/test/resources/hybridScanTest/index..., PartitionFilters: [], PushedFilters: [IsNotNull(_data_file_name), Not(EqualTo(_data_file_name,file:/C:/Users/eunsong/repo/hyperspace2/..., ReadSchema: struct<clicks:int,Query:string,_data_file_name:string>, Sele
ctedBucketsCount: 200 out of 200
            +- ReusedExchange [clicks#470, query#468], Exchange hashpartitioning(clicks#456, 200)

```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
unit test
