### PR TITLE
Fix Hyperspace with Databricks Runtime 5.5 LTS & 6.4 ClassCastException

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/sources/default/DefaultFileBasedSource.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/default/DefaultFileBasedSource.scala
@@ -24,6 +24,7 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex, HadoopFsRelation, LogicalRelation, PartitioningAwareFileIndex}
 import org.apache.spark.sql.sources.DataSourceRegister
+import org.apache.spark.util.hyperspace.Utils
 
 import com.microsoft.hyperspace.HyperspaceException
 import com.microsoft.hyperspace.index.{Content, FileIdTracker, Hdfs, Relation}
@@ -65,7 +66,7 @@ class DefaultFileBasedSource(private val spark: SparkSession) extends FileBasedS
           _,
           fileFormat,
           options) if isSupportedFileFormat(fileFormat) =>
-        val files = location.allFiles
+        val files = filesFromIndex(location)
         // Note that source files are currently fingerprinted when the optimized plan is
         // fingerprinted by LogicalPlanFingerprint.
         val sourceDataProperties =
@@ -81,7 +82,7 @@ class DefaultFileBasedSource(private val spark: SparkSession) extends FileBasedS
             // This logic is picked from the globbing logic at:
             // https://github.com/apache/spark/blob/v2.4.4/sql/core/src/main/scala/org/apache/
             // spark/sql/execution/datasources/DataSource.scala#L540
-            val fs = location.allFiles.head.getPath.getFileSystem(new Configuration)
+            val fs = filesFromIndex(location).head.getPath.getFileSystem(new Configuration)
             val globPaths = pattern
               .split(",")
               .map(_.trim)
@@ -161,7 +162,7 @@ class DefaultFileBasedSource(private val spark: SparkSession) extends FileBasedS
     logicalRelation.relation match {
       case HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, format, _)
           if isSupportedFileFormat(format) =>
-        val result = location.allFiles.sortBy(_.getPath.toString).foldLeft("") {
+        val result = filesFromIndex(location).sortBy(_.getPath.toString).foldLeft("") {
           (acc: String, f: FileStatus) =>
             HashingUtils.md5Hex(acc + fingerprint(f))
         }
@@ -190,7 +191,7 @@ class DefaultFileBasedSource(private val spark: SparkSession) extends FileBasedS
   override def allFiles(logicalRelation: LogicalRelation): Option[Seq[FileStatus]] = {
     logicalRelation.relation match {
       case HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _) =>
-        Some(location.allFiles)
+        Some(filesFromIndex(location))
       case _ => None
     }
   }
@@ -259,6 +260,31 @@ class DefaultFileBasedSource(private val spark: SparkSession) extends FileBasedS
         None
     }
   }
+
+  private def filesFromIndex(index: PartitioningAwareFileIndex): Seq[FileStatus] =
+    try {
+      // keep the `asInstanceOf` to force casting or fallback because Databricks `InMemoryFileIndex`
+      // implementation does return a `SerializableFileStatus` instead of the
+      // standard API's `FileStatus`
+      index.allFiles.map(_.asInstanceOf[FileStatus])
+    } catch {
+      case e: ClassCastException if e.getMessage.contains("SerializableFileStatus") =>
+        val dbClassName = "org.apache.spark.sql.execution.datasources.SerializableFileStatus"
+        val clazz = Utils.classForName(dbClassName)
+        val lengthMethod = clazz.getMethod("length")
+        val isDirMethod = clazz.getMethod("isDir")
+        val modificationTimeMethod = clazz.getMethod("modificationTime")
+        val pathMethod = clazz.getMethod("path")
+        index.allFiles.asInstanceOf[Seq[_]].map { f =>
+          new FileStatus(
+            lengthMethod.invoke(f).asInstanceOf[Long],
+            isDirMethod.invoke(f).asInstanceOf[Boolean],
+            0,
+            0,
+            modificationTimeMethod.invoke(f).asInstanceOf[Long],
+            new Path(pathMethod.invoke(f).asInstanceOf[String]))
+        }
+    }
 }
 
 /**

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/default/DefaultFileBasedSource.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/default/DefaultFileBasedSource.scala
@@ -263,9 +263,9 @@ class DefaultFileBasedSource(private val spark: SparkSession) extends FileBasedS
 
   private def filesFromIndex(index: PartitioningAwareFileIndex): Seq[FileStatus] =
     try {
-      // keep the `asInstanceOf` to force casting or fallback because Databricks `InMemoryFileIndex`
-      // implementation does return a `SerializableFileStatus` instead of the
-      // standard API's `FileStatus`
+      // Keep the `asInstanceOf` to force casting or fallback because Databrick's
+      // `InMemoryFileIndex` implementation returns `SerializableFileStatus` instead of the
+      // standard API's `FileStatus`.
       index.allFiles.map(_.asInstanceOf[FileStatus])
     } catch {
       case e: ClassCastException if e.getMessage.contains("SerializableFileStatus") =>


### PR DESCRIPTION
### What is the context for this pull request?

 - **Tracking Issue**: https://github.com/microsoft/hyperspace/issues/302
 - **Discussion**: https://github.com/microsoft/hyperspace/discussions/285

### What changes were proposed in this pull request?

This PR fixes the `ClassCastException` encountered when running Hyperspace with Databricks 5.5 LTS Runtime.

Technically, in the case of `org.apache.spark.sql.execution.datasources.SerializableFileStatus cannot be cast to org.apache.hadoop.fs.FileStatus` exception we fall back dynamically getting the needed properties from the `SerializableFileStatus` instance.

This exception is happening because the Spark running in the Databricks 5.5 Runtime has the `PartitioningAwareFileIndex` modified and instead of returning `FileStatus` it returns the `SerializableFileStatus` class. `SerializableFileStatus` is part of Delta open-source project, and normally it should be present at `org.apache.spark.sql.delta.util` but Databricks decided to incorporate into their own version of Spark in another location as seen in the exception.

I tried the following 3 solutions:
1. Use the `inputFiles` of the `PartitioningAwareFileIndex`
2. Create the `SerializableFileStatus` class under `org.apache.spark.sql.execution.datasources` inside the Hyperspace project
3. Dynamically retrieve the properties from the `org.apache.spark.sql.execution.datasources.SerializableFileStatus` class instance.

I decided to go with the **3rd solution** because:
- solution 1 gives all the input files not the ones resulting after the scan
- solution 2 adds code that is part of another open-source project

The code in this PR represents the 3rd solution.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This was tested in a Databricks 5.5 LTS & 6.4 Runtime by executing the example code.