### PR TITLE
Change lineage UDF to fix CreateIndex performance issue

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -196,7 +196,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
       // - Normalized path to be stored in DATA_FILE_NAME_COLUMN column:
       //    + file:/C:/myGit/hyperspace-1/src/test/part-00003.snappy.parquet
       val absolutePath: UserDefinedFunction = udf(
-        (filePath: String) => PathUtils.makeAbsolute(filePath).toString)
+        (filePath: String) => filePath.replace("file:///", "file:/"))
 
       df.select(allIndexColumns.head, allIndexColumns.tail: _*)
         .withColumn(IndexConstants.DATA_FILE_NAME_COLUMN, absolutePath(input_file_name()))

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -192,9 +192,9 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
       // value of DATA_FILE_NAME_COLUMN column is read.
       // Here is an example of normalization:
       // - Original raw path (output of input_file_name() udf, before normalization):
-      //    + file:///C:/myGit/hyperspace-1/src/test/part-00003.snappy.parquet
+      //    + file:///C:/hyperspace/src/test/part-00003.snappy.parquet
       // - Normalized path to be stored in DATA_FILE_NAME_COLUMN column:
-      //    + file:/C:/myGit/hyperspace-1/src/test/part-00003.snappy.parquet
+      //    + file:/C:/hyperspace/src/test/part-00003.snappy.parquet
       val absolutePath: UserDefinedFunction = udf(
         (filePath: String) => filePath.replace("file:///", "file:/"))
 


### PR DESCRIPTION
### What is the context for this pull request?
This PR changes the UDF used for normalizing source data file paths to fill lineage column values.
We normalize path values in the lineage column by removing extra preceding `/` characters in the full file path for each and every index entry.

### What changes were proposed in this pull request?
Currently, file path normalization happens by calling: `PathUtils.makeAbsolute()`. However, according to some simple performance benchmark, we realized this adds a significant overhead to createIndex operation. This PR modifies the UDF to use  String's `replace()` function. Given that `input_file()` function returns full path to source data file for each row, this change of UDF is safe and produces the same output as the original UDF.
  
### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests cases under `RefreshIndexTests` and `E2EHyperspaceRulesTests` already cover this code path.