### PR TITLE
[WIP] Introduce whyNot API

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
@@ -110,6 +110,13 @@ class IndexCollectionManager(
       .map(toIndexLogEntry)
   }
 
+  override private[hyperspace] def getLatestStableLog(indexName: String): Option[IndexLogEntry] = {
+    getLogManager(indexName) match {
+      case Some(logManager) => logManager.getLatestStableLog().map(toIndexLogEntry)
+      case None => throw HyperspaceException(s"Index with name $indexName could not be found")
+    }
+  }
+
   private def indexLogManagers: Seq[IndexLogManager] = {
     val rootPath = PathResolver(conf).systemPath
     val fs = fileSystemFactory.create(rootPath)

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexManager.scala
@@ -96,4 +96,6 @@ trait IndexManager {
    * @return all indexes that match any of the given states
    */
   def getIndexes(states: Seq[String] = Seq()): Seq[IndexLogEntry]
+
+  private[hyperspace] def getLatestStableLog(indexName: String): Option[IndexLogEntry]
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/plananalysis/IndexConditionAnalyzer.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/plananalysis/IndexConditionAnalyzer.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index.plananalysis
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation, PartitioningAwareFileIndex}
+
+import com.microsoft.hyperspace.Hyperspace
+import com.microsoft.hyperspace.index.{FileInfo, IndexConstants, IndexLogEntry, LogicalPlanSignatureProvider, PathResolver}
+import com.microsoft.hyperspace.util.ResolverUtils
+
+object IndexConditionAnalyzer {
+
+  def whyNotString(spark: SparkSession, df: DataFrame, entry: IndexLogEntry): String = {
+    // Collect all possible logical relations & its signatures.
+    val relations = df.queryExecution.optimizedPlan.collect {
+      case relation @ LogicalRelation(_: HadoopFsRelation, _, _, _) =>
+        relation
+    }
+
+    if (relations.isEmpty) {
+      return "No applicable relation type in query. Hyperspace only supports HadoopFsRelation."
+    }
+
+    // Check Column Schema.
+    val allColumnsInIndex = entry.indexedColumns ++ entry.includedColumns
+    val relationsAfterSchemaCheck = relations.filter { rel =>
+      val relationCols = rel.output.map(_.name)
+      ResolverUtils.resolve(spark, allColumnsInIndex, relationCols).isDefined
+    }
+
+    if (relationsAfterSchemaCheck.isEmpty) {
+      return s"Not found relation including all indexed/included columns in the given index. " +
+        s"Column Names: $allColumnsInIndex"
+    }
+
+    val sourcePlanSignatures = entry.source.plan.properties.fingerprint.properties.signatures
+    val sourcePlanSignature = sourcePlanSignatures.head
+
+    val relationsAfterSignatureCheck = relationsAfterSchemaCheck.filter { rel =>
+      LogicalPlanSignatureProvider
+        .create(sourcePlanSignature.provider)
+        .signature(rel) match {
+        case Some(s) => s.equals(sourcePlanSignature.value)
+        case None => false
+      }
+    }
+
+    val outputStream = BufferStream(PlanAnalyzerUtils.getDisplayMode(spark))
+
+    if (relationsAfterSignatureCheck.isEmpty) {
+      outputStream.writeLine("Inapplicable relations in the given query:")
+      relationsAfterSchemaCheck.map {
+        case rel @ LogicalRelation(
+              HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _),
+              _,
+              _,
+              _) =>
+          val curFiles = Hyperspace
+            .getContext(spark)
+            .sourceProviderManager
+            .allFiles(rel)
+            .map(
+              f =>
+                FileInfo(
+                  f.getPath.toString,
+                  f.getLen,
+                  f.getModificationTime,
+                  IndexConstants.UNKNOWN_FILE_ID))
+            .toSet
+
+          val appendedFiles = curFiles -- entry.sourceFileInfoSet
+          val deletedFiles = entry.sourceFileInfoSet -- curFiles
+          outputStream.writeLine(rel.schemaString)
+          val numCommonFiles = entry.sourceFileInfoSet.size - deletedFiles.size
+          if (numCommonFiles == 0) {
+            // No common files.
+            outputStream.writeLine("  - No common source file.")
+            outputStream.writeLine(s"    - Relation files sample: ${curFiles.head.name}")
+            outputStream.writeLine(
+              s"    - Index files sample: ${entry.sourceFileInfoSet.head.name}")
+          } else {
+            outputStream.writeLine(
+              s"  - Detected $numCommonFiles of common source file(s) between " +
+                s"${entry.sourceFileInfoSet.size} of index files and ${curFiles.size} of " +
+                "relation files.")
+            if (appendedFiles.nonEmpty) {
+              outputStream.writeLine(s"  - Detected ${appendedFiles.size} of appended file(s).")
+              outputStream.writeLine(s"    - Appended files sample: ${appendedFiles.head.name}")
+            }
+            if (deletedFiles.nonEmpty) {
+              outputStream.writeLine(s"    - Detected ${deletedFiles.size} of deleted file(s).")
+              outputStream.writeLine(s"      - Deleted files sample: ${deletedFiles.head.name}")
+            }
+          }
+      }
+      return outputStream.toString
+    }
+
+    {
+      outputStream.writeLine("Candidate logical relations after signature match:")
+      relationsAfterSchemaCheck.foreach { rel =>
+        outputStream.writeLine(rel.schema.toString)
+      }
+      outputStream.writeLine()
+
+      PlanAnalyzerUtils.withHyperspaceState(spark, desiredState = true) {
+        val originalPlan = spark.sessionState
+          .executePlan(df.queryExecution.optimizedPlan)
+          .executedPlan
+        val indexPath = PathResolver(spark.sessionState.conf).getIndexPath(entry.name).toString
+        if (PlanAnalyzerUtils.getPaths(originalPlan).exists(f => f.startsWith(indexPath))) {
+          outputStream.writeLine("The index is applied to the given query. Plan:")
+          outputStream.writeLine(originalPlan.toString)
+          return outputStream.toString
+        }
+        outputStream.writeLine("Given query plan using Hyperspace:")
+        outputStream.writeLine(originalPlan.toString)
+      }
+
+      // TODO - check query plan for each candidate relation.
+      // TODO - elaborate possible causes.
+      outputStream.writeLine("There can be several possible causes:")
+      outputStream.writeLine(
+        "  - Filter condition: " +
+          "filter column should be the first \"indexed\" column.")
+      outputStream.writeLine("  - Join condition: only support Equi-join and ANDs.")
+      outputStream.writeLine(
+        "  - Join condition: " +
+          "both left and right child should have a candidate index.")
+      outputStream.writeLine("  - Rule order: Join Rule is prior to Filter Rule.")
+      outputStream.writeLine("  - Index rank: another index is applied to the relation.")
+      outputStream.toString
+    }
+  }
+}

