### PR TITLE
Add hybrid scan config for the max number of deleted files

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -42,11 +42,19 @@ object IndexConstants {
   val INDEX_HYBRID_SCAN_DELETE_ENABLED = "spark.hyperspace.index.hybridscan.delete.enabled"
   val INDEX_HYBRID_SCAN_DELETE_ENABLED_DEFAULT = "false"
 
+  // With the current performance limitation of Hybrid scan for delete files, we limit
+  // the number of deleted files to avoid regression from Hybrid scan.
+  // If the number of deleted files is larger than this config, the index is disabled and
+  // cannot be a candidate for Hybrid Scan.
+  val INDEX_HYBRID_SCAN_DELETE_MAX_NUM_FILES =
+    "spark.hyperspace.index.hybridscan.delete.maxNumDeletedFiles"
+  val INDEX_HYBRID_SCAN_DELETE_MAX_NUM_FILES_DEFAULT = "10"
+
   // Identifier injected to HadoopFsRelation as an option if an index is applied.
   // Currently, the identifier is added to options field of HadoopFsRelation.
   // In Spark 3.0, we could utilize TreeNodeTag to mark the identifier for each plan.
   // See https://github.com/microsoft/hyperspace/issues/185
-  val INDEX_RELATION_IDENTIFIER: (String, String) = ("indexRelation" -> "true")
+  val INDEX_RELATION_IDENTIFIER: (String, String) = "indexRelation" -> "true"
 
   // Default number of buckets is set the default value of "spark.sql.shuffle.partitions".
   val INDEX_NUM_BUCKETS_DEFAULT: Int = SQLConf.SHUFFLE_PARTITIONS.defaultValue.get

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -79,12 +79,12 @@ object RuleUtils {
 
       // Find the number of common files between the source relations & index source files.
       val commonCnt = inputSourceFiles.count(entry.allSourceFileInfos.contains)
+      val deletedCnt = entry.allSourceFileInfos.size - commonCnt
 
       if (hybridScanDeleteEnabled && entry.hasLineageColumn(spark)) {
-        commonCnt > 0
+        commonCnt > 0 && deletedCnt <= HyperspaceConf.hybridScanDeleteMaxNumFiles(spark)
       } else {
         // For append-only Hybrid Scan, deleted files are not allowed.
-        val deletedCnt = entry.allSourceFileInfos.size - commonCnt
         deletedCnt == 0 && commonCnt > 0
       }
     }
@@ -105,12 +105,13 @@ object RuleUtils {
         }
       assert(filesByRelations.length == 1)
       indexes.filter(index =>
-        index.created && isHybridScanCandidate(index, filesByRelations.flatten))
+        index.created && index.deletedFiles.isEmpty && index.appendedFiles.isEmpty &&
+          isHybridScanCandidate(index, filesByRelations.flatten))
     } else {
       indexes.filter(
         index =>
-          index.created && signatureValid(index) &&
-            index.deletedFiles.isEmpty && index.appendedFiles.isEmpty)
+          index.created && index.deletedFiles.isEmpty && index.appendedFiles.isEmpty &&
+            signatureValid(index))
     }
   }
 

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -104,6 +104,10 @@ object RuleUtils {
               FileInfo(f.getPath.toString, f.getLen, f.getModificationTime))
         }
       assert(filesByRelations.length == 1)
+      // index.deletedFiles and index.appendedFiles should be non-empty until Hybrid Scan
+      // handles the lists properly. Otherwise, as the source file list of each index entry
+      // (entry.allSourceFileInfo) also contains the appended and deleted files, we cannot
+      // get the actual appended files and deleted files correctly.
       indexes.filter(index =>
         index.created && index.deletedFiles.isEmpty && index.appendedFiles.isEmpty &&
           isHybridScanCandidate(index, filesByRelations.flatten))

--- a/src/main/scala/com/microsoft/hyperspace/util/HyperspaceConf.scala
+++ b/src/main/scala/com/microsoft/hyperspace/util/HyperspaceConf.scala
@@ -40,6 +40,14 @@ object HyperspaceConf {
       .toBoolean
   }
 
+  def hybridScanDeleteMaxNumFiles(spark: SparkSession): Int = {
+    spark.conf
+      .get(
+        IndexConstants.INDEX_HYBRID_SCAN_DELETE_MAX_NUM_FILES,
+        IndexConstants.INDEX_HYBRID_SCAN_DELETE_MAX_NUM_FILES_DEFAULT)
+      .toInt
+  }
+
   def refreshDeleteEnabled(spark: SparkSession): Boolean = {
     spark.conf
       .get(IndexConstants.REFRESH_DELETE_ENABLED,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What is the context for this pull request?
<!--
Please clarify the context for the changes you are contributing. The purpose of this section is to outline information information to help reviewers have enough context.
-->

 - **Tracking Issue**: #159 
 - **Parent Issue**: #150 
 - **Dependencies**: n/a

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.

The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->
With the current performance limitation of Hybrid scan operation for delete dataset, we limit the number of  deleted files to avoid regression from Hybrid scan. If the number of deleted files is larger than this config, the index is disabled and cannot be a candidate for Hybrid Scan.

```
  val INDEX_HYBRID_SCAN_DELETE_MAX_NUM_FILES =
    "spark.hyperspace.index.hybridscan.delete.maxNumDeletedFiles"
  val INDEX_HYBRID_SCAN_DELETE_MAX_NUM_FILES_DEFAULT = "10"
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, a new config is added for Hybrid scan delete dataset.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
unit test