### PR TITLE
Sort source file list in FileBasedSignatureProvider

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/FileBasedSignatureProvider.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/FileBasedSignatureProvider.scala
@@ -55,7 +55,7 @@ class FileBasedSignatureProvider extends LogicalPlanSignatureProvider {
           _,
           _,
           _) =>
-        fingerprint ++= location.allFiles.sortBy(_.hashCode).foldLeft("")(
+        fingerprint ++= location.allFiles.sortBy(_.getPath.toString).foldLeft("")(
           (accumulate: String, fileStatus: FileStatus) =>
             HashingUtils.md5Hex(accumulate + getFingerprint(fileStatus)))
       case _ =>

--- a/src/main/scala/com/microsoft/hyperspace/index/FileBasedSignatureProvider.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/FileBasedSignatureProvider.scala
@@ -55,7 +55,7 @@ class FileBasedSignatureProvider extends LogicalPlanSignatureProvider {
           _,
           _,
           _) =>
-        fingerprint ++= location.allFiles.foldLeft("")(
+        fingerprint ++= location.allFiles.sortBy(_.hashCode).foldLeft("")(
           (accumulate: String, fileStatus: FileStatus) =>
             HashingUtils.md5Hex(accumulate + getFingerprint(fileStatus)))
       case _ =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What is the context for this pull request?
<!--
Please clarify the context for the changes you are contributing. The purpose of this section is to outline information information to help reviewers have enough context.
-->

 - **Tracking Issue**: n/a
 - **Parent Issue**: n/a
 - **Dependencies**: n/a

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.

The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->

The signature calculation in FileBasedSignatureProvider can differ depending on the order of input files.  Therefore, we need to make sure the order is consistent.

For example, the following dataframes have the same list of input files, but can have different order in `HadoopFsRelation.allFiles`. This can cause an unexpected signature mistmatch.

```
spark.read.parquet("testPath") // location.allFiles
file:/tmp/spark-5a167814-d814-4a69-b579-c90d3604de4d/Date=2017-09-03/part-00000-376e6280-30cb-4d77-80ce-4afec0991682.c000.snappy.parquet
file:/tmp/spark-5a167814-d814-4a69-b579-c90d3604de4d/Date=2017-09-03/part-00001-376e6280-30cb-4d77-80ce-4afec0991682.c000.snappy.parquet
file:/tmp/spark-5a167814-d814-4a69-b579-c90d3604de4d/Date=2017-09-03/part-00002-376e6280-30cb-4d77-80ce-4afec0991682.c000.snappy.parquet
file:/tmp/spark-5a167814-d814-4a69-b579-c90d3604de4d/Date=2018-09-03/part-00002-376e6280-30cb-4d77-80ce-4afec0991682.c000.snappy.parquet
file:/tmp/spark-5a167814-d814-4a69-b579-c90d3604de4d/Date=2018-09-03/part-00003-376e6280-30cb-4d77-80ce-4afec0991682.c000.snappy.parquet

val basePath = "file:/tmp/spark-5a167814-d814-4a69-b579-c90d3604de4d"
spark.read.options("basePath", basePath).parquet(basePath + "/Date=2017-09-03", basePath + "/Date=2018-09-03")
file:/tmp/spark-5a167814-d814-4a69-b579-c90d3604de4d/Date=2018-09-03/part-00002-376e6280-30cb-4d77-80ce-4afec0991682.c000.snappy.parquet
file:/tmp/spark-5a167814-d814-4a69-b579-c90d3604de4d/Date=2018-09-03/part-00003-376e6280-30cb-4d77-80ce-4afec0991682.c000.snappy.parquet
file:/tmp/spark-5a167814-d814-4a69-b579-c90d3604de4d/Date=2017-09-03/part-00000-376e6280-30cb-4d77-80ce-4afec0991682.c000.snappy.parquet
file:/tmp/spark-5a167814-d814-4a69-b579-c90d3604de4d/Date=2017-09-03/part-00001-376e6280-30cb-4d77-80ce-4afec0991682.c000.snappy.parquet
file:/tmp/spark-5a167814-d814-4a69-b579-c90d3604de4d/Date=2017-09-03/part-00002-376e6280-30cb-4d77-80ce-4afec0991682.c000.snappy.parquet
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, fixes the bug described in above section.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test
