### PR TITLE
Store appended files and deleted files as Content type in IndexLogEntry

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -106,7 +106,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
         val files = location.allFiles
         // Note that source files are currently fingerprinted when the optimized plan is
         // fingerprinted by LogicalPlanFingerprint.
-        val sourceDataProperties = Hdfs.Properties(Content.fromLeafFiles(files))
+        val sourceDataProperties = Hdfs.Properties(Content.fromLeafFiles(files).get)
         val fileFormatName = fileFormat match {
           case d: DataSourceRegister => d.shortName
           case other => throw HyperspaceException(s"Unsupported file format: $other")

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
@@ -47,7 +47,7 @@ class RefreshAction(
   final override def validate(): Unit = {
     super.validate()
 
-    if (currentFiles.equals(previousIndexLogEntry.allSourceFileInfos)) {
+    if (currentFiles.equals(previousIndexLogEntry.sourceFileInfoSet)) {
       throw NoChangesException("Refresh full aborted as no source data changed.")
     }
   }

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
@@ -102,7 +102,10 @@ private[actions] abstract class RefreshActionBase(
   protected lazy val deletedFiles: Seq[FileInfo] = {
     val relation = previousIndexLogEntry.relations.head
     val originalFiles = relation.data.properties.content.fileInfos
-    (originalFiles -- currentFiles).toSeq
+
+    // TODO: Add test for the scenario where existing appendedFiles and newly appended
+    //  files are updated. https://github.com/microsoft/hyperspace/issues/195.
+    ((originalFiles -- currentFiles) ++ previousIndexLogEntry.deletedFiles).toSeq
   }
 
   /**

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
@@ -109,7 +109,7 @@ private[actions] abstract class RefreshActionBase(
     val prevDeletedFiles =
       previousIndexLogEntry.deletedFiles.filterNot(f => delFileNames.contains(f.name))
 
-    // TODO: Add test for the scenario where existing appendedFiles and newly appended
+    // TODO: Add test for the scenario where existing deletedFiles and newly deleted
     //  files are updated. https://github.com/microsoft/hyperspace/issues/195.
     delFiles.toSeq ++ prevDeletedFiles
   }

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
@@ -99,17 +99,10 @@ private[actions] abstract class RefreshActionBase(
    * Finally, append the previously known deleted files to the result. These
    * are the files for which the index was never updated in the past.
    */
-  protected lazy val deletedFiles: Seq[String] = {
+  protected lazy val deletedFiles: Seq[FileInfo] = {
     val relation = previousIndexLogEntry.relations.head
     val originalFiles = relation.data.properties.content.fileInfos
-    val delFiles = (originalFiles -- currentFiles).map(_.name)
-
-    // Remove duplicate deleted file names in the previous log entry.
-    val prevDeletedFiles = previousIndexLogEntry.deletedFiles.filterNot(delFiles.contains)
-
-    // TODO: Add test for the scenario where existing deletedFiles and newly deleted
-    //  files are updated. https://github.com/microsoft/hyperspace/issues/195.
-    delFiles.toSeq ++ prevDeletedFiles
+    (originalFiles -- currentFiles).toSeq
   }
 
   /**
@@ -139,16 +132,12 @@ private[actions] abstract class RefreshActionBase(
    * Finally, append the previously known appended files to the result. These
    * are the files for which index was never updated in the past.
    */
-  protected lazy val appendedFiles: Seq[String] = {
+  protected lazy val appendedFiles: Seq[FileInfo] = {
     val relation = previousIndexLogEntry.relations.head
     val originalFiles = relation.data.properties.content.fileInfos
-    val newFiles = (currentFiles -- originalFiles).map(_.name)
-
-    // Remove duplicate appended file names in the previous log entry.
-    val prevAppendedFiles = previousIndexLogEntry.appendedFiles.filterNot(newFiles.contains)
 
     // TODO: Add test for the scenario where existing appendedFiles and newly appended
     //  files are updated. https://github.com/microsoft/hyperspace/issues/195.
-    newFiles.toSeq ++ prevAppendedFiles
+    (currentFiles -- (originalFiles -- previousIndexLogEntry.appendedFiles)).toSeq
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
@@ -144,7 +144,7 @@ private[actions] abstract class RefreshActionBase(
   protected lazy val appendedFiles: Seq[FileInfo] = {
     val relation = previousIndexLogEntry.relations.head
     val originalFiles = relation.data.properties.content.fileInfos
-    val newFiles = (currentFiles -- originalFiles)
+    val newFiles = currentFiles -- originalFiles
     val newFileNames = newFiles.map(_.name)
 
     // Remove duplicate appended file names in the previous log entry.

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshAppendAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshAppendAction.scala
@@ -67,7 +67,7 @@ class RefreshAppendAction(
       .schema(df.schema)
       .format(relation.fileFormat)
       .options(relation.options)
-      .load(appendedFiles: _*)
+      .load(appendedFiles.map(_.name): _*)
   }
 
   /**

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshDeleteAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshDeleteAction.scala
@@ -80,7 +80,8 @@ class RefreshDeleteAction(
     val refreshDF =
       spark.read
         .parquet(previousIndexLogEntry.content.files.map(_.toString): _*)
-        .filter(!col(s"${IndexConstants.DATA_FILE_NAME_COLUMN}").isin(deletedFiles: _*))
+        .filter(
+          !col(s"${IndexConstants.DATA_FILE_NAME_COLUMN}").isin(deletedFiles.map(_.name): _*))
 
     refreshDF.write.saveWithBuckets(
       refreshDF,

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -334,8 +334,8 @@ object Hdfs {
    */
   case class Properties(
       content: Content,
-      appendedFiles: Seq[String] = Nil,
-      deletedFiles: Seq[String] = Nil)
+      appendedFiles: Seq[FileInfo] = Nil,
+      deletedFiles: Seq[FileInfo] = Nil)
 }
 
 // IndexLogEntry-specific Relation that represents the source relation.
@@ -389,15 +389,16 @@ case class IndexLogEntry(
       .toSet
   }
 
-  def deletedFiles: Seq[String] = {
+  def deletedFiles: Seq[FileInfo] = {
     relations.head.data.properties.deletedFiles
   }
 
-  def appendedFiles: Seq[String] = {
+  def appendedFiles: Seq[FileInfo] = {
     relations.head.data.properties.appendedFiles
   }
 
-  def withAppendedAndDeletedFiles(appended: Seq[String], deleted: Seq[String]): IndexLogEntry = {
+  def withAppendedAndDeletedFiles(appended: Seq[FileInfo], deleted: Seq[FileInfo]): IndexLogEntry
+  = {
     copy(
       source = source.copy(
         plan = source.plan.copy(

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -79,8 +79,8 @@ object RuleUtils {
       //  See https://github.com/microsoft/hyperspace/issues/158
 
       // Find the number of common files between the source relations & index source files.
-      val commonCnt = inputSourceFiles.count(entry.allSourceFileInfos.contains)
-      val deletedCnt = entry.allSourceFileInfos.size - commonCnt
+      val commonCnt = inputSourceFiles.count(entry.sourceFileInfoSet.contains)
+      val deletedCnt = entry.sourceFileInfoSet.size - commonCnt
 
       if (hybridScanDeleteEnabled && entry.hasLineageColumn(spark)) {
         commonCnt > 0 && deletedCnt <= HyperspaceConf.hybridScanDeleteMaxNumFiles(spark)
@@ -91,7 +91,7 @@ object RuleUtils {
     }
 
     if (hybridScanEnabled) {
-      // TODO: Duplicate listing files for the given relation as in
+      // TODO: Duplicate listing files for the given 361relation as in
       //  [[transformPlanToUseHybridScan]]
       //  See https://github.com/microsoft/hyperspace/issues/160
       val filesByRelations = plan
@@ -259,10 +259,10 @@ object RuleUtils {
 
         val (filesDeleted, filesAppended) =
           if (HyperspaceConf.hybridScanDeleteEnabled(spark) && index.hasLineageColumn(spark)) {
-            val (exist, nonExist) = curFileSet.partition(index.allSourceFileInfos.contains)
+            val (exist, nonExist) = curFileSet.partition(index.sourceFileInfoSet.contains)
             val filesAppended = nonExist.map(f => new Path(f.name))
-            if (exist.length < index.allSourceFileInfos.size) {
-              (index.allSourceFileInfos -- exist, filesAppended)
+            if (exist.length < index.sourceFileInfoSet.size) {
+              (index.sourceFileInfoSet -- exist, filesAppended)
             } else {
               (Nil, filesAppended)
             }
@@ -272,7 +272,7 @@ object RuleUtils {
             // 'deletedCnt == 0 && commonCnt > 0' in isHybridScanCandidate function.
             (
               Nil,
-              curFileSet.filterNot(index.allSourceFileInfos.contains).map(f => new Path(f.name)))
+              curFileSet.filterNot(index.sourceFileInfoSet.contains).map(f => new Path(f.name)))
           }
 
         val filesToRead = {

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -91,7 +91,7 @@ object RuleUtils {
     }
 
     if (hybridScanEnabled) {
-      // TODO: Duplicate listing files for the given 361relation as in
+      // TODO: Duplicate listing files for the given relation as in
       //  [[transformPlanToUseHybridScan]]
       //  See https://github.com/microsoft/hyperspace/issues/160
       val filesByRelations = plan

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -126,16 +126,36 @@ class IndexLogEntryTest extends SparkFunSuite with SQLHelper with BeforeAndAfter
         |                  "properties" : { }
         |                }
         |              },
-        |              "deletedFiles" : [{
-        |                    "name" : "file:/rootpath/f1",
+        |              "deletedFiles" : {
+        |                "root" : {
+        |                  "name" : "",
+        |                  "files" : [ {
+        |                    "name" : "f1",
         |                    "size" : 10,
         |                    "modifiedTime" : 10
         |                  }],
-        |              "appendedFiles" : [{
-        |                    "name" : "file:/rootpath/f3",
+        |                  "subDirs" : [ ]
+        |                },
+        |                "fingerprint" : {
+        |                  "kind" : "NoOp",
+        |                  "properties" : { }
+        |                }
+        |              },
+        |              "appendedFiles" : {
+        |                "root" : {
+        |                  "name" : "",
+        |                  "files" : [ {
+        |                    "name" : "f3",
         |                    "size" : 10,
-        |                    "modifiedTime" : 10}]
-        |            },
+        |                    "modifiedTime" : 10
+        |                  }],
+        |                  "subDirs" : [ ]
+        |                },
+        |                "fingerprint" : {
+        |                  "kind" : "NoOp",
+        |                  "properties" : { }
+        |                }
+        |            }},
         |            "kind" : "HDFS"
         |          },
         |          "dataSchemaJson" : "schema",
@@ -173,8 +193,8 @@ class IndexLogEntryTest extends SparkFunSuite with SQLHelper with BeforeAndAfter
         Seq("rootpath"),
         Hdfs(Hdfs.Properties(Content(
           Directory("", Seq(FileInfo("f1", 100L, 100L), FileInfo("f2", 200L, 200L)), Seq())),
-          Seq(FileInfo("file:/rootpath/f3", 10, 10)),
-          Seq(FileInfo("file:/rootpath/f1", 10, 10)))),
+          Content(Directory("", Seq(FileInfo("f3", 10, 10)))),
+          Content(Directory("", Seq(FileInfo("f1", 10, 10)))))),
         "schema",
         "type",
         Map())),

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -126,8 +126,15 @@ class IndexLogEntryTest extends SparkFunSuite with SQLHelper with BeforeAndAfter
         |                  "properties" : { }
         |                }
         |              },
-        |              "deletedFiles" : ["file:/rootpath/f1"],
-        |              "appendedFiles" : ["file:/rootpath/f3"]
+        |              "deletedFiles" : [{
+        |                    "name" : "file:/rootpath/f1",
+        |                    "size" : 10,
+        |                    "modifiedTime" : 10
+        |                  }],
+        |              "appendedFiles" : [{
+        |                    "name" : "file:/rootpath/f3",
+        |                    "size" : 10,
+        |                    "modifiedTime" : 10}]
         |            },
         |            "kind" : "HDFS"
         |          },
@@ -166,8 +173,8 @@ class IndexLogEntryTest extends SparkFunSuite with SQLHelper with BeforeAndAfter
         Seq("rootpath"),
         Hdfs(Hdfs.Properties(Content(
           Directory("", Seq(FileInfo("f1", 100L, 100L), FileInfo("f2", 200L, 200L)), Seq())),
-          Seq("file:/rootpath/f3"),
-          Seq("file:/rootpath/f1"))),
+          Seq(FileInfo("file:/rootpath/f3", 10, 10)),
+          Seq(FileInfo("file:/rootpath/f1", 10, 10)))),
         "schema",
         "type",
         Map())),

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -141,21 +141,8 @@ class IndexLogEntryTest extends SparkFunSuite with SQLHelper with BeforeAndAfter
         |                  "properties" : { }
         |                }
         |              },
-        |              "appendedFiles" : {
-        |                "root" : {
-        |                  "name" : "",
-        |                  "files" : [ {
-        |                    "name" : "f3",
-        |                    "size" : 10,
-        |                    "modifiedTime" : 10
-        |                  }],
-        |                  "subDirs" : [ ]
-        |                },
-        |                "fingerprint" : {
-        |                  "kind" : "NoOp",
-        |                  "properties" : { }
-        |                }
-        |            }},
+        |              "appendedFiles" : null
+        |            },
         |            "kind" : "HDFS"
         |          },
         |          "dataSchemaJson" : "schema",
@@ -193,8 +180,8 @@ class IndexLogEntryTest extends SparkFunSuite with SQLHelper with BeforeAndAfter
         Seq("rootpath"),
         Hdfs(Hdfs.Properties(Content(
           Directory("", Seq(FileInfo("f1", 100L, 100L), FileInfo("f2", 200L, 200L)), Seq())),
-          Content(Directory("", Seq(FileInfo("f3", 10, 10)))),
-          Content(Directory("", Seq(FileInfo("f1", 10, 10)))))),
+          None,
+          Some(Content(Directory("", Seq(FileInfo("f1", 10, 10))))))),
         "schema",
         "type",
         Map())),

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -513,7 +513,7 @@ class IndexManagerTests extends HyperspaceSuite with SQLHelper {
               _,
               _) =>
             val files = location.allFiles
-            val sourceDataProperties = Hdfs.Properties(Content.fromLeafFiles(files))
+            val sourceDataProperties = Hdfs.Properties(Content.fromLeafFiles(files).get)
             val fileFormatName = fileFormat match {
               case d: DataSourceRegister => d.shortName
               case other => throw HyperspaceException(s"Unsupported file format $other")

--- a/src/test/scala/com/microsoft/hyperspace/index/RefreshIndexTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/RefreshIndexTests.scala
@@ -319,7 +319,7 @@ class RefreshIndexTests extends QueryTest with HyperspaceSuite {
 
           assert(indexLogEntry.deletedFiles.isEmpty)
           assert((oldFiles -- latestFiles).isEmpty)
-          assert(indexLogEntry.appendedFiles.toSet.equals(latestFiles -- oldFiles))
+          assert(indexLogEntry.appendedFiles.equals(latestFiles -- oldFiles))
         }
       }
     }
@@ -360,7 +360,7 @@ class RefreshIndexTests extends QueryTest with HyperspaceSuite {
         assert(indexLogEntry.appendedFiles.isEmpty)
 
         val latestFiles = listFiles(testPath).toSet
-        assert(indexLogEntry.deletedFiles.toSet === (oldFiles -- latestFiles))
+        assert(indexLogEntry.deletedFiles === (oldFiles -- latestFiles))
       }
     }
   }

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
@@ -35,8 +35,8 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
       indexCols: Seq[AttributeReference],
       includedCols: Seq[AttributeReference],
       plan: LogicalPlan,
-      appendedFiles: Seq[String] = Seq(),
-      deletedFiles: Seq[String] = Seq()): IndexLogEntry = {
+      appendedFiles: Seq[FileInfo] = Seq(),
+      deletedFiles: Seq[FileInfo] = Seq()): IndexLogEntry = {
     val signClass = new RuleTestHelper.TestSignatureProvider().getClass.getName
 
     LogicalPlanSignatureProvider.create(signClass).signature(plan) match {

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
@@ -34,9 +34,7 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
       name: String,
       indexCols: Seq[AttributeReference],
       includedCols: Seq[AttributeReference],
-      plan: LogicalPlan,
-      appendedFiles: Seq[FileInfo] = Seq(),
-      deletedFiles: Seq[FileInfo] = Seq()): IndexLogEntry = {
+      plan: LogicalPlan): IndexLogEntry = {
     val signClass = new RuleTestHelper.TestSignatureProvider().getClass.getName
 
     LogicalPlanSignatureProvider.create(signClass).signature(plan) match {
@@ -45,7 +43,7 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
           Seq(
             Relation(
               Seq("dummy"),
-              Hdfs(Properties(Content(Directory("/")), appendedFiles, deletedFiles)),
+              Hdfs(Properties(Content(Directory("/")))),
               "schema",
               "format",
               Map())),

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/HyperspaceRuleTestSuite.scala
@@ -63,7 +63,7 @@ trait HyperspaceRuleTestSuite extends HyperspaceSuite {
                 .Columns(indexCols.map(_.name), includedCols.map(_.name)),
               IndexLogEntry.schemaString(schemaFromAttributes(indexCols ++ includedCols: _*)),
               10)),
-          Content.fromLeafFiles(indexFiles),
+          Content.fromLeafFiles(indexFiles).get,
           Source(SparkPlan(sourcePlanProperties)),
           Map())
 

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -288,6 +288,9 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite with SQLHelper {
       val entry1 = createIndexLogEntry("t1iTest", Seq(t1c1), Seq(t1c3), t1ProjectNode)
       val entry2 = entry1.withAppendedAndDeletedFiles(Seq(), Seq(FileInfo("file:/dir/f1", 1, 1)))
       val entry3 = entry1.withAppendedAndDeletedFiles(Seq(FileInfo("file:/dir/f2", 1, 1)), Seq())
+      // IndexLogEntry.withAppendedAndDeletedFiles doesn't copy LogEntry's fields.
+      // Thus, set the 'state' to ACTIVE manually so that these entries are considered
+      // in RuleUtils.getCandidateIndexes.
       entry2.state = "ACTIVE"
       entry3.state = "ACTIVE"
       val usableIndexes =

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InMemoryFil
 import org.apache.spark.sql.types.{IntegerType, StringType}
 
 import com.microsoft.hyperspace.actions.Constants
-import com.microsoft.hyperspace.index.{IndexCollectionManager, IndexConfig, IndexConstants}
+import com.microsoft.hyperspace.index.{FileInfo, IndexCollectionManager, IndexConfig, IndexConstants}
 import com.microsoft.hyperspace.index.IndexConstants.INDEX_HYBRID_SCAN_ENABLED
 import com.microsoft.hyperspace.util.{FileUtils, PathUtils}
 
@@ -286,8 +286,8 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite with SQLHelper {
       "'appendedFiles' are not usable indexes if hybrid scan is disabled.") {
     withSQLConf(INDEX_HYBRID_SCAN_ENABLED -> "false") {
       val entry1 = createIndexLogEntry("t1iTest", Seq(t1c1), Seq(t1c3), t1ProjectNode)
-      val entry2 = entry1.withAppendedAndDeletedFiles(Seq(), Seq("f1"))
-      val entry3 = entry1.withAppendedAndDeletedFiles(Seq("f2"), Seq())
+      val entry2 = entry1.withAppendedAndDeletedFiles(Seq(), Seq(FileInfo("f1", 1, 1)))
+      val entry3 = entry1.withAppendedAndDeletedFiles(Seq(FileInfo("f2", 1, 1)), Seq())
       val usableIndexes =
         RuleUtils.getCandidateIndexes(spark, Seq(entry1, entry2, entry3), t1ProjectNode)
       assert(usableIndexes.equals(Seq(entry1)))

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -286,11 +286,13 @@ class RuleUtilsTest extends HyperspaceRuleTestSuite with SQLHelper {
       "'appendedFiles' are not usable indexes if hybrid scan is disabled.") {
     withSQLConf(INDEX_HYBRID_SCAN_ENABLED -> "false") {
       val entry1 = createIndexLogEntry("t1iTest", Seq(t1c1), Seq(t1c3), t1ProjectNode)
-      val entry2 = entry1.withAppendedAndDeletedFiles(Seq(), Seq(FileInfo("f1", 1, 1)))
-      val entry3 = entry1.withAppendedAndDeletedFiles(Seq(FileInfo("f2", 1, 1)), Seq())
+      val entry2 = entry1.withAppendedAndDeletedFiles(Seq(), Seq(FileInfo("file:/dir/f1", 1, 1)))
+      val entry3 = entry1.withAppendedAndDeletedFiles(Seq(FileInfo("file:/dir/f2", 1, 1)), Seq())
+      entry2.state = "ACTIVE"
+      entry3.state = "ACTIVE"
       val usableIndexes =
         RuleUtils.getCandidateIndexes(spark, Seq(entry1, entry2, entry3), t1ProjectNode)
-      assert(usableIndexes.equals(Seq(entry1)))
+      assert(usableIndexes === Seq(entry1))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What is the context for this pull request?
<!--
Please clarify the context for the changes you are contributing. The purpose of this section is to outline information information to help reviewers have enough context.
-->

 - **Tracking Issue**: Fixes #210 
 - **Parent Issue**: n/a
 - **Dependencies**: n/a

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.

The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->
Store the type of appendedFiles and deletedFiles as Content type instead of list of String.
This change is required for #200 and #198.

```
case class Properties(
      content: Content,
-      appendedFiles: Seq[String] = Nil,
-      deletedFiles: Seq[String] = Nil)
+      appendedFiles: Option[Content] = None,
+      deletedFiles: Option[Content] = None)
```

ref) `None` value is serialized as "null" in JSON
```
...
appendedFiles: null
...
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes.
This is a breakage change.
Form of `appendedFiles` and `deletedFiles` in IndexLogEntry has changed - a user should rebuild indexes.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test