--- a/src/main/scala/com/microsoft/hyperspace/index/plananalysis/PlanAnalyzerUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/plananalysis/PlanAnalyzerUtils.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index.plananalysis
+
+import scala.collection.mutable.ListBuffer
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InMemoryFileIndex}
+
+import com.microsoft.hyperspace.{HyperspaceException, Implicits}
+import com.microsoft.hyperspace.index.IndexConstants
+
+object PlanAnalyzerUtils {
+
+  /**
+   * Gets paths of all file source nodes in given plan.
+   *
+   * @param sparkPlan spark plan.
+   * @return paths of all file source nodes in given plan.
+   */
+  private[hyperspace] def getPaths(sparkPlan: SparkPlan): Seq[String] = {
+    val usedPaths = new ListBuffer[String]
+    sparkPlan.foreach {
+      case FileSourceScanExec(
+          HadoopFsRelation(location: InMemoryFileIndex, _, _, _, _, _),
+          _,
+          _,
+          _,
+          _,
+          _,
+          _) =>
+        usedPaths += location.rootPaths.head.getParent.toString
+      case other =>
+        other.subqueries.foreach { subQuery =>
+          getPaths(subQuery).flatMap(path => usedPaths += path)
+        }
+    }
+    usedPaths
+  }
+
+  private[hyperspace] def getDisplayMode(sparkSession: SparkSession): DisplayMode = {
+    val displayMode =
+      sparkSession.conf
+        .get(IndexConstants.DISPLAY_MODE, IndexConstants.DisplayMode.PLAIN_TEXT)
+    val highlightTags = Map(
+      IndexConstants.HIGHLIGHT_BEGIN_TAG -> sparkSession.conf
+        .get(IndexConstants.HIGHLIGHT_BEGIN_TAG, ""),
+      IndexConstants.HIGHLIGHT_END_TAG -> sparkSession.conf
+        .get(IndexConstants.HIGHLIGHT_END_TAG, ""))
+    displayMode match {
+      case IndexConstants.DisplayMode.PLAIN_TEXT => new PlainTextMode(highlightTags)
+      case IndexConstants.DisplayMode.HTML => new HTMLMode(highlightTags)
+      case IndexConstants.DisplayMode.CONSOLE => new ConsoleMode(highlightTags)
+      case _ =>
+        throw HyperspaceException(s"Display mode: $displayMode not supported.")
+    }
+  }
+
+  /**
+   * Executes given body function in expected Hyperspace state for given spark session and restores
+   * back to original state.
+   *
+   * @param spark spark session.
+   * @param desiredState desired Hyperspace state.
+   * @param f function to execute in the given Hyperspace state.
+   */
+  private[hyperspace] def withHyperspaceState[T](spark: SparkSession, desiredState: Boolean)(
+      f: => T): T = {
+    // Figure outs initial Hyperspace state and enable/disable Hyperspace if needed.
+    val isHyperspaceEnabled = spark.isHyperspaceEnabled()
+    if (desiredState) {
+      spark.enableHyperspace()
+    } else {
+      spark.disableHyperspace()
+    }
+
+    val result = f
+
+    // Restores initial Hyperspace state on given spark session.
+    if (isHyperspaceEnabled) {
+      spark.enableHyperspace()
+    } else {
+      spark.disableHyperspace()
+    }
+
+    result
+  }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What is the context for this pull request?
<!--
Please clarify the context for the changes you are contributing. The purpose of this section is to outline information information to help reviewers have enough context.
-->

 - **Tracking Issue**: n/a
 - **Parent Issue**:  #253
 - **Dependencies**: n/a

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.

The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->

This PR introduces whyNot API which analyzes why the given index is not applied to the given query.

#### Scope - check logical relation only
0. Get latest stable index log entry of "indexName"
    - invalid index name
    - no available stable version
1. Collect all logical relations in the given query
    - no `HadoopFsRelation`
2. Schema check - exclude relations by comparing column names (relations & index included columns & indexed columns)
    - column schema mismatch
3. Signature comparison
    - if signature mismatch - print number of common files, appended files, deleted files
4. Index application check 
    - if the index is applied, show query plan.
    - if not, show the list of the possible causes.

#### Example scenario (term or msg can be revised - result is from the draft change):

```scala
val hs = new Hyperspace(spark)val df2 = Seq((1, 2), (3, 4)).toDF("id", "id2")
val df2 = Seq((1, 2), (3, 4)).toDF("id", "id2")
hs.whyNot(df2, "testIndex2")
```
```
No applicable relation type in query. Hyperspace only supports HadoopFsRelation.
```
```scala
df2.write.parquet("testda")
val df2 = spark.read.parquet("testda")
hs.whyNot(df2, "testIndex2")
```
```
Not found relation including all indexed/included columns in the given index. Column Names: List(id, name)
```
```
val df = spark.read.parquet("table2")
val query = df.filter("id == 1")
hs.whyNot(query2, "testIndex2")
```
```
Inapplicable relations in the given query:
root
 |-- id: integer (nullable = true)
 |-- name: string (nullable = true)

  - No common source file.
    - Relation files sample: file:/C:/path/to/table2/part-00002-2a4a0234-dd64-4075-802c-72284aff5705-c000.snappy.parquet
    - Index files sample: file:/C:/path/to/table/part-00000-6646a693-a8fa-4d69-93df-8bf68c1a1d5a-c000.snappy.parquet
```
```scala
hs.createIndex(df, IndexConfig("testIndex2", Seq("id"), Seq("name")))
hs.whyNot(query, "testIndex")
````
```
Candidate logical relations after signature match:
StructType(StructField(id,IntegerType,true), StructField(name,StringType,true))

The index is applied to the given query. Plan:
*(1) Project [id#0, name#1]
+- *(1) Filter (isnotnull(id#0) && (id#0 = 1))
   +- *(1) FileScan parquet [id#0,name#1] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/path/to/spark-warehouse/indexes/testIndex2/v..., PartitionFilters: [], PushedFilters: [IsNotNull(id), EqualTo(id,1)], ReadSchema: struct<id:int,name:string>
```
```scala
val query2 = df.filter("name == 'name3'") // indexed column mismatch
hs.whyNot(query2, "testIndex2")
```
```
Candidate logical relations after signature match:
StructType(StructField(id,IntegerType,true), StructField(name,StringType,true))

Given query plan using Hyperspace:
*(1) Project [id#0, name#1]
+- *(1) Filter (isnotnull(name#1) && (name#1 = name3))
   +- *(1) FileScan parquet [id#0,name#1] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/C:/path/to/table2], PartitionFilters: [], PushedFilters: [IsNotNull(name), EqualTo(name,name3)], ReadSchema: struct<id:int,name:string>

There can be several possible causes:
  - Filter condition: filter column should be the first "indexed" column.
  - Join condition: only support Equi-join and ANDs.
  - Join condition: both left and right child should have a candidate index.
  - Rule order: Join Rule is prior to Filter Rule.
  - Index rank: another index is applied to the relation.
```
```scala
df.write.mode("append").parquet("table2")
val df = spark.read.parquet("table2")
val query = df.filter("id == 1")
hs.whyNot(query, "testIndex2") // source file change
```
```
Inapplicable relations in the given query:
root
 |-- id: integer (nullable = true)
 |-- name: string (nullable = true)

  - Detected 8 of common source file(s) between 8 of index files and 16 of relation files.
  - Detected 8 of appended file(s).
    - Appended files sample: file:/C:/path/to/table2/part-00004-5839d8a7-cc14-4cfd-8e50-b0478c5b1f23-c000.snappy.parquet
``` 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, introduces a new API described above section.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
TODO - unit test