### PR TITLE
Expose HyperspaceSuite.withTempDir() to be used in tests involving temporary directories.

### DIFF
--- a/src/main/scala/org/apache/spark/util/hyperspace/Utils.scala
+++ b/src/main/scala/org/apache/spark/util/hyperspace/Utils.scala
@@ -16,11 +16,21 @@
 
 package org.apache.spark.util.hyperspace
 
+import java.io.File
+
 /**
  * This class is used to expose package private methods from org.apache.spark.util.Utils.
  */
 object Utils {
   def classForName(className: String): Class[_] = {
     org.apache.spark.util.Utils.classForName(className)
+  }
+
+  def createTempDir(): File = {
+    org.apache.spark.util.Utils.createTempDir()
+  }
+
+  def deleteRecursively(file: File): Unit = {
+    org.apache.spark.util.Utils.deleteRecursively(file)
   }
 }

--- a/src/test/scala/com/microsoft/hyperspace/index/HyperspaceSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HyperspaceSuite.scala
@@ -16,8 +16,11 @@
 
 package com.microsoft.hyperspace.index
 
+import java.io.File
+
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.util.hyperspace.Utils
 
 import com.microsoft.hyperspace.{Hyperspace, SparkInvolvedSuite}
 import com.microsoft.hyperspace.util.FileUtils
@@ -84,6 +87,19 @@ trait HyperspaceSuite extends SparkFunSuite with SparkInvolvedSuite {
         hs.deleteIndex(name)
         hs.vacuumIndex(name)
       }
+    }
+  }
+
+  /**
+   * Creates a temporary directory, which is then passed to `f` and will be deleted after `f`
+   * returns. This is copied from SparkFunSuite.scala in Spark 3.0.
+   *
+   * TODO: This can be removed when we support Spark 3.0.
+   */
+  protected def withTempDir(f: File => Unit): Unit = {
+    val dir = Utils.createTempDir()
+    try f(dir) finally {
+      Utils.deleteRecursively(dir)
     }
   }
 }


### PR DESCRIPTION
I see many tests where we need to be careful about deleting a directory used after a test is run.

This PR exposes `HyperspaceSuite.withTempDir()` where you can use it like the following:
```scala
withTempDir { dir =>
  foo(dir)
}
```
This is a copy of `SparkFunSuite.withTempDir`, which is available in Spark 3.0. When we move to Spark 3.0, we can just remove this function and any existing code should just work since `HyperspaceSuite` extends `SparkFunSuite`.