### PR TITLE
Support globbing patterns in dataframes for creation/maintenance/usage of indexes.

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -127,7 +127,8 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
         // "path" key in options can incur multiple data read unexpectedly.
         val opts = options - "path"
 
-        // If user provided a globbing pattern, set rootPaths to this pattern. Else, use file index.
+        // If user provided a globbing pattern, set rootPaths to globbing pattern.
+        // Else, use file index to identify rootPaths.
         val rootPaths = opts.get(GLOBBING_PATTERN_KEY) match {
           case Some(pattern) =>
             // Validate if globbing pattern matches actual source paths.

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -100,4 +100,11 @@ object IndexConstants {
 
   // JSON property name used in index metadata to store whether lineage is enabled for an index.
   private[hyperspace] val LINEAGE_PROPERTY = "lineage"
+
+  // Hyperspace allows users to use globbing patterns to create indexes on. E.g. if user wants to
+  // create an index on "/temp/*/*", they can do so by setting this key to "/temp/*/*". If not set,
+  // Hyperspace assumes the actual folder names were picked for indexing instead of the wildcards.
+  // To provide multiple paths in the globbing pattern, separate them with commas, e.g.
+  // "/temp/1/*, /temp/2/*"
+  val GLOBBING_PATTERN_KEY = "spark.hyperspace.source.globbingPattern"
 }

--- a/src/test/scala/com/microsoft/hyperspace/TestUtils.scala
+++ b/src/test/scala/com/microsoft/hyperspace/TestUtils.scala
@@ -74,6 +74,13 @@ object TestUtils {
     val indexPath = PathUtils.makeAbsolute(s"$systemPath/$indexName")
     IndexLogManagerFactoryImpl.create(indexPath)
   }
+
+  def latestIndexLogEntry(systemPath: Path, indexName: String): IndexLogEntry = {
+    logManager(systemPath, indexName)
+      .getLatestStableLog()
+      .get
+      .asInstanceOf[IndexLogEntry]
+  }
 }
 
 /**

--- a/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InMemoryFil
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 
 import com.microsoft.hyperspace.{Hyperspace, Implicits, SampleData, TestUtils}
-import com.microsoft.hyperspace.index.IndexConstants.{REFRESH_MODE_INCREMENTAL, REFRESH_MODE_QUICK}
+import com.microsoft.hyperspace.index.IndexConstants.{GLOBBING_PATTERN_KEY, REFRESH_MODE_INCREMENTAL, REFRESH_MODE_QUICK}
 import com.microsoft.hyperspace.index.execution.BucketUnionStrategy
 import com.microsoft.hyperspace.index.rules.{FilterIndexRule, JoinIndexRule}
 import com.microsoft.hyperspace.util.PathUtils
@@ -680,6 +680,66 @@ class E2EHyperspaceRulesTests extends QueryTest with HyperspaceSuite {
             checkAnswer(dfWithHyperspaceDisabled, dfWithHyperspaceEnabled)
           }
         }
+      }
+    }
+  }
+
+  test("Hybrid scan works well with modified data when globbing pattern is used.") {
+    withTempPathAsString { testPath =>
+      val absoluteTestPath = PathUtils.makeAbsolute(testPath)
+      val globPath = absoluteTestPath + "/*"
+      val p1 = absoluteTestPath + "/1"
+      import spark.implicits._
+      SampleData.testData
+        .toDF("Date", "RGUID", "Query", "imprs", "clicks")
+        .limit(10)
+        .write
+        .parquet(p1)
+
+      // Create index with globbing pattern.
+      val df = spark.read.option(GLOBBING_PATTERN_KEY, globPath).parquet(globPath)
+      val indexConfig = IndexConfig("index", Seq("clicks"), Seq("query"))
+      hyperspace.createIndex(df, indexConfig)
+
+      // Append data to a new directory which matches the globbing pattern.
+      val p2 = absoluteTestPath + "/2"
+      SampleData.testData
+        .toDF("Date", "RGUID", "Query", "imprs", "clicks")
+        .limit(3)
+        .write
+        .parquet(p2)
+
+      val df2 = spark.read.parquet(globPath)
+      def filterQuery: DataFrame = df2.filter(df2("clicks") <= 2000).select(df2("query"))
+      val baseQuery = filterQuery
+      val basePlan = baseQuery.queryExecution.optimizedPlan
+      spark.enableHyperspace()
+
+      withSQLConf(IndexConstants.INDEX_HYBRID_SCAN_ENABLED -> "false") {
+        val filter = filterQuery
+        assert(basePlan.equals(filter.queryExecution.optimizedPlan))
+      }
+
+      withSQLConf(IndexConstants.INDEX_HYBRID_SCAN_ENABLED -> "true") {
+        val filter = filterQuery
+        val planWithHybridScan = filter.queryExecution.optimizedPlan
+        assert(!basePlan.equals(planWithHybridScan))
+
+        // Check appended file is added to relation node or not.
+        val nodes = planWithHybridScan.collect {
+          case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
+            // Verify appended file is included or not.
+            assert(
+              fsRelation.location.inputFiles
+                .count(_.contains(absoluteTestPath.toUri.toString)) === 3)
+            // Verify number of index data files.
+            assert(fsRelation.location.inputFiles.count(_.contains("index")) === 4)
+            assert(fsRelation.location.inputFiles.length === 7)
+            p
+        }
+        // Filter Index and Parquet format source file can be handled with 1 LogicalRelation.
+        assert(nodes.length === 1)
+        checkAnswer(baseQuery, filter)
       }
     }
   }

--- a/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTests.scala
@@ -728,13 +728,13 @@ class E2EHyperspaceRulesTests extends QueryTest with HyperspaceSuite {
         // Check appended file is added to relation node or not.
         val nodes = planWithHybridScan.collect {
           case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
-            // Verify appended file is included or not.
-            assert(
-              fsRelation.location.inputFiles
-                .count(_.contains(absoluteTestPath.toUri.toString)) === 3)
-            // Verify number of index data files.
-            assert(fsRelation.location.inputFiles.count(_.contains("index")) === 4)
-            assert(fsRelation.location.inputFiles.length === 7)
+            // Verify old data files are not present but newly appended files are included.
+            val p1UriPath = new Path(p1).toUri.getPath
+            val p2UriPath = new Path(p2).toUri.getPath
+            assert(!fsRelation.location.inputFiles.exists(_.contains(p1UriPath)))
+            assert(fsRelation.location.inputFiles.exists(_.contains(p2UriPath)))
+            // Verify index data files are present.
+            assert(fsRelation.location.inputFiles.exists(_.contains("index")))
             p
         }
         // Filter Index and Parquet format source file can be handled with 1 LogicalRelation.


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What is the context for this pull request?
<!--
Please clarify the context for the changes you are contributing. The purpose of this section is to outline information information to help reviewers have enough context.
-->

 - **Tracking Issue**: #226

### What changes were proposed in this pull request?
Support for globbing patterns in data sources when creating/maintaining/using indexes.

<!--
Please clarify what changes you are proposing and why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.

The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->

### Does this PR introduce _any_ user-facing change?
Users will now be able to create and maintain indexes on dataframes created with globbing patterns e.g. 

```scala
  val path = "tmp/1/*"
  val path2 = "tmp/2/*"
  val df = spark.read
    .option("spark.hyperspace.source.globbingPattern", s"$path,$path2") // This is only required the first time index is being created.
    .parquet(path, path2)

  val hs = new Hyperspace(spark)
  hs.createIndex(df, ...)
```
> Note: for multiple paths, as shown in the example above, please concatenate the paths with commas `,`.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
unit tests
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
