### PR TITLE
Add hasParquetAsSourceFormat API in source provider

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -99,7 +99,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
       df: DataFrame): Option[(String, String)] = {
     val relation = df.queryExecution.optimizedPlan.asInstanceOf[LogicalRelation]
     if (Hyperspace.getContext(spark).sourceProviderManager.hasParquetAsSourceFormat(relation)) {
-      Some(IndexConstants.IS_PARQUET_SOURCE_PROPERTY -> "true")
+      Some(IndexConstants.HAS_PARQUET_AS_SOURCE_FORMAT -> "true")
     } else {
       None
     }

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -99,7 +99,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
       df: DataFrame): Option[(String, String)] = {
     val relation = df.queryExecution.optimizedPlan.asInstanceOf[LogicalRelation]
     if (Hyperspace.getContext(spark).sourceProviderManager.hasParquetAsSourceFormat(relation)) {
-      Some(IndexConstants.HAS_PARQUET_AS_SOURCE_FORMAT -> "true")
+      Some(IndexConstants.HAS_PARQUET_AS_SOURCE_FORMAT_PROPERTY -> "true")
     } else {
       None
     }

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -74,11 +74,8 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
           LogicalPlanFingerprint(
             LogicalPlanFingerprint.Properties(Seq(Signature(signatureProvider.name, s)))))
 
-        val coveringIndexProperties = if (hasLineage(spark)) {
-          Map(IndexConstants.LINEAGE_PROPERTY -> "true")
-        } else {
-          Map[String, String]()
-        }
+        val coveringIndexProperties =
+          (hasLineageProperty(spark) ++ hasParquetAsSourceFormatProperty(spark, df)).toMap
 
         IndexLogEntry(
           indexConfig.indexName,
@@ -94,6 +91,25 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
           Map())
 
       case None => throw HyperspaceException("Invalid plan for creating an index.")
+    }
+  }
+
+  private def hasParquetAsSourceFormatProperty(
+      spark: SparkSession,
+      df: DataFrame): Option[(String, String)] = {
+    val relation = df.queryExecution.optimizedPlan.asInstanceOf[LogicalRelation]
+    if (Hyperspace.getContext(spark).sourceProviderManager.hasParquetAsSourceFormat(relation)) {
+      Some(IndexConstants.IS_PARQUET_SOURCE_PROPERTY -> "true")
+    } else {
+      None
+    }
+  }
+
+  private def hasLineageProperty(spark: SparkSession): Option[(String, String)] = {
+    if (hasLineage(spark)) {
+      Some(IndexConstants.LINEAGE_PROPERTY -> "true")
+    } else {
+      None
     }
   }
 

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -103,7 +103,7 @@ object IndexConstants {
   // Indicate whether lineage is enabled for an index.
   private[hyperspace] val LINEAGE_PROPERTY = "lineage"
   // Indicate whether the source file format is parquet.
-  private[hyperspace] val IS_PARQUET_SOURCE_PROPERTY = "isParquetSource"
+  private[hyperspace] val HAS_PARQUET_AS_SOURCE_FORMAT = "hasParquetAsSourceFormat"
 
   // Hyperspace allows users to use globbing patterns to create indexes on. E.g. if user wants to
   // create an index on "/temp/*/*", they can do so by setting this key to "/temp/*/*". If not set,

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -103,7 +103,7 @@ object IndexConstants {
   // Indicate whether lineage is enabled for an index.
   private[hyperspace] val LINEAGE_PROPERTY = "lineage"
   // Indicate whether the source file format is parquet.
-  private[hyperspace] val HAS_PARQUET_AS_SOURCE_FORMAT = "hasParquetAsSourceFormat"
+  private[hyperspace] val HAS_PARQUET_AS_SOURCE_FORMAT_PROPERTY = "hasParquetAsSourceFormat"
 
   // Hyperspace allows users to use globbing patterns to create indexes on. E.g. if user wants to
   // create an index on "/temp/*/*", they can do so by setting this key to "/temp/*/*". If not set,

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -99,8 +99,11 @@ object IndexConstants {
   // Default id used for a file which does not have an id or its id is not known.
   private[hyperspace] val UNKNOWN_FILE_ID: Long = -1L
 
-  // JSON property name used in index metadata to store whether lineage is enabled for an index.
+  // JSON property names used in index metadata.
+  // Indicate whether lineage is enabled for an index.
   private[hyperspace] val LINEAGE_PROPERTY = "lineage"
+  // Indicate whether the source file format is parquet.
+  private[hyperspace] val IS_PARQUET_SOURCE_PROPERTY = "isParquetSource"
 
   // Hyperspace allows users to use globbing patterns to create indexes on. E.g. if user wants to
   // create an index on "/temp/*/*", they can do so by setting this key to "/temp/*/*". If not set,

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -526,9 +526,16 @@ case class IndexLogEntry(
     sourcePlanSignatures.head
   }
 
-  def hasLineageColumn: Boolean =
+  def hasLineageColumn: Boolean = {
     derivedDataset.properties.properties.getOrElse(
       IndexConstants.LINEAGE_PROPERTY, IndexConstants.INDEX_LINEAGE_ENABLED_DEFAULT).toBoolean
+  }
+
+  def hasParquetAsSourceFormat: Boolean = {
+    relations.head.fileFormat.equals("parquet") ||
+      derivedDataset.properties.properties.getOrElse(IndexConstants.IS_PARQUET_SOURCE_PROPERTY,
+        "false").toBoolean
+  }
 
   @JsonIgnore
   lazy val fileIdTracker: FileIdTracker = {

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -533,8 +533,8 @@ case class IndexLogEntry(
 
   def hasParquetAsSourceFormat: Boolean = {
     relations.head.fileFormat.equals("parquet") ||
-      derivedDataset.properties.properties.getOrElse(IndexConstants.HAS_PARQUET_AS_SOURCE_FORMAT,
-        "false").toBoolean
+      derivedDataset.properties.properties.getOrElse(
+        IndexConstants.HAS_PARQUET_AS_SOURCE_FORMAT_PROPERTY, "false").toBoolean
   }
 
   @JsonIgnore

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -533,7 +533,7 @@ case class IndexLogEntry(
 
   def hasParquetAsSourceFormat: Boolean = {
     relations.head.fileFormat.equals("parquet") ||
-      derivedDataset.properties.properties.getOrElse(IndexConstants.IS_PARQUET_SOURCE_PROPERTY,
+      derivedDataset.properties.properties.getOrElse(IndexConstants.HAS_PARQUET_AS_SOURCE_FORMAT,
         "false").toBoolean
   }
 

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -262,8 +262,6 @@ object RuleUtils {
       index: IndexLogEntry,
       plan: LogicalPlan,
       useBucketSpec: Boolean): LogicalPlan = {
-    val fileFormat = index.relations.head.fileFormat
-    val isParquetSourceFormat = fileFormat.equals("parquet") || fileFormat.equals("delta")
     var unhandledAppendedFiles: Seq[Path] = Nil
 
     // Get transformed plan with index data and appended files if applicable.
@@ -307,7 +305,7 @@ object RuleUtils {
           }
 
         val filesToRead = {
-          if (useBucketSpec || !isParquetSourceFormat || filesDeleted.nonEmpty ||
+          if (useBucketSpec || !index.hasParquetAsSourceFormat || filesDeleted.nonEmpty ||
               location.partitionSchema.nonEmpty) {
             // Since the index data is in "parquet" format, we cannot read source files
             // in formats other than "parquet" using one FileScan node as the operator requires

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/FileBasedSourceProviderManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/FileBasedSourceProviderManager.scala
@@ -120,6 +120,12 @@ class FileBasedSourceProviderManager(spark: SparkSession) {
     run(p => p.lineagePairs(logicalRelation, fileIdTracker))
   }
 
+  /**
+   * Returns whether the given relation has parquet source files or not.
+   *
+   * @param logicalRelation Logical Relation to check the source file format.
+   * @return True if source files in the given relation are parquet.
+   */
   def hasParquetAsSourceFormat(logicalRelation: LogicalRelation): Boolean = {
     run(p => p.hasParquetAsSourceFormat(logicalRelation))
   }

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/FileBasedSourceProviderManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/FileBasedSourceProviderManager.scala
@@ -120,6 +120,10 @@ class FileBasedSourceProviderManager(spark: SparkSession) {
     run(p => p.lineagePairs(logicalRelation, fileIdTracker))
   }
 
+  def hasParquetAsSourceFormat(logicalRelation: LogicalRelation): Boolean = {
+    run(p => p.hasParquetAsSourceFormat(logicalRelation))
+  }
+
   /**
    * Runs the given function 'f', which executes a [[FileBasedSourceProvider]]'s API that returns
    * [[Option]] for each provider built. This function ensures that only one provider returns

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/default/DefaultFileBasedSource.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/default/DefaultFileBasedSource.scala
@@ -242,6 +242,17 @@ class DefaultFileBasedSource(private val spark: SparkSession) extends FileBasedS
         None
     }
   }
+
+  override def hasParquetAsSourceFormat(logicalRelation: LogicalRelation): Option[Boolean] = {
+    logicalRelation.relation match {
+      case HadoopFsRelation(_: PartitioningAwareFileIndex, _, _, _, format, _)
+        if isSupportedFileFormat(format) =>
+        val fileFormatName = format.asInstanceOf[DataSourceRegister].shortName
+        Some(fileFormatName.equals("parquet"))
+      case _ =>
+        None
+    }
+  }
 }
 
 /**

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/default/DefaultFileBasedSource.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/default/DefaultFileBasedSource.scala
@@ -243,6 +243,12 @@ class DefaultFileBasedSource(private val spark: SparkSession) extends FileBasedS
     }
   }
 
+  /**
+   * Returns whether the given relation has parquet source files or not.
+   *
+   * @param logicalRelation Logical Relation to check the source file format.
+   * @return True if source files in the given relation are parquet.
+   */
   override def hasParquetAsSourceFormat(logicalRelation: LogicalRelation): Option[Boolean] = {
     logicalRelation.relation match {
       case HadoopFsRelation(_: PartitioningAwareFileIndex, _, _, _, format, _)

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/delta/DeltaLakeFileBasedSource.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/delta/DeltaLakeFileBasedSource.scala
@@ -173,6 +173,12 @@ class DeltaLakeFileBasedSource(private val spark: SparkSession) extends FileBase
     }
   }
 
+  /**
+   * Returns whether the given relation has parquet source files or not.
+   *
+   * @param logicalRelation Logical Relation to check the source file format.
+   * @return True if source files in the given relation are parquet.
+   */
   override def hasParquetAsSourceFormat(logicalRelation: LogicalRelation): Option[Boolean] = {
     logicalRelation.relation match {
       case HadoopFsRelation(_: TahoeLogFileIndex, _, _, _, _, _) =>

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/delta/DeltaLakeFileBasedSource.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/delta/DeltaLakeFileBasedSource.scala
@@ -172,6 +172,15 @@ class DeltaLakeFileBasedSource(private val spark: SparkSession) extends FileBase
         None
     }
   }
+
+  override def hasParquetAsSourceFormat(logicalRelation: LogicalRelation): Option[Boolean] = {
+    logicalRelation.relation match {
+      case HadoopFsRelation(_: TahoeLogFileIndex, _, _, _, _, _) =>
+        Some(true)
+      case _ =>
+        None
+    }
+  }
 }
 
 /**

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/interfaces.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/interfaces.scala
@@ -132,4 +132,6 @@ trait FileBasedSourceProvider extends SourceProvider {
       logicalRelation: LogicalRelation,
       fileIdTracker: FileIdTracker): Option[Seq[(String, Long)]]
 
+  def hasParquetAsSourceFormat(logicalRelation: LogicalRelation): Option[Boolean]
+
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/interfaces.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/interfaces.scala
@@ -132,6 +132,12 @@ trait FileBasedSourceProvider extends SourceProvider {
       logicalRelation: LogicalRelation,
       fileIdTracker: FileIdTracker): Option[Seq[(String, Long)]]
 
+  /**
+   * Returns whether the given relation has parquet source files or not.
+   *
+   * @param logicalRelation Logical Relation to check the source file format.
+   * @return True if source files in the given relation are parquet.
+   */
   def hasParquetAsSourceFormat(logicalRelation: LogicalRelation): Option[Boolean]
 
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What is the context for this pull request?
<!--
Please clarify the context for the changes you are contributing. The purpose of this section is to outline information information to help reviewers have enough context.
-->

 - **Tracking Issue**: #288 
 - **Parent Issue**: n/a
 - **Dependencies**: n/a


Fixes #288

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.

The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->

Added a new API - hasParquetAsSourceFormat to determine each source relation uses parquet file format internally in a pluggable way.
For example, Delta Lake stores the file format as "delta" but uses parquet as source file format internally.

Hyperspace applies an additional optimization for parquet source format when using Hybrid Scan & filter index rule.
Therefore to support this optimization for a new source provider, we need this API.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, added new property in index metadata.
(added only if `hasParquetAsSourceFormat` is true.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
This is refactoring change so will be tested by existing testcases.
