### PR TITLE
Use configs of previous LogEntry for refresh action

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -39,11 +39,11 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
       .getOrElse(dataManager.getPath(0))
   }
 
-  protected def getNumBucketsConfig(spark: SparkSession): Int = {
+  protected def numBucketsForIndex(spark: SparkSession): Int = {
     HyperspaceConf.numBucketsForIndex(spark)
   }
 
-  protected def getLineageColumnConfig(spark: SparkSession): Boolean = {
+  protected def indexLineageEnabled(spark: SparkSession): Boolean = {
     HyperspaceConf.indexLineageEnabled(spark)
   }
 
@@ -53,7 +53,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
       indexConfig: IndexConfig,
       path: Path): IndexLogEntry = {
     val absolutePath = PathUtils.makeAbsolute(path)
-    val numBuckets = getNumBucketsConfig(spark)
+    val numBuckets = numBucketsForIndex(spark)
 
     val signatureProvider = LogicalPlanSignatureProvider.create()
 
@@ -122,7 +122,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
     }
 
   protected def write(spark: SparkSession, df: DataFrame, indexConfig: IndexConfig): Unit = {
-    val numBuckets = getNumBucketsConfig(spark)
+    val numBuckets = numBucketsForIndex(spark)
 
     val (indexDataFrame, resolvedIndexedColumns, _) =
       prepareIndexDataFrame(spark, df, indexConfig)
@@ -168,7 +168,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
       indexConfig: IndexConfig): (DataFrame, Seq[String], Seq[String]) = {
     val (resolvedIndexedColumns, resolvedIncludedColumns) = resolveConfig(df, indexConfig)
     val columnsFromIndexConfig = resolvedIndexedColumns ++ resolvedIncludedColumns
-    val addLineage = getLineageColumnConfig(spark)
+    val addLineage = indexLineageEnabled(spark)
 
     val indexDF = if (addLineage) {
       // Lineage is captured using two sets of columns:

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.sources.DataSourceRegister
 import com.microsoft.hyperspace.HyperspaceException
 import com.microsoft.hyperspace.index._
 import com.microsoft.hyperspace.index.DataFrameWriterExtensions.Bucketizer
-import com.microsoft.hyperspace.util.{PathUtils, ResolverUtils}
+import com.microsoft.hyperspace.util.{HyperspaceConf, PathUtils, ResolverUtils}
 
 /**
  * CreateActionBase provides functionality to write dataframe as covering index.
@@ -40,19 +40,11 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
   }
 
   protected def getNumBucketsConfig(spark: SparkSession): Int = {
-    spark.sessionState.conf
-      .getConfString(
-        IndexConstants.INDEX_NUM_BUCKETS,
-        IndexConstants.INDEX_NUM_BUCKETS_DEFAULT.toString)
-      .toInt
+    HyperspaceConf.numBucketsForIndex(spark)
   }
 
   protected def getLineageColumnConfig(spark: SparkSession): Boolean = {
-    spark.sessionState.conf
-      .getConfString(
-        IndexConstants.INDEX_LINEAGE_ENABLED,
-        IndexConstants.INDEX_LINEAGE_ENABLED_DEFAULT)
-      .toBoolean
+    HyperspaceConf.indexLineageEnabled(spark)
   }
 
   protected def getIndexLogEntry(

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
@@ -37,10 +37,6 @@ class RefreshAction(
     extends RefreshActionBase(spark, logManager, dataManager) {
 
   final override def op(): Unit = {
-    // TODO: The current implementation picks the number of buckets and
-    //  "spark.hyperspace.index.lineage.enabled" from session config. This should be
-    //  user-configurable to allow maintain the existing bucket numbers in the index log entry.
-    //  https://github.com/microsoft/hyperspace/issues/196.
     write(spark, df, indexConfig)
   }
 

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
@@ -49,6 +49,14 @@ private[actions] abstract class RefreshActionBase(
 
   protected lazy val previousIndexLogEntry = previousLogEntry.asInstanceOf[IndexLogEntry]
 
+  override protected final def getNumBucketsConfig(spark: SparkSession): Int = {
+    previousIndexLogEntry.numBuckets
+  }
+
+  override protected final def getLineageColumnConfig(spark: SparkSession): Boolean = {
+    previousIndexLogEntry.hasLineageColumn(spark)
+  }
+
   // Reconstruct a df from schema
   protected lazy val df = {
     val rels = previousIndexLogEntry.relations

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
@@ -53,13 +53,13 @@ private[actions] abstract class RefreshActionBase(
   // throughout all index versions. For "full" refresh mode, we could allow to change configs
   // like num buckets or lineage column as it is newly building the index data. This might
   // be done with a different refresh mode if necessary.
-  override protected final def getNumBucketsConfig(spark: SparkSession): Int = {
+  override protected final def numBucketsForIndex(spark: SparkSession): Int = {
     previousIndexLogEntry.numBuckets
   }
 
   // Refresh maintains the same lineage column config as the existing index.
   // See above getNumBucketsConfig for more detail.
-  override protected final def getLineageColumnConfig(spark: SparkSession): Boolean = {
+  override protected final def indexLineageEnabled(spark: SparkSession): Boolean = {
     previousIndexLogEntry.hasLineageColumn(spark)
   }
 

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
@@ -49,10 +49,16 @@ private[actions] abstract class RefreshActionBase(
 
   protected lazy val previousIndexLogEntry = previousLogEntry.asInstanceOf[IndexLogEntry]
 
+  // Refresh maintains the same number of buckets as the existing index to be consistent
+  // throughout all index versions. For "full" refresh mode, we could allow to change configs
+  // like num buckets or lineage column as it is newly building the index data. This might
+  // be done with a different refresh mode if necessary.
   override protected final def getNumBucketsConfig(spark: SparkSession): Int = {
     previousIndexLogEntry.numBuckets
   }
 
+  // Refresh maintains the same lineage column config as the existing index.
+  // See above getNumBucketsConfig for more detail.
   override protected final def getLineageColumnConfig(spark: SparkSession): Boolean = {
     previousIndexLogEntry.hasLineageColumn(spark)
   }

--- a/src/main/scala/com/microsoft/hyperspace/util/HyperspaceConf.scala
+++ b/src/main/scala/com/microsoft/hyperspace/util/HyperspaceConf.scala
@@ -18,7 +18,7 @@ package com.microsoft.hyperspace.util
 
 import org.apache.spark.sql.SparkSession
 
-import com.microsoft.hyperspace.index.IndexConstants
+import com.microsoft.hyperspace.index.{Content, CoveringIndex, IndexConstants, IndexLogEntry, LogEntry, Source}
 
 /**
  * Helper class to extract Hyperspace-related configs from SparkSession.
@@ -46,5 +46,21 @@ object HyperspaceConf {
         IndexConstants.INDEX_HYBRID_SCAN_DELETE_MAX_NUM_FILES,
         IndexConstants.INDEX_HYBRID_SCAN_DELETE_MAX_NUM_FILES_DEFAULT)
       .toInt
+  }
+
+  def numBucketsForIndex(spark: SparkSession): Int = {
+    spark.sessionState.conf
+      .getConfString(
+        IndexConstants.INDEX_NUM_BUCKETS,
+        IndexConstants.INDEX_NUM_BUCKETS_DEFAULT.toString)
+      .toInt
+  }
+
+  def indexLineageEnabled(spark: SparkSession): Boolean = {
+    spark.sessionState.conf
+      .getConfString(
+        IndexConstants.INDEX_LINEAGE_ENABLED,
+        IndexConstants.INDEX_LINEAGE_ENABLED_DEFAULT)
+      .toBoolean
   }
 }

--- a/src/test/scala/com/microsoft/hyperspace/index/RefreshIndexTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/RefreshIndexTests.scala
@@ -347,6 +347,36 @@ class RefreshIndexTests extends QueryTest with HyperspaceSuite {
     }
   }
 
+  test("Validate incremental index data is consistent with the current") {
+    withTempPathAsString { testPath =>
+      SampleData.save(spark, testPath, Seq("Date", "RGUID", "Query", "imprs", "clicks"))
+      val df = spark.read.parquet(testPath)
+
+      withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "false",
+        IndexConstants.INDEX_NUM_BUCKETS -> "20") {
+        hyperspace.createIndex(df, indexConfig)
+      }
+
+      // Add some new data to source.
+      import spark.implicits._
+      SampleData.testData
+        .take(3)
+        .toDF("Date", "RGUID", "Query", "imprs", "clicks")
+        .write
+        .mode("append")
+        .parquet(testPath)
+
+      withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true",
+        IndexConstants.INDEX_NUM_BUCKETS -> "10") {
+        hyperspace.refreshIndex(indexConfig.indexName, REFRESH_MODE_INCREMENTAL)
+      }
+
+      val indexLogEntry = getLatestStableLog(indexConfig.indexName)
+      assert(!indexLogEntry.hasLineageColumn(spark))
+      assert(indexLogEntry.numBuckets === 20)
+    }
+  }
+
   /**
    * Delete one file from a given path.
    *

--- a/src/test/scala/com/microsoft/hyperspace/index/RefreshIndexTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/RefreshIndexTests.scala
@@ -347,7 +347,8 @@ class RefreshIndexTests extends QueryTest with HyperspaceSuite {
     }
   }
 
-  test("Validate incremental index data is consistent with the current") {
+  test("Validate the configs for incremental index data is consistent with" +
+    "the previous version.") {
     withTempPathAsString { testPath =>
       SampleData.save(spark, testPath, Seq("Date", "RGUID", "Query", "imprs", "clicks"))
       val df = spark.read.parquet(testPath)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What is the context for this pull request?
<!--
Please clarify the context for the changes you are contributing. The purpose of this section is to outline information information to help reviewers have enough context.
-->

 - **Tracking Issue**: #196 
 - **Parent Issue**: n/a
 - **Dependencies**: n/a

Fixes #196 

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.

The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->

Instead of using the current spark.config, this PR gets numBuckets and lineage column config from previous index entry at refresh and use it for refresh.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Fixes a buggy behavior.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test