### PR TITLE
Skip applying rules for modified plans by Hyperspace

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -30,7 +30,9 @@ object IndexConstants {
   val INDEX_HYBRID_SCAN_ENABLED = "spark.hyperspace.index.hybridscan.enabled"
   val INDEX_HYBRID_SCAN_ENABLED_DEFAULT = "false"
 
-  var INDEX_RELATION_IDENTIFIER_KEY: String = "indexRelation"
+  // Identifier injected to HadoopFsRelation as an option if an index is applied.
+  val INDEX_RELATION_IDENTIFIER_KEY: String = "indexRelation"
+  val INDEX_RELATION_IDENTIFIER: (String, String) = ("indexRelation" -> "true")
 
   // Default number of buckets is set the default value of "spark.sql.shuffle.partitions".
   val INDEX_NUM_BUCKETS_DEFAULT: Int = SQLConf.SHUFFLE_PARTITIONS.defaultValue.get

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -30,6 +30,8 @@ object IndexConstants {
   val INDEX_HYBRID_SCAN_ENABLED = "spark.hyperspace.index.hybridscan.enabled"
   val INDEX_HYBRID_SCAN_ENABLED_DEFAULT = "false"
 
+  var INDEX_RELATION_IDENTIFIER_KEY: String = "indexRelation"
+
   // Default number of buckets is set the default value of "spark.sql.shuffle.partitions".
   val INDEX_NUM_BUCKETS_DEFAULT: Int = SQLConf.SHUFFLE_PARTITIONS.defaultValue.get
 

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -31,7 +31,6 @@ object IndexConstants {
   val INDEX_HYBRID_SCAN_ENABLED_DEFAULT = "false"
 
   // Identifier injected to HadoopFsRelation as an option if an index is applied.
-  val INDEX_RELATION_IDENTIFIER_KEY: String = "indexRelation"
   val INDEX_RELATION_IDENTIFIER: (String, String) = ("indexRelation" -> "true")
 
   // Default number of buckets is set the default value of "spark.sql.shuffle.partitions".

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -31,6 +31,9 @@ object IndexConstants {
   val INDEX_HYBRID_SCAN_ENABLED_DEFAULT = "false"
 
   // Identifier injected to HadoopFsRelation as an option if an index is applied.
+  // Currently, the identifier is added to options field of HadoopFsRelation.
+  // In Spark 3.0, we could utilize TreeNodeTag to mark the identifier for each plan.
+  // See https://github.com/microsoft/hyperspace/issues/185
   val INDEX_RELATION_IDENTIFIER: (String, String) = ("indexRelation" -> "true")
 
   // Default number of buckets is set the default value of "spark.sql.shuffle.partitions".

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources._
 
 import com.microsoft.hyperspace.{ActiveSparkSession, Hyperspace}
-import com.microsoft.hyperspace.index.IndexLogEntry
+import com.microsoft.hyperspace.index.{IndexConstants, IndexLogEntry}
 import com.microsoft.hyperspace.telemetry.{AppInfo, HyperspaceEventLogging, HyperspaceIndexUsageEvent}
 import com.microsoft.hyperspace.util.{HyperspaceConf, ResolverUtils}
 
@@ -174,10 +174,10 @@ object ExtractFilterNode {
           filter @ Filter(
             condition: Expression,
             logicalRelation @ LogicalRelation(
-              fsRelation @ HadoopFsRelation(_, _, _, _, _, _),
+              fsRelation @ HadoopFsRelation(_, _, _, _, _, options),
               _,
               _,
-              _))) =>
+              _))) if !options.contains(IndexConstants.INDEX_RELATION_IDENTIFIER_KEY) =>
       val projectColumnNames = CleanupAliases(project)
         .asInstanceOf[Project]
         .projectList
@@ -190,10 +190,10 @@ object ExtractFilterNode {
     case filter @ Filter(
           condition: Expression,
           logicalRelation @ LogicalRelation(
-            fsRelation @ HadoopFsRelation(_, _, _, _, _, _),
+            fsRelation @ HadoopFsRelation(_, _, _, _, _, options),
             _,
             _,
-            _)) =>
+            _)) if !options.contains(IndexConstants.INDEX_RELATION_IDENTIFIER_KEY) =>
       val relationColumnsName = logicalRelation.output.map(_.name)
       val filterColumnNames = condition.references.map(_.name).toSeq
 

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources._
 
 import com.microsoft.hyperspace.{ActiveSparkSession, Hyperspace}
-import com.microsoft.hyperspace.index.{IndexConstants, IndexLogEntry}
+import com.microsoft.hyperspace.index.IndexLogEntry
 import com.microsoft.hyperspace.telemetry.{AppInfo, HyperspaceEventLogging, HyperspaceIndexUsageEvent}
 import com.microsoft.hyperspace.util.{HyperspaceConf, ResolverUtils}
 
@@ -173,11 +173,8 @@ object ExtractFilterNode {
           _,
           filter @ Filter(
             condition: Expression,
-            logicalRelation @ LogicalRelation(
-              fsRelation @ HadoopFsRelation(_, _, _, _, _, options),
-              _,
-              _,
-              _))) if !options.contains(IndexConstants.INDEX_RELATION_IDENTIFIER_KEY) =>
+            logicalRelation @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _)))
+        if !RuleUtils.isIndexApplied(fsRelation) =>
       val projectColumnNames = CleanupAliases(project)
         .asInstanceOf[Project]
         .projectList
@@ -189,11 +186,8 @@ object ExtractFilterNode {
 
     case filter @ Filter(
           condition: Expression,
-          logicalRelation @ LogicalRelation(
-            fsRelation @ HadoopFsRelation(_, _, _, _, _, options),
-            _,
-            _,
-            _)) if !options.contains(IndexConstants.INDEX_RELATION_IDENTIFIER_KEY) =>
+          logicalRelation @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _))
+        if !RuleUtils.isIndexApplied(fsRelation) =>
       val relationColumnsName = logicalRelation.output.map(_.name)
       val filterColumnNames = condition.references.map(_.name).toSeq
 

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -189,17 +189,17 @@ object JoinIndexRule
 
   /**
    * Check if the candidate plan is already modified by Hyperspace or not.
-   * This can be determined by a specific key in options of HadoopFsRelation.
+   * This can be determined by an identifier in options field of HadoopFsRelation.
    *
    * @param plan Logical plan.
    * @return true if the relation in the plan is modified by Hyperspace.
    */
   private def isPlanModified(plan: LogicalPlan): Boolean = {
-    plan.collect {
-      case LogicalRelation(HadoopFsRelation(_, _, _, _, _, options), _, _, _)
-          if (options.contains(IndexConstants.INDEX_RELATION_IDENTIFIER_KEY)) =>
-        true
-    }.nonEmpty
+    plan.find {
+      case LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
+        RuleUtils.isIndexApplied(fsRelation)
+      case _ => false
+    }.isDefined
   }
 
   /**

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -130,8 +130,7 @@ object RuleUtils {
    * @return true if the relation has index plan identifier. Otherwise false.
    */
   def isIndexApplied(relation: HadoopFsRelation): Boolean = {
-    val identifier = relation.options.get(IndexConstants.INDEX_RELATION_IDENTIFIER_KEY)
-    identifier.isDefined && identifier.get.equals("true")
+    relation.options.exists(_.equals(IndexConstants.INDEX_RELATION_IDENTIFIER))
   }
 
   /**

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.types.StructType
 
 import com.microsoft.hyperspace.actions.Constants
-import com.microsoft.hyperspace.index.{FileInfo, IndexLogEntry, IndexManager, LogicalPlanSignatureProvider}
+import com.microsoft.hyperspace.index.{FileInfo, IndexConstants, IndexLogEntry, IndexManager, LogicalPlanSignatureProvider}
 import com.microsoft.hyperspace.index.plans.logical.BucketUnion
 import com.microsoft.hyperspace.util.HyperspaceConf
 
@@ -186,7 +186,7 @@ object RuleUtils {
           StructType(index.schema.filter(baseRelation.schema.contains(_))),
           if (useBucketSpec) Some(index.bucketSpec) else None,
           new ParquetFileFormat,
-          Map())(spark)
+          Map(IndexConstants.INDEX_RELATION_IDENTIFIER_KEY -> "true"))(spark)
 
         val updatedOutput =
           baseOutput.filter(attr => relation.schema.fieldNames.contains(attr.name))
@@ -253,7 +253,7 @@ object RuleUtils {
           StructType(index.schema.filter(baseRelation.schema.contains(_))),
           if (useBucketSpec) Some(index.bucketSpec) else None,
           new ParquetFileFormat,
-          Map())(spark)
+          Map(IndexConstants.INDEX_RELATION_IDENTIFIER_KEY -> "true"))(spark)
 
         val updatedOutput =
           baseOutput.filter(attr => relation.schema.fieldNames.contains(attr.name))
@@ -322,7 +322,9 @@ object RuleUtils {
         val newRelation =
           fsRelation.copy(
             location = newLocation,
-            dataSchema = StructType(indexSchema.filter(baseRelation.schema.contains(_))))(spark)
+            dataSchema = StructType(indexSchema.filter(baseRelation.schema.contains(_))),
+            options = fsRelation.options ++ Map(
+              IndexConstants.INDEX_RELATION_IDENTIFIER_KEY -> "true"))(spark)
         baseRelation.copy(relation = newRelation, output = updatedOutput)
     }
     assert(!originalPlan.equals(planForAppended))

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/FilterIndexRuleTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/FilterIndexRuleTest.scala
@@ -126,7 +126,6 @@ class FilterIndexRuleTest extends HyperspaceRuleTestSuite {
   }
 
   test("Verify FilterIndex rule is not applied for modified plan.") {
-    // Copied from test("Verify FilterIndex rule is applied when all columns are selected.")
     val filterCondition = And(IsNotNull(c4), EqualTo(c4, Literal(10, IntegerType)))
     val plan = Filter(filterCondition, scanNode)
     // Verify index rule updates the plan.

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
@@ -88,8 +88,11 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
   def schemaFromAttributes(attributes: Attribute*): StructType =
     StructType(attributes.map(a => StructField(a.name, a.dataType, a.nullable, a.metadata)))
 
-  def baseRelation(location: FileIndex, schema: StructType): HadoopFsRelation =
-    HadoopFsRelation(location, new StructType(), schema, None, new ParquetFileFormat, Map.empty)(
+  def baseRelation(
+      location: FileIndex,
+      schema: StructType,
+      options: Map[String, String] = Map.empty): HadoopFsRelation =
+    HadoopFsRelation(location, new StructType(), schema, None, new ParquetFileFormat, options)(
       spark)
 
   def getIndexRootPath(indexName: String): Path =

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
@@ -88,11 +88,8 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
   def schemaFromAttributes(attributes: Attribute*): StructType =
     StructType(attributes.map(a => StructField(a.name, a.dataType, a.nullable, a.metadata)))
 
-  def baseRelation(
-      location: FileIndex,
-      schema: StructType,
-      options: Map[String, String] = Map.empty): HadoopFsRelation =
-    HadoopFsRelation(location, new StructType(), schema, None, new ParquetFileFormat, options)(
+  def baseRelation(location: FileIndex, schema: StructType): HadoopFsRelation =
+    HadoopFsRelation(location, new StructType(), schema, None, new ParquetFileFormat, Map.empty)(
       spark)
 
   def getIndexRootPath(indexName: String): Path =

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/JoinIndexRuleTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/JoinIndexRuleTest.scala
@@ -399,7 +399,6 @@ class JoinIndexRuleTest extends HyperspaceRuleTestSuite with SQLHelper {
   }
 
   test("Join rule is not applied for modified plan.") {
-    // Copied from test("Join rule works if indexes exist and configs are set correctly")
     val joinCondition = EqualTo(t1c1, t2c1)
     val plan = Join(t1ProjectNode, t2ProjectNode, JoinType("inner"), Some(joinCondition))
     assert(!JoinIndexRule(plan).equals(plan))


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What is the context for this pull request?
<!--
Please clarify the context for the changes you are contributing. The purpose of this section is to outline information information to help reviewers have enough context.
-->

 - **Tracking Issue**: #160 
 - **Parent Issue**: N/A.
 - **Dependencies**: N/A

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.

The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->

To avoid applying rules for already modified plans by Hyperspace, this PR introduces a new tag to the modified plan.
Spark provides `TreeNodeTag` feature, but it's only available from [Spark 3.0](https://github.com/apache/spark/blob/branch-3.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala)

This PR creates a new identifier to `options` field in `HadoopFsRelation` of each modified plan which location is replaced by index data path (or appended file paths for hybrid scan).

```
// IndexConstants.scala 
 val INDEX_RELATION_IDENTIFIER: (String, String) = ("indexRelation" -> "true")
```

With this, in `FilterIndexRule` and `JoinIndexRule`, we can check whether each candidate plan has the identifier or not. If the plan is modified, we could skip trying to apply rules for it.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test
