### PR TITLE
Optimize Hybrid Scan for deleted files

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -35,20 +35,20 @@ object IndexConstants {
   val INDEX_HYBRID_SCAN_ENABLED_DEFAULT = "false"
 
   // This is a temporary config to support Hybrid scan on both append & delete dataset.
-  // The config does not work without the Hybrid scan config
+  // The config does not work without the Hybrid scan config -
   // "spark.hyperspace.index.hybridscan.enabled"
   // and will be removed after performance validation and optimization.
   // See https://github.com/microsoft/hyperspace/issues/184
   val INDEX_HYBRID_SCAN_DELETE_ENABLED = "spark.hyperspace.index.hybridscan.delete.enabled"
   val INDEX_HYBRID_SCAN_DELETE_ENABLED_DEFAULT = "false"
 
-  // With the current performance limitation of Hybrid scan for delete files, we limit
-  // the number of deleted files to avoid regression from Hybrid scan.
+  // While the performance validation of Hybrid scan for delete files described above,
+  // we limit the number of deleted files to avoid regression from Hybrid scan.
   // If the number of deleted files is larger than this config, the index is disabled and
   // cannot be a candidate for Hybrid Scan.
   val INDEX_HYBRID_SCAN_DELETE_MAX_NUM_FILES =
     "spark.hyperspace.index.hybridscan.delete.maxNumDeletedFiles"
-  val INDEX_HYBRID_SCAN_DELETE_MAX_NUM_FILES_DEFAULT = "10"
+  val INDEX_HYBRID_SCAN_DELETE_MAX_NUM_FILES_DEFAULT = "30"
 
   // Identifier injected to HadoopFsRelation as an option if an index is applied.
   // Currently, the identifier is added to options field of HadoopFsRelation.

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -109,9 +109,10 @@ object RuleUtils {
       // handles the lists properly. Otherwise, as the source file list of each index entry
       // (entry.allSourceFileInfo) also contains the appended and deleted files, we cannot
       // get the actual appended files and deleted files correctly.
-      indexes.filter(index =>
-        index.created && index.deletedFiles.isEmpty && index.appendedFiles.isEmpty &&
-          isHybridScanCandidate(index, filesByRelations.flatten))
+      indexes.filter(
+        index =>
+          index.created && index.deletedFiles.isEmpty && index.appendedFiles.isEmpty &&
+            isHybridScanCandidate(index, filesByRelations.flatten))
     } else {
       indexes.filter(
         index =>
@@ -320,9 +321,8 @@ object RuleUtils {
         } else {
           val lineageAttr = AttributeReference(IndexConstants.DATA_FILE_NAME_COLUMN, StringType)()
           val deletedFileNames = filesDeleted.map(f => Literal(f.name)).toArray
-          val rel = {
+          val rel =
             baseRelation.copy(relation = relation, output = updatedOutput ++ Seq(lineageAttr))
-          }
           val filterForDeleted = Filter(Not(In(lineageAttr, deletedFileNames)), rel)
           Project(updatedOutput, OptimizeIn(filterForDeleted))
         }

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanTest.scala
@@ -750,5 +750,4 @@ class HybridScanTest extends QueryTest with HyperspaceSuite {
       }
     }
   }
-
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What is the context for this pull request?
<!--
Please clarify the context for the changes you are contributing. The purpose of this section is to outline information information to help reviewers have enough context.
-->

 - **Tracking Issue**: #184
 - **Parent Issue**: #150 
 - **Dependencies**: n/a

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.

The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->
Apply catalyst's `OptimizeIn` rule to the injected filter-not-in plan for Hybrid Scan with delete files. (refer #171)

https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala#L237

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, performance optimization is done by using "InSet" instead of "In", in case deleted files are larger than `spark.sql.optimizer.inSetConversionThreshold` config, default value: 10.

Changed plan example (with the threshold value=1): 
```
  +- Project [clicks#684, Date#680]
      +- Filter ((isnotnull(clicks#684) && (clicks#684 <= 4000)) && (clicks#684 >= 2000))
         +- Project [Date#680, clicks#684]
            +- Filter NOT _data_file_name#712 INSET (file:/C:/Users/eunsong/repo/hyperspace2/src/test/resources/data/sampleparquet4/part-00003-6fb13b2d-abcc-46e2-81ba-42b3a933acec-c000.snappy.parquet,file:/C:/Users/eunsong/repo/hyperspace2/src/test/resources/data/sampleparquet4/part-00002-6fb13b2d-abcc-46e2-81ba-42b3a933acec-c000.snappy.parquet)
               +- Relation[Date#680,clicks#684,_data_file_name#712] parquet
```


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test
