### PR TITLE
Support DataSourceV2 sources

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateAction.scala
@@ -43,7 +43,7 @@ class CreateAction(
 
   final override def validate(): Unit = {
     // We currently only support createIndex() over HDFS file based scan nodes.
-    if (!LogicalPlanUtils.isLogicalRelation(df.queryExecution.optimizedPlan)) {
+    if (!LogicalPlanUtils.isLogicalPlanSupported(df.queryExecution.optimizedPlan)) {
       throw HyperspaceException(
         "Only creating index over HDFS file based scan nodes is supported.")
     }

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateAction.scala
@@ -43,7 +43,7 @@ class CreateAction(
 
   final override def validate(): Unit = {
     // We currently only support createIndex() over HDFS file based scan nodes.
-    if (!LogicalPlanUtils.hasSupportedLogicalRelation(df.queryExecution.optimizedPlan)) {
+    if (!LogicalPlanUtils.isSupportedRelation(df.queryExecution.optimizedPlan)) {
       throw HyperspaceException(
         "Only creating index over HDFS file based scan nodes is supported.")
     }

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateAction.scala
@@ -43,7 +43,7 @@ class CreateAction(
 
   final override def validate(): Unit = {
     // We currently only support createIndex() over HDFS file based scan nodes.
-    if (!LogicalPlanUtils.isLogicalPlanSupported(df.queryExecution.optimizedPlan)) {
+    if (!LogicalPlanUtils.hasSupportedLogicalRelation(df.queryExecution.optimizedPlan)) {
       throw HyperspaceException(
         "Only creating index over HDFS file based scan nodes is supported.")
     }

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -67,6 +67,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
     signatureProvider.signature(df.queryExecution.optimizedPlan) match {
       case Some(s) =>
         val relations = sourceRelations(spark, df)
+        // Currently, we only support to create an index on only one relation.
         assert(relations.size == 1)
 
         val sourcePlanProperties = SparkPlan.Properties(
@@ -117,7 +118,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
 
   protected def sourceRelations(spark: SparkSession, df: DataFrame): Seq[Relation] =
     df.queryExecution.optimizedPlan.collect {
-      case p: LogicalPlan if LogicalPlanUtils.hasSupportedLogicalRelation(p) =>
+      case p: LogicalPlan if LogicalPlanUtils.isSupportedRelation(p) =>
         Hyperspace.getContext(spark).sourceProviderManager.createRelation(p, fileIdTracker)
     }
 

--- a/src/main/scala/com/microsoft/hyperspace/index/FileBasedSignatureProvider.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/FileBasedSignatureProvider.scala
@@ -18,6 +18,7 @@ package com.microsoft.hyperspace.index
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
 import com.microsoft.hyperspace.Hyperspace
 import com.microsoft.hyperspace.util.HashingUtils
@@ -49,7 +50,7 @@ class FileBasedSignatureProvider extends LogicalPlanSignatureProvider {
   private def fingerprintVisitor(logicalPlan: LogicalPlan): Option[String] = {
     var fingerprint = ""
     logicalPlan.foreachUp {
-      case p: LogicalRelation =>
+      case p @ (_: LogicalRelation | _: DataSourceV2Relation) =>
         fingerprint ++= Hyperspace.getContext.sourceProviderManager.signature(p)
       case _ =>
     }

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -166,7 +166,7 @@ object ExtractFilterNode {
           filter @ Filter(
             condition: Expression,
             p: LogicalPlan))
-        if LogicalPlanUtils.hasSupportedLogicalRelation(p) &&
+        if LogicalPlanUtils.isSupportedRelation(p) &&
             !RuleUtils.isIndexApplied(p) =>
       val projectColumnNames = CleanupAliases(project)
         .asInstanceOf[Project]
@@ -180,7 +180,7 @@ object ExtractFilterNode {
     case filter @ Filter(
           condition: Expression,
           p: LogicalPlan)
-        if LogicalPlanUtils.hasSupportedLogicalRelation(p) &&
+        if LogicalPlanUtils.isSupportedRelation(p) &&
             !RuleUtils.isIndexApplied(p) =>
       val relationColumnsName = p.output.map(_.name)
       val filterColumnNames = condition.references.map(_.name).toSeq

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/FilterIndexRule.scala
@@ -161,7 +161,7 @@ object ExtractFilterNode {
       Filter,
       Seq[String], // output columns
       Seq[String], // filter columns
-      LogicalRelation,
+      LogicalPlan, // relation node
       HadoopFsRelation)
 
   def unapply(plan: LogicalPlan): Option[returnType] = plan match {

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -32,6 +32,7 @@ import com.microsoft.hyperspace.actions.Constants
 import com.microsoft.hyperspace.index._
 import com.microsoft.hyperspace.index.rankers.JoinIndexRanker
 import com.microsoft.hyperspace.telemetry.{AppInfo, HyperspaceEventLogging, HyperspaceIndexUsageEvent}
+import com.microsoft.hyperspace.util.LogicalPlanUtils
 import com.microsoft.hyperspace.util.ResolverUtils._
 
 /**
@@ -340,7 +341,7 @@ object JoinIndexRule
 
   private def relationOutputs(l: LogicalPlan): Seq[Attribute] = {
     l.collectLeaves()
-        .filter(i => i.isInstanceOf[LogicalRelation] ||  i.isInstanceOf[DataSourceV2Relation])
+        .filter(LogicalPlanUtils.hasSupportedLogicalRelation)
         .flatMap(_.output)
   }
 

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -341,7 +341,7 @@ object JoinIndexRule
 
   private def relationOutputs(l: LogicalPlan): Seq[Attribute] = {
     l.collectLeaves()
-        .filter(LogicalPlanUtils.hasSupportedLogicalRelation)
+        .filter(LogicalPlanUtils.isSupportedRelation)
         .flatMap(_.output)
   }
 

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -480,7 +480,7 @@ object RuleUtils {
         val options = Hyperspace
           .getContext(spark)
           .sourceProviderManager
-          .partitionBasePath(location)
+          .partitionBasePath(baseRelation)
           .map { basePath =>
             // Set "basePath" so that partitioned columns are also included in the output schema.
             Map("basePath" -> basePath)

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/FileBasedSourceProviderManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/FileBasedSourceProviderManager.scala
@@ -21,7 +21,6 @@ import scala.util.{Success, Try}
 import org.apache.hadoop.fs.FileStatus
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.execution.datasources.FileIndex
 import org.apache.spark.util.hyperspace.Utils
 
 import com.microsoft.hyperspace.HyperspaceException
@@ -107,13 +106,13 @@ class FileBasedSourceProviderManager(spark: SparkSession) {
   /**
    * Runs partitionBasePath() for each provider.
    *
-   * @param location Partitioned location.
-   * @return Optional basePath string to read the given partitioned location.
+   * @param logicalPlan Partitioned location.
+   * @return basePath string to read the given partitioned location.
    * @throws HyperspaceException if multiple providers returns [[Some]] or
    *                             if no providers return [[Some]].
    */
-  def partitionBasePath(location: FileIndex): Option[String] = {
-    run(p => p.partitionBasePath(location))
+  def partitionBasePath(logicalPlan: LogicalPlan): Option[String] = {
+    run(p => p.partitionBasePath(logicalPlan))
   }
 
   /**

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/FileBasedSourceProviderManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/FileBasedSourceProviderManager.scala
@@ -20,7 +20,8 @@ import scala.util.{Success, Try}
 
 import org.apache.hadoop.fs.FileStatus
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.execution.datasources.{FileIndex, LogicalRelation}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.FileIndex
 import org.apache.spark.util.hyperspace.Utils
 
 import com.microsoft.hyperspace.HyperspaceException
@@ -47,14 +48,14 @@ class FileBasedSourceProviderManager(spark: SparkSession) {
   /**
    * Runs createRelation() for each provider.
    *
-   * @param logicalRelation Logical relation to create [[Relation]] from.
+   * @param logicalPlan Logical plan to create [[Relation]] from.
    * @param fileIdTracker [[FileIdTracker]] to use when populating the data of [[Relation]].
    * @return [[Relation]] created from the given logical relation.
    * @throws HyperspaceException if multiple providers returns [[Some]] or
    *                             if no providers return [[Some]].
    */
-  def createRelation(logicalRelation: LogicalRelation, fileIdTracker: FileIdTracker): Relation = {
-    run(p => p.createRelation(logicalRelation, fileIdTracker))
+  def createRelation(logicalPlan: LogicalPlan, fileIdTracker: FileIdTracker): Relation = {
+    run(p => p.createRelation(logicalPlan, fileIdTracker))
   }
 
   /**
@@ -82,25 +83,25 @@ class FileBasedSourceProviderManager(spark: SparkSession) {
   /**
    * Runs signature() for each provider.
    *
-   * @param logicalRelation Logical relation to compute signature from.
+   * @param logicalPlan Logical plan to compute signature from.
    * @return Computed signature.
    * @throws HyperspaceException if multiple providers returns [[Some]] or
    *                             if no providers return [[Some]].
    */
-  def signature(logicalRelation: LogicalRelation): String = {
-    run(p => p.signature(logicalRelation))
+  def signature(logicalPlan: LogicalPlan): String = {
+    run(p => p.signature(logicalPlan))
   }
 
   /**
    * Runs allFiles() for each provider.
    *
-   * @param logicalRelation Logical relation to retrieve all input files.
+   * @param logicalPlan Logical plan to retrieve all input files.
    * @return List of all input files.
    * @throws HyperspaceException if multiple providers returns [[Some]] or
    *                             if no providers return [[Some]].
    */
-  def allFiles(logicalRelation: LogicalRelation): Seq[FileStatus] = {
-    run(p => p.allFiles(logicalRelation))
+  def allFiles(logicalPlan: LogicalPlan): Seq[FileStatus] = {
+    run(p => p.allFiles(logicalPlan))
   }
 
   /**
@@ -118,26 +119,26 @@ class FileBasedSourceProviderManager(spark: SparkSession) {
   /**
    * Runs lineagePairs() for each provider.
    *
-   * @param logicalRelation Logical Relation to check the relation type.
+   * @param logicalPlan Logical plan to check the relation type.
    * @param fileIdTracker [[FileIdTracker]] to create the list of (file path, file id).
    * @return List of (file path, file id).
    * @throws HyperspaceException if multiple providers returns [[Some]] or
    *                             if no providers return [[Some]].
    */
   def lineagePairs(
-      logicalRelation: LogicalRelation,
+      logicalPlan: LogicalPlan,
       fileIdTracker: FileIdTracker): Seq[(String, Long)] = {
-    run(p => p.lineagePairs(logicalRelation, fileIdTracker))
+    run(p => p.lineagePairs(logicalPlan, fileIdTracker))
   }
 
   /**
    * Returns whether the given relation has parquet source files or not.
    *
-   * @param logicalRelation Logical Relation to check the source file format.
+   * @param logicalPlan Logical plan to check the source file format.
    * @return True if source files in the given relation are parquet.
    */
-  def hasParquetAsSourceFormat(logicalRelation: LogicalRelation): Boolean = {
-    run(p => p.hasParquetAsSourceFormat(logicalRelation))
+  def hasParquetAsSourceFormat(logicalPlan: LogicalPlan): Boolean = {
+    run(p => p.hasParquetAsSourceFormat(logicalPlan))
   }
 
   /**

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/default/DefaultFileBasedSource.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/default/DefaultFileBasedSource.scala
@@ -21,6 +21,7 @@ import java.util.Locale
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.sources.DataSourceRegister
@@ -50,75 +51,80 @@ class DefaultFileBasedSource(private val spark: SparkSession) extends FileBasedS
   /**
    * Creates [[Relation]] for IndexLogEntry using the given [[LogicalRelation]].
    *
-   * @param logicalRelation Logical relation to derive [[Relation]] from.
+   * @param logicalPlan Logical plan to derive [[Relation]] from.
    * @param fileIdTracker [[FileIdTracker]] to use when populating the data of [[Relation]].
    * @return [[Relation]] object if the given 'logicalRelation' can be processed by this provider.
    *         Otherwise, None.
    */
   override def createRelation(
-      logicalRelation: LogicalRelation,
+      logicalPlan: LogicalPlan,
       fileIdTracker: FileIdTracker): Option[Relation] = {
-    logicalRelation.relation match {
-      case HadoopFsRelation(
-          location: PartitioningAwareFileIndex,
-          _,
-          dataSchema,
-          _,
-          fileFormat,
-          options) if isSupportedFileFormat(fileFormat) =>
-        val files = filesFromIndex(location)
-        // Note that source files are currently fingerprinted when the optimized plan is
-        // fingerprinted by LogicalPlanFingerprint.
-        val sourceDataProperties =
-          Hdfs.Properties(Content.fromLeafFiles(files, fileIdTracker).get)
-        val fileFormatName = fileFormat.asInstanceOf[DataSourceRegister].shortName
+    logicalPlan match {
+      case logicalRelation: LogicalRelation =>
+        logicalRelation.relation match {
+          case HadoopFsRelation(
+              location: PartitioningAwareFileIndex,
+              _,
+              dataSchema,
+              _,
+              fileFormat,
+              options) if isSupportedFileFormat(fileFormat) =>
 
-        // Use case-sensitive map if the provided options are case insensitive. Case-insensitive
-        // map converts all key-value pairs to lowercase before storing them in the metadata,
-        // making them unusable for future use. An example is "basePath" option.
-        val caseSensitiveOptions = options match {
-          case map: CaseInsensitiveMap[String] => map.originalMap
-          case map => map
-        }
+            val files = filesFromIndex(location)
+            // Note that source files are currently fingerprinted when the optimized plan is
+            // fingerprinted by LogicalPlanFingerprint.
+            val sourceDataProperties =
+            Hdfs.Properties(Content.fromLeafFiles(files, fileIdTracker).get)
+            val fileFormatName = fileFormat.asInstanceOf[DataSourceRegister].shortName
 
-        // Get basePath of hive-partitioned data sources, if applicable.
-        val basePathOpt = partitionBasePath(location).flatten.map("basePath" -> _)
-
-        // "path" key in options can incur multiple data read unexpectedly.
-        val opts = caseSensitiveOptions - "path" ++ basePathOpt
-
-        val rootPaths = opts.get(GLOBBING_PATTERN_KEY) match {
-          case Some(pattern) =>
-            // Validate if globbing pattern matches actual source paths.
-            // This logic is picked from the globbing logic at:
-            // https://github.com/apache/spark/blob/v2.4.4/sql/core/src/main/scala/org/apache/
-            // spark/sql/execution/datasources/DataSource.scala#L540
-            val fs = filesFromIndex(location).head.getPath
-              .getFileSystem(spark.sessionState.newHadoopConf())
-            val globPaths = pattern
-              .split(",")
-              .map(_.trim)
-              .map { path =>
-                val hdfsPath = new Path(path)
-                val qualified = hdfsPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
-                qualified.toString -> SparkHadoopUtil.get.globPathIfNecessary(fs, qualified)
-              }
-              .toMap
-
-            val globPathValues = globPaths.values.flatten.toSet
-            if (!location.rootPaths.forall(globPathValues.contains)) {
-              throw HyperspaceException(
-                "Some glob patterns do not match with available root " +
-                  s"paths of the source data. Please check if $pattern matches all of " +
-                  s"${location.rootPaths.mkString(",")}.")
+            // Use case-sensitive map if the provided options are case insensitive. Case-insensitive
+            // map converts all key-value pairs to lowercase before storing them in the metadata,
+            // making them unusable for future use. An example is "basePath" option.
+            val caseSensitiveOptions = options match {
+              case map: CaseInsensitiveMap[String] => map.originalMap
+              case map => map
             }
-            globPaths.keySet.toSeq
 
-          case _ => location.rootPaths.map(_.toString)
+            // Get basePath of hive-partitioned data sources, if applicable.
+            val basePathOpt = partitionBasePath(logicalPlan).flatten.map("basePath" -> _)
+
+            // "path" key in options can incur multiple data read unexpectedly.
+            val opts = caseSensitiveOptions - "path" ++ basePathOpt
+
+            val rootPaths = opts.get(GLOBBING_PATTERN_KEY) match {
+              case Some(pattern) =>
+                // Validate if globbing pattern matches actual source paths.
+                // This logic is picked from the globbing logic at:
+                // https://github.com/apache/spark/blob/v2.4.4/sql/core/src/main/scala/org/apache/
+                // spark/sql/execution/datasources/DataSource.scala#L540
+                val fs = filesFromIndex(location).head.getPath
+                  .getFileSystem(spark.sessionState.newHadoopConf())
+                val globPaths = pattern
+                    .split(",")
+                    .map(_.trim)
+                    .map { path =>
+                      val hdfsPath = new Path(path)
+                      val qualified = hdfsPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
+                      qualified.toString -> SparkHadoopUtil.get.globPathIfNecessary(fs, qualified)
+                    }
+                    .toMap
+
+                val globPathValues = globPaths.values.flatten.toSet
+                if (!location.rootPaths.forall(globPathValues.contains)) {
+                  throw HyperspaceException(
+                    "Some glob patterns do not match with available root " +
+                        s"paths of the source data. Please check if $pattern matches all of " +
+                        s"${location.rootPaths.mkString(",")}.")
+                }
+                globPaths.keySet.toSeq
+
+              case _ => location.rootPaths.map(_.toString)
+            }
+
+            Some(Relation(rootPaths, Hdfs(sourceDataProperties), dataSchema.json,
+              fileFormatName, opts))
+          case _ => None
         }
-
-        Some(
-          Relation(rootPaths, Hdfs(sourceDataProperties), dataSchema.json, fileFormatName, opts))
       case _ => None
     }
   }
@@ -181,19 +187,23 @@ class DefaultFileBasedSource(private val spark: SparkSession) extends FileBasedS
    * Computes the signature using the given [[LogicalRelation]]. This computes a signature of
    * using all the files found in [[PartitioningAwareFileIndex]].
    *
-   * @param logicalRelation Logical relation to compute signature from.
+   * @param logicalPlan Logical plan to compute signature from.
    * @return Signature computed if the given 'logicalRelation' can be processed by this provider.
    *         Otherwise, None.
    */
-  override def signature(logicalRelation: LogicalRelation): Option[String] = {
-    logicalRelation.relation match {
-      case HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, format, _)
-          if isSupportedFileFormat(format) =>
-        val result = filesFromIndex(location).sortBy(_.getPath.toString).foldLeft("") {
-          (acc: String, f: FileStatus) =>
-            HashingUtils.md5Hex(acc + fingerprint(f))
+  override def signature(logicalPlan: LogicalPlan): Option[String] = {
+    logicalPlan match {
+      case logicalRelation: LogicalRelation =>
+        logicalRelation.relation match {
+          case HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, format, _)
+            if isSupportedFileFormat(format) =>
+            val result = filesFromIndex(location).sortBy(_.getPath.toString).foldLeft("") {
+              (acc: String, f: FileStatus) =>
+                HashingUtils.md5Hex(acc + fingerprint(f))
+            }
+            Some(result)
+          case _ => None
         }
-        Some(result)
       case _ => None
     }
   }
@@ -212,39 +222,49 @@ class DefaultFileBasedSource(private val spark: SparkSession) extends FileBasedS
   /**
    * Retrieves all input files from the given [[LogicalRelation]].
    *
-   * @param logicalRelation Logical relation to retrieve input files from.
+   * @param logicalPlan Logical plan to retrieve input files from.
    * @return List of [[FileStatus]] for the given relation.
    */
-  override def allFiles(logicalRelation: LogicalRelation): Option[Seq[FileStatus]] = {
-    logicalRelation.relation match {
-      case HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _) =>
-        Some(filesFromIndex(location))
+  override def allFiles(logicalPlan: LogicalPlan): Option[Seq[FileStatus]] = {
+    logicalPlan match {
+      case logicalRelation: LogicalRelation =>
+        logicalRelation.relation match {
+          case HadoopFsRelation(location: PartitioningAwareFileIndex, _, _, _, _, _) =>
+            Some(filesFromIndex(location))
+          case _ => None
+        }
       case _ => None
     }
   }
 
   /**
-   * Constructs the basePath for the given [[FileIndex]].
+   * Constructs the basePath for the given [[LogicalPlan]].
    *
-   * @param location Partitioned data location.
-   * @return Optional basePath to read the given partitioned location as explained below:
-   *         Some(Some(path)) => The given location is supported and partition is specified.
-   *         Some(None) => The given location is supported but partition is not specified.
-   *         None => The given location is not supported.
+   * @param logicalPlan Logical plan to extract the base path from.
+   * @return basePath to read the given partitioned location.
+   *         Some(Some(path)) => The location of the given plan is supported
+   *                             and partition is specified.
+   *         Some(None) => The location of the given plan is supported
+   *                       but is un-partitioned.
+   *         None => The location of the given plan is not supported.
    */
-  override def partitionBasePath(location: FileIndex): Option[Option[String]] = {
-    location match {
-      case p: PartitioningAwareFileIndex if p.partitionSpec.partitions.nonEmpty =>
-        // For example, we could have the following in PartitionSpec:
-        //   - partition columns = "col1", "col2"
-        //   - partitions: "/path/col1=1/col2=1", "/path/col1=1/col2=2", etc.
-        // , and going up the same number of directory levels as the number of partition columns
-        // will compute the base path. Note that PartitionSpec.partitions will always contain
-        // all the partitions in the path, so "partitions.head" is taken as an initial value.
-        val basePath = p.partitionSpec.partitionColumns
-          .foldLeft(p.partitionSpec.partitions.head.path)((path, _) => path.getParent)
-        Some(Some(basePath.toString))
-      case _: PartitioningAwareFileIndex => Some(None)
+  override def partitionBasePath(logicalPlan: LogicalPlan): Option[Option[String]] = {
+    logicalPlan match {
+      case LogicalRelation(HadoopFsRelation(location, _, _, _, _, _), _, _, _) =>
+        location match {
+          case p: PartitioningAwareFileIndex if p.partitionSpec.partitions.nonEmpty =>
+            // For example, we could have the following in PartitionSpec:
+            //   - partition columns = "col1", "col2"
+            //   - partitions: "/path/col1=1/col2=1", "/path/col1=1/col2=2", etc.
+            // , and going up the same number of directory levels as the number of partition columns
+            // will compute the base path. Note that PartitionSpec.partitions will always contain
+            // all the partitions in the path, so "partitions.head" is taken as an initial value.
+            val basePath = p.partitionSpec.partitionColumns
+                .foldLeft(p.partitionSpec.partitions.head.path)((path, _) => path.getParent)
+            Some(Some(basePath.toString))
+          case _: PartitioningAwareFileIndex => Some(None)
+          case _ => None
+        }
       case _ => None
     }
   }
@@ -256,38 +276,43 @@ class DefaultFileBasedSource(private val spark: SparkSession) extends FileBasedS
    * For [[DefaultFileBasedSource]], each file path should be in this format:
    *   `file:///path/to/file`
    *
-   * @param logicalRelation Logical relation to check the relation type.
+   * @param logicalPlan Logical plan to check the relation type.
    * @param fileIdTracker [[FileIdTracker]] to create the list of (file path, file id).
    * @return List of pairs of (file path, file id).
    */
-  override def lineagePairs(
-      logicalRelation: LogicalRelation,
+  override def lineagePairs(logicalPlan: LogicalPlan,
       fileIdTracker: FileIdTracker): Option[Seq[(String, Long)]] = {
-    logicalRelation.relation match {
-      case HadoopFsRelation(_: PartitioningAwareFileIndex, _, _, _, format, _)
-          if isSupportedFileFormat(format) =>
-        Some(fileIdTracker.getFileToIdMap.toSeq.map { kv =>
-          (kv._1._1.replace("file:/", "file:///"), kv._2)
-        })
-      case _ =>
-        None
+    logicalPlan match {
+      case logicalRelation: LogicalRelation =>
+        logicalRelation.relation match {
+          case HadoopFsRelation(_: PartitioningAwareFileIndex, _, _, _, format, _)
+            if isSupportedFileFormat(format) =>
+            Some(fileIdTracker.getFileToIdMap.toSeq.map { kv =>
+              (kv._1._1.replace("file:/", "file:///"), kv._2)
+            })
+          case _ => None
+        }
+      case _ => None
     }
   }
 
   /**
    * Returns whether the given relation has parquet source files or not.
    *
-   * @param logicalRelation Logical Relation to check the source file format.
+   * @param logicalPlan Logical plan to check the source file format.
    * @return True if source files in the given relation are parquet.
    */
-  override def hasParquetAsSourceFormat(logicalRelation: LogicalRelation): Option[Boolean] = {
-    logicalRelation.relation match {
-      case HadoopFsRelation(_: PartitioningAwareFileIndex, _, _, _, format, _)
-          if isSupportedFileFormat(format) =>
-        val fileFormatName = format.asInstanceOf[DataSourceRegister].shortName
-        Some(fileFormatName.equals("parquet"))
-      case _ =>
-        None
+  override def hasParquetAsSourceFormat(logicalPlan: LogicalPlan): Option[Boolean] = {
+    logicalPlan match {
+      case logicalRelation: LogicalRelation =>
+        logicalRelation.relation match {
+          case HadoopFsRelation(_: PartitioningAwareFileIndex, _, _, _, format, _)
+            if isSupportedFileFormat(format) =>
+            val fileFormatName = format.asInstanceOf[DataSourceRegister].shortName
+            Some(fileFormatName.equals("parquet"))
+          case _ => None
+        }
+      case _ => None
     }
   }
 

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/interfaces.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/interfaces.scala
@@ -18,7 +18,8 @@ package com.microsoft.hyperspace.index.sources
 
 import org.apache.hadoop.fs.FileStatus
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.execution.datasources.{FileIndex, LogicalRelation}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.FileIndex
 
 import com.microsoft.hyperspace.index.{FileIdTracker, Relation}
 
@@ -61,19 +62,19 @@ trait SourceProviderBuilder {
 trait FileBasedSourceProvider extends SourceProvider {
 
   /**
-   * Creates [[Relation]] for IndexLogEntry using the given [[LogicalRelation]].
+   * Creates [[Relation]] for IndexLogEntry using the given [[LogicalPlan]].
    *
    * This API is used when an index is created.
    *
    * If the given logical relation does not belong to this provider, None should be returned.
    *
-   * @param logicalRelation Logical relation to derive [[Relation]] from.
+   * @param logicalPlan Logical relation to derive [[Relation]] from.
    * @param fileIdTracker [[FileIdTracker]] to use when populating the data of [[Relation]].
    * @return [[Relation]] object if the given 'logicalRelation' can be processed by this provider.
    *         Otherwise, None.
    */
   def createRelation(
-      logicalRelation: LogicalRelation,
+      logicalPlan: LogicalPlan,
       fileIdTracker: FileIdTracker): Option[Relation]
 
   /**
@@ -105,19 +106,19 @@ trait FileBasedSourceProvider extends SourceProvider {
    *
    * If the given logical relation does not belong to this provider, None should be returned.
    *
-   * @param logicalRelation Logical relation to compute signature from.
+   * @param logicalPlan Logical relation to compute signature from.
    * @return Signature computed if the given 'logicalRelation' can be processed by this provider.
    *         Otherwise, None.
    */
-  def signature(logicalRelation: LogicalRelation): Option[String]
+  def signature(logicalPlan: LogicalPlan): Option[String]
 
   /**
-   * Retrieves all input files from the given [[LogicalRelation]].
+   * Retrieves all input files from the given [[LogicalPlan]].
    *
-   * @param logicalRelation Logical relation to retrieve input files from.
+   * @param logicalPlan Logical relation to retrieve input files from.
    * @return List of [[FileStatus]] for the given relation.
    */
-  def allFiles(logicalRelation: LogicalRelation): Option[Seq[FileStatus]]
+  def allFiles(logicalPlan: LogicalPlan): Option[Seq[FileStatus]]
 
   /**
    * Constructs the basePath for the given [[FileIndex]].
@@ -135,20 +136,20 @@ trait FileBasedSourceProvider extends SourceProvider {
    *
    * File paths should be the same format with "input_file_name()" of the given relation type.
    *
-   * @param logicalRelation Logical relation to check the relation type.
+   * @param logicalPlan Logical relation to check the relation type.
    * @param fileIdTracker [[FileIdTracker]] to create the list of (file path, file id).
    * @return List of pairs of (file path, file id).
    */
   def lineagePairs(
-      logicalRelation: LogicalRelation,
+      logicalPlan: LogicalPlan,
       fileIdTracker: FileIdTracker): Option[Seq[(String, Long)]]
 
   /**
    * Returns whether the given relation has parquet source files or not.
    *
-   * @param logicalRelation Logical Relation to check the source file format.
+   * @param logicalPlan Logical Relation to check the source file format.
    * @return True if source files in the given relation are parquet.
    */
-  def hasParquetAsSourceFormat(logicalRelation: LogicalRelation): Option[Boolean]
+  def hasParquetAsSourceFormat(logicalPlan: LogicalPlan): Option[Boolean]
 
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/interfaces.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/interfaces.scala
@@ -121,15 +121,17 @@ trait FileBasedSourceProvider extends SourceProvider {
   def allFiles(logicalPlan: LogicalPlan): Option[Seq[FileStatus]]
 
   /**
-   * Constructs the basePath for the given [[FileIndex]].
+   * Constructs the basePath for the given [[LogicalPlan]].
    *
-   * @param location Partitioned data location.
-   * @return Optional basePath to read the given partitioned location as explained below:
-   *         Some(Some(path)) => The given location is supported and partition is specified.
-   *         Some(None) => The given location is supported but partition is not specified.
-   *         None => The given location is not supported.
+   * @param logicalPlan Logical plan to extract the base path from.
+   * @return basePath to read the given partitioned location.
+   *         Some(Some(path)) => The location of the given plan is supported
+   *                             and partition is specified.
+   *         Some(None) => The location of the given plan is supported
+   *                       but is un-partitioned.
+   *         None => The location of the given plan is not supported.
    */
-  def partitionBasePath(location: FileIndex): Option[Option[String]]
+  def partitionBasePath(logicalPlan: LogicalPlan): Option[Option[String]]
 
   /**
    * Returns list of pairs of (file path, file id) to build lineage column.

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/interfaces.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/interfaces.scala
@@ -19,7 +19,6 @@ package com.microsoft.hyperspace.index.sources
 import org.apache.hadoop.fs.FileStatus
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.execution.datasources.FileIndex
 
 import com.microsoft.hyperspace.index.{FileIdTracker, Relation}
 
@@ -138,7 +137,7 @@ trait FileBasedSourceProvider extends SourceProvider {
    *
    * File paths should be the same format with "input_file_name()" of the given relation type.
    *
-   * @param logicalPlan Logical relation to check the relation type.
+   * @param logicalPlan Logical plan to check the relation type.
    * @param fileIdTracker [[FileIdTracker]] to create the list of (file path, file id).
    * @return List of pairs of (file path, file id).
    */
@@ -149,7 +148,7 @@ trait FileBasedSourceProvider extends SourceProvider {
   /**
    * Returns whether the given relation has parquet source files or not.
    *
-   * @param logicalPlan Logical Relation to check the source file format.
+   * @param logicalPlan Logical plan to check the source file format.
    * @return True if source files in the given relation are parquet.
    */
   def hasParquetAsSourceFormat(logicalPlan: LogicalPlan): Option[Boolean]

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/interfaces.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/interfaces.scala
@@ -67,7 +67,7 @@ trait FileBasedSourceProvider extends SourceProvider {
    *
    * If the given logical relation does not belong to this provider, None should be returned.
    *
-   * @param logicalPlan Logical relation to derive [[Relation]] from.
+   * @param logicalPlan Logical plan to derive [[Relation]] from.
    * @param fileIdTracker [[FileIdTracker]] to use when populating the data of [[Relation]].
    * @return [[Relation]] object if the given 'logicalRelation' can be processed by this provider.
    *         Otherwise, None.
@@ -105,7 +105,7 @@ trait FileBasedSourceProvider extends SourceProvider {
    *
    * If the given logical relation does not belong to this provider, None should be returned.
    *
-   * @param logicalPlan Logical relation to compute signature from.
+   * @param logicalPlan Logical plan to compute signature from.
    * @return Signature computed if the given 'logicalRelation' can be processed by this provider.
    *         Otherwise, None.
    */
@@ -114,7 +114,7 @@ trait FileBasedSourceProvider extends SourceProvider {
   /**
    * Retrieves all input files from the given [[LogicalPlan]].
    *
-   * @param logicalPlan Logical relation to retrieve input files from.
+   * @param logicalPlan Logical plan to retrieve input files from.
    * @return List of [[FileStatus]] for the given relation.
    */
   def allFiles(logicalPlan: LogicalPlan): Option[Seq[FileStatus]]

--- a/src/main/scala/com/microsoft/hyperspace/util/LogicalPlanUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/util/LogicalPlanUtils.scala
@@ -17,7 +17,7 @@
 package com.microsoft.hyperspace.util
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
 /**
@@ -26,35 +26,15 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 object LogicalPlanUtils {
 
   /**
-   * Check if a logical plan is a LogicalRelation.
-   * @param logicalPlan logical plan to check.
-   * @return true if a logical plan is a LogicalRelation or false.
-   */
-  def isLogicalRelation(logicalPlan: LogicalPlan): Boolean = {
-    logicalPlan match {
-      case _: LogicalRelation => true
-      case _ => false
-    }
-  }
-
-  /**
-   * Check if a logical plan is a DataSourceV2Relation.
+   * Check if a logical plan is supported.
    * @param logicalPlan Logical plan to check.
-   * @return true if a logical plan is a DataSourceV2Relation or false.
+   * @return true if a logical plan is supported or false.
    */
-  def isDataSourceV2Relation(logicalPlan: LogicalPlan): Boolean = {
+  def hasSupportedLogicalRelation(logicalPlan: LogicalPlan): Boolean = {
     logicalPlan match {
+      case LogicalRelation(_: HadoopFsRelation, _, _, _) => true
       case _: DataSourceV2Relation => true
       case _ => false
     }
   }
-
-  /**
-   * Check if a logical plan is supported.
-   * @param logicalPlan logical plan to check.
-   * @return true if a logical plan is supported or false.
-   */
-  def isLogicalPlanSupported(logicalPlan: LogicalPlan): Boolean =
-    isLogicalRelation(logicalPlan) || isDataSourceV2Relation(logicalPlan)
-
 }

--- a/src/main/scala/com/microsoft/hyperspace/util/LogicalPlanUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/util/LogicalPlanUtils.scala
@@ -26,11 +26,11 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 object LogicalPlanUtils {
 
   /**
-   * Check if a logical plan is supported.
+   * Check if a logical plan is a supported relation.
    * @param logicalPlan Logical plan to check.
    * @return true if a logical plan is supported or false.
    */
-  def hasSupportedLogicalRelation(logicalPlan: LogicalPlan): Boolean = {
+  def isSupportedRelation(logicalPlan: LogicalPlan): Boolean = {
     logicalPlan match {
       case LogicalRelation(_: HadoopFsRelation, _, _, _) => true
       case _: DataSourceV2Relation => true

--- a/src/main/scala/com/microsoft/hyperspace/util/LogicalPlanUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/util/LogicalPlanUtils.scala
@@ -18,6 +18,7 @@ package com.microsoft.hyperspace.util
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
 /**
  * Utility functions for logical plan.
@@ -35,4 +36,25 @@ object LogicalPlanUtils {
       case _ => false
     }
   }
+
+  /**
+   * Check if a logical plan is a DataSourceV2Relation.
+   * @param logicalPlan Logical plan to check.
+   * @return true if a logical plan is a DataSourceV2Relation or false.
+   */
+  def isDataSourceV2Relation(logicalPlan: LogicalPlan): Boolean = {
+    logicalPlan match {
+      case _: DataSourceV2Relation => true
+      case _ => false
+    }
+  }
+
+  /**
+   * Check if a logical plan is supported.
+   * @param logicalPlan logical plan to check.
+   * @return true if a logical plan is supported or false.
+   */
+  def isLogicalPlanSupported(logicalPlan: LogicalPlan): Boolean =
+    isLogicalRelation(logicalPlan) || isDataSourceV2Relation(logicalPlan)
+
 }


### PR DESCRIPTION
### What is the context for this pull request?

 - **Tracking Issue**: #306
 - **Proposal**: #318
 - **Dependencies**: N/A
 - Fixes: #306
 - Fixes: #318  

### What changes were proposed in this pull request?

This PR adds support for DataSourceV2.

The following changes are in this PR and each of them are separate commits:

- Use `LogicaPlan` instead of `LogicalRelation`. This gives us the possibility to add support for other kinds of relations like Spark datas source version 2.
- Add support for `DataSourceV2`.

### Does this PR introduce _any_ user-facing change?

The source interfaces has changed. Now instead of using `LogicalRelation` as parameter type it now uses `LogicalPlan`. There has been added support for `DataSourceV2` sources.

Detailed information can be found in the #318 proposal.

### How was this patch tested?

1. All already present tests are passing
2. Locally & Databricks Runtime tests based on the [Hyperspace usage API in Apache Spark](https://microsoft.github.io/hyperspace/#hyperspace-usage-api-in-apache-spark).
