### PR TITLE
Add include/exclude columns to IndexConfig and modify included columns resolution

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateAction.scala
@@ -66,7 +66,10 @@ class CreateAction(
   private def isValidIndexSchema(config: IndexConfig, schema: StructType): Boolean = {
     // Resolve index config columns from available column names present in the schema.
     ResolverUtils
-      .resolve(spark, config.indexedColumns ++ config.includedColumns, schema.fieldNames)
+      .resolve(
+        spark,
+        config.indexedColumns ++ config.includedColumns.include ++ config.includedColumns.exclude,
+        schema.fieldNames)
       .isDefined
   }
 

--- a/src/test/scala/com/microsoft/hyperspace/index/CreateIndexTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/CreateIndexTests.scala
@@ -165,7 +165,7 @@ class CreateIndexTests extends HyperspaceSuite with SQLHelper {
       // For non-partitioned data, only file name lineage column should be added to index schema.
       assert(
         indexRecordsDF.schema.fieldNames.sorted ===
-          (indexConfig1.indexedColumns ++ indexConfig1.includedColumns ++
+          (indexConfig1.indexedColumns ++ indexConfig1.includedColumns.include ++
             Seq(IndexConstants.DATA_FILE_NAME_ID)).sorted)
     }
   }
@@ -180,7 +180,7 @@ class CreateIndexTests extends HyperspaceSuite with SQLHelper {
       // should be added to index schema if they are not already among index config columns.
       assert(
         indexRecordsDF.schema.fieldNames.sorted ===
-          (indexConfig3.indexedColumns ++ indexConfig3.includedColumns ++
+          (indexConfig3.indexedColumns ++ indexConfig3.includedColumns.include ++
             Seq(IndexConstants.DATA_FILE_NAME_ID) ++ partitionKeys).sorted)
     }
   }
@@ -195,7 +195,7 @@ class CreateIndexTests extends HyperspaceSuite with SQLHelper {
       // there should be no duplicates due to adding lineage.
       assert(
         indexRecordsDF.schema.fieldNames.sorted ===
-          (indexConfig4.indexedColumns ++ indexConfig4.includedColumns ++
+          (indexConfig4.indexedColumns ++ indexConfig4.includedColumns.include ++
             Seq(IndexConstants.DATA_FILE_NAME_ID)).sorted)
     }
   }
@@ -212,7 +212,7 @@ class CreateIndexTests extends HyperspaceSuite with SQLHelper {
       // file name column and second partition key column as lineage columns.
       assert(
         indexRecordsDF.schema.fieldNames.sorted ===
-          (indexConfig3.indexedColumns ++ indexConfig3.includedColumns ++
+          (indexConfig3.indexedColumns ++ indexConfig3.includedColumns.include ++
             Seq(IndexConstants.DATA_FILE_NAME_ID, partitionKeys(1))).sorted)
     }
   }

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexConfigTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexConfigTests.scala
@@ -106,7 +106,7 @@ class IndexConfigTests extends SparkFunSuite {
 
     assert(indexConfig.indexName.equals(indexName))
     assert(indexConfig.indexedColumns.equals(indexedColumns))
-    assert(indexConfig.includedColumns.equals(includedColumns))
+    assert(indexConfig.includedColumns.include.equals(includedColumns))
   }
 
   test("Test exception on multiple indexBy, include and index name on IndexConfig builder.") {

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTests.scala
@@ -84,7 +84,7 @@ class IndexManagerTests extends HyperspaceSuite with SQLHelper {
           val expected = IndexStatistics(
             indexConfig1.indexName,
             indexConfig1.indexedColumns,
-            indexConfig1.includedColumns,
+            indexConfig1.includedColumns.include,
             200,
             expectedSchema.json,
             s"$systemPath/${indexConfig1.indexName}" +
@@ -755,7 +755,7 @@ class IndexManagerTests extends HyperspaceSuite with SQLHelper {
           CoveringIndex(
             CoveringIndex.Properties(
               CoveringIndex.Properties
-                .Columns(indexConfig.indexedColumns, indexConfig.includedColumns),
+                .Columns(indexConfig.indexedColumns, indexConfig.includedColumns.include),
               IndexLogEntry.schemaString(schema),
               IndexConstants.INDEX_NUM_BUCKETS_DEFAULT,
               Map())),

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexTests.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexTests.scala
@@ -42,7 +42,7 @@ class IndexTests extends SparkFunSuite {
       CoveringIndex(
         CoveringIndex.Properties(
           CoveringIndex.Properties
-            .Columns(config.indexedColumns, config.includedColumns),
+            .Columns(config.indexedColumns, config.includedColumns.include),
           IndexLogEntry.schemaString(schema),
           10,
           Map())),


### PR DESCRIPTION
### What is the context for this pull request?
This PR is part of changes to add support for indexing datasets with evolving schema. Check proposal #263 for more details.
This PR extends `IndexConfig` so that user can define included columns for an index via specifying `include` or `exclude` columns.

**Tracking Issue**: #229

### What changes were proposed in this pull request?
This PR adds changes to:
- `IndexConfig` to support defining an index's included columns via specifying `include' or `exclude` columns.
- Column resolution in create index path is modified to extract list of index's included columns from `IndexConfig.include` and `IndexConfig.exclude` .

**Example:**
Assume user wants to create an index on DataFrame `df` whose schema has 5 columns:

`{"C0", "C1", "C2", "C3", "C4"}`

and `"C0"` is picked as the indexed column. 

Below is how `IndexConfig.includedColumns` can be used to define different sets of included columns:
- Pick `{"C1", "C2"}` as included columns:
```
val cols = IncludedColumns(include = Seq("C1", "C2"))
```  
- Pick no column as included columns (i.e. Index only has indexed column):
```
val cols = IncludedColumns(include = Seq())
```
- Exclude `{"C1", "C2"}` from data schema and pick `{"C3", "C4"}` as included columns:
```
val cols = IncludedColumns(exclude = Seq("C1", "C2"))
```
- Exclude no column from schema and pick all columns as included columns. So index will have `{"C1", "C2", "C3", "C4"}` as its included columns:
```
val cols = IncludedColumns(exclude = Seq())
```
We use above `IncludedColumns` instance (i.e. `cols`) for index creation as:
```
val ixConfig = IndexConfig(indexName = "ix", indexedColumns = Seq("C0"), includedColumns = cols)
createIndex(df, ixConfig)
```
### Does this PR introduce _any_ user-facing change?
Yes, it extends `IndexConfig` definition which is used by user when creating an index.

### How was this patch tested?
Unit testing.