### PR TITLE
Remove duplicate getFileIdTracker() in tests

### DIFF
--- a/src/test/scala/com/microsoft/hyperspace/TestUtils.scala
+++ b/src/test/scala/com/microsoft/hyperspace/TestUtils.scala
@@ -20,7 +20,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 import com.microsoft.hyperspace.MockEventLogger.reset
-import com.microsoft.hyperspace.index.{IndexLogEntry, IndexLogManager, IndexLogManagerFactoryImpl}
+import com.microsoft.hyperspace.index.{FileIdTracker, IndexConfig, IndexLogEntry, IndexLogManager, IndexLogManagerFactoryImpl}
 import com.microsoft.hyperspace.telemetry.{EventLogger, HyperspaceEvent}
 import com.microsoft.hyperspace.util.{FileUtils, PathUtils}
 
@@ -80,6 +80,10 @@ object TestUtils {
       .getLatestStableLog()
       .get
       .asInstanceOf[IndexLogEntry]
+  }
+
+  def getFileIdTracker(systemPath: Path, indexConfig: IndexConfig): FileIdTracker = {
+    latestIndexLogEntry(systemPath, indexConfig.indexName).fileIdTracker
   }
 }
 

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -25,10 +25,9 @@ import org.apache.spark.sql.sources.DataSourceRegister
 import org.apache.spark.sql.types._
 
 import com.microsoft.hyperspace.{Hyperspace, HyperspaceException, MockEventLogger, SampleData}
-import com.microsoft.hyperspace.TestUtils.{copyWithState, latestIndexLogEntry, logManager}
+import com.microsoft.hyperspace.TestUtils.{copyWithState, getFileIdTracker, latestIndexLogEntry, logManager}
 import com.microsoft.hyperspace.actions.Constants
 import com.microsoft.hyperspace.index.IndexConstants.{GLOBBING_PATTERN_KEY, OPTIMIZE_FILE_SIZE_THRESHOLD, REFRESH_MODE_FULL, REFRESH_MODE_INCREMENTAL}
-import com.microsoft.hyperspace.index.RefreshIndexTests.getFileIdTracker
 import com.microsoft.hyperspace.telemetry.OptimizeActionEvent
 import com.microsoft.hyperspace.util.{FileUtils, JsonUtils, PathUtils}
 
@@ -704,7 +703,7 @@ class IndexManagerTests extends HyperspaceSuite with SQLHelper {
       df: DataFrame,
       state: String = Constants.States.ACTIVE): IndexLogEntry = {
 
-    val fileIdTracker = RefreshIndexTests.getFileIdTracker(indexConfig, systemPath)
+    val fileIdTracker = getFileIdTracker(systemPath, indexConfig)
     LogicalPlanSignatureProvider.create().signature(df.queryExecution.optimizedPlan) match {
       case Some(s) =>
         val relations = df.queryExecution.optimizedPlan.collect {

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -28,6 +28,7 @@ import com.microsoft.hyperspace.{Hyperspace, HyperspaceException, MockEventLogge
 import com.microsoft.hyperspace.TestUtils.{copyWithState, latestIndexLogEntry, logManager}
 import com.microsoft.hyperspace.actions.Constants
 import com.microsoft.hyperspace.index.IndexConstants.{GLOBBING_PATTERN_KEY, OPTIMIZE_FILE_SIZE_THRESHOLD, REFRESH_MODE_FULL, REFRESH_MODE_INCREMENTAL}
+import com.microsoft.hyperspace.index.RefreshIndexTests.getFileIdTracker
 import com.microsoft.hyperspace.telemetry.OptimizeActionEvent
 import com.microsoft.hyperspace.util.{FileUtils, JsonUtils, PathUtils}
 
@@ -703,7 +704,7 @@ class IndexManagerTests extends HyperspaceSuite with SQLHelper {
       df: DataFrame,
       state: String = Constants.States.ACTIVE): IndexLogEntry = {
 
-    val fileIdTracker = getFileIdTracker(indexConfig)
+    val fileIdTracker = RefreshIndexTests.getFileIdTracker(indexConfig, systemPath)
     LogicalPlanSignatureProvider.create().signature(df.queryExecution.optimizedPlan) match {
       case Some(s) =>
         val relations = df.queryExecution.optimizedPlan.collect {
@@ -773,13 +774,4 @@ class IndexManagerTests extends HyperspaceSuite with SQLHelper {
       .count()
   }
 
-  private def getFileIdTracker(indexConfig: IndexConfig): FileIdTracker = {
-    val indexLogPath = PathUtils.makeAbsolute(
-      s"$systemPath/${indexConfig.indexName}/${IndexConstants.HYPERSPACE_LOG}/latestStable")
-    val indexLogJson =
-      FileUtils.readContents(indexLogPath.getFileSystem(new Configuration), indexLogPath)
-    JsonUtils
-      .fromJson[IndexLogEntry](indexLogJson)
-      .fileIdTracker
-  }
 }


### PR DESCRIPTION
### What is the context for this pull request?
Removes a duplicate method getFileIdTracker() from IndexManagerTests class

 - **Tracking Issue**: #257
 - **Parent Issue**: N/A
 - **Dependencies**: N/A

### What changes were proposed in this pull request?
Removes duplicate method `getFileIdTracker` from IndexManagerTests and adds it to a companion object in RefreshIndexTests along with additional parameter systemPath which is required inside the method.
```
Removed from IndexManagerTests
private def getFileIdTracker(indexConfig: IndexConfig): FileIdTracker = {
    val indexLogPath = PathUtils.makeAbsolute(
      s"$systemPath/${indexConfig.indexName}/${IndexConstants.HYPERSPACE_LOG}/latestStable")
    val indexLogJson =
      FileUtils.readContents(indexLogPath.getFileSystem(new Configuration), indexLogPath)
    JsonUtils
      .fromJson[IndexLogEntry](indexLogJson)
      .fileIdTracker}
```

```
Added in RefreshIndexTests with additional parameter systemPath
object RefreshIndexTests {
  def getFileIdTracker(indexConfig: IndexConfig, systemPath: Path): FileIdTracker = {
    val indexLogPath = PathUtils.makeAbsolute(
      s"$systemPath/${indexConfig.indexName}/${IndexConstants.HYPERSPACE_LOG}/latestStable")
    val indexLogJson =
      FileUtils.readContents(indexLogPath.getFileSystem(new Configuration), indexLogPath)
    JsonUtils
      .fromJson[IndexLogEntry](indexLogJson)
      .fileIdTracker
  }
}
```

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Changes in the tests.
