### PR TITLE
Use Spark shared Hadoop configuration

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -52,7 +52,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
       df: DataFrame,
       indexConfig: IndexConfig,
       path: Path): IndexLogEntry = {
-    val absolutePath = PathUtils.makeAbsolute(path)
+    val absolutePath = PathUtils.makeAbsolute(path, spark.sessionState.newHadoopConf())
     val numBuckets = numBucketsForIndex(spark)
 
     val signatureProvider = LogicalPlanSignatureProvider.create()

--- a/src/main/scala/com/microsoft/hyperspace/actions/OptimizeAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/OptimizeAction.scala
@@ -135,11 +135,13 @@ class OptimizeAction(
   override def logEntry: LogEntry = {
     // Update `previousIndexLogEntry` to keep `filesToIngore` files and append to it
     // the list of newly created index files.
-    val absolutePath = PathUtils.makeAbsolute(indexDataPath)
-    val newContent = Content.fromDirectory(absolutePath, fileIdTracker)
+    val hadoopConf = spark.sessionState.newHadoopConf()
+    val absolutePath = PathUtils.makeAbsolute(indexDataPath.toString, hadoopConf)
+    val newContent =
+      Content.fromDirectory(absolutePath, fileIdTracker, hadoopConfiguration = hadoopConf)
     if (filesToIgnore.nonEmpty) {
       val filesToIgnoreDirectory = {
-        val fs = new Path(filesToIgnore.head.name).getFileSystem(new Configuration)
+        val fs = new Path(filesToIgnore.head.name).getFileSystem(hadoopConf)
         val filesToIgnoreStatuses =
           filesToIgnore.map(fileInfo => fs.getFileStatus(new Path(fileInfo.name)))
 

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexDataManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexDataManager.scala
@@ -43,9 +43,10 @@ trait IndexDataManager {
   def delete(id: Int): Unit
 }
 
-class IndexDataManagerImpl(indexPath: Path) extends IndexDataManager {
+class IndexDataManagerImpl(indexPath: Path, configuration: Configuration)
+    extends IndexDataManager {
   // TODO: Investigate whether FileContext should be used instead of FileSystem for atomic renames.
-  private lazy val fs: FileSystem = indexPath.getFileSystem(new Configuration)
+  private lazy val fs: FileSystem = indexPath.getFileSystem(configuration)
 
   /**
    * This method relies on the naming convention that directory name will be similar to hive

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -88,8 +88,10 @@ object Content {
       path: Path,
       fileIdTracker: FileIdTracker,
       pathFilter: PathFilter = PathUtils.DataPathFilter,
+      hadoopConfiguration: Configuration = new Configuration,
       throwIfNotExists: Boolean = false): Content =
-    Content(Directory.fromDirectory(path, fileIdTracker, pathFilter, throwIfNotExists))
+    Content(Directory.fromDirectory(path, fileIdTracker, pathFilter, hadoopConfiguration,
+      throwIfNotExists))
 
   /**
    * Create a Content object from a specified list of leaf files. Any files not listed here will
@@ -192,8 +194,9 @@ object Directory {
       path: Path,
       fileIdTracker: FileIdTracker,
       pathFilter: PathFilter = PathUtils.DataPathFilter,
+      hadoopConfiguration: Configuration = new Configuration,
       throwIfNotExists: Boolean = false): Directory = {
-    val fs = path.getFileSystem(new Configuration)
+    val fs = path.getFileSystem(hadoopConfiguration)
     val leafFiles = listLeafFiles(path, pathFilter, throwIfNotExists, fs)
 
     if (leafFiles.nonEmpty) {

--- a/src/main/scala/com/microsoft/hyperspace/index/PathResolver.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/PathResolver.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.internal.SQLConf
  *
  * @param conf SQL Configuration
  */
-private[hyperspace] class PathResolver(conf: SQLConf) {
+private[hyperspace] class PathResolver(conf: SQLConf, hadoopConf: Configuration) {
 
   /**
    * Get path for the given index name. It enumerates the file system to resolve
@@ -38,7 +38,7 @@ private[hyperspace] class PathResolver(conf: SQLConf) {
    */
   def getIndexPath(name: String): Path = {
     val root = systemPath
-    val fs = root.getFileSystem(new Configuration)
+    val fs = root.getFileSystem(hadoopConf)
     if (fs.exists(root)) {
       // Note that fs.exists() is case-sensitive in some platforms and case-insensitive
       // in others, thus the check is manually done to make the comparison case-insensitive.
@@ -70,7 +70,7 @@ private[hyperspace] class PathResolver(conf: SQLConf) {
 }
 
 object PathResolver {
-  def apply(conf: SQLConf): PathResolver = {
-    new PathResolver(conf)
+  def apply(conf: SQLConf, hadoopConf: Configuration): PathResolver = {
+    new PathResolver(conf, hadoopConf)
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/factories.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/factories.scala
@@ -20,31 +20,34 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 trait IndexLogManagerFactory {
-  def create(indexPath: Path): IndexLogManager
+  def create(indexPath: Path, configuration: Configuration): IndexLogManager
 }
 
 object IndexLogManagerFactoryImpl extends IndexLogManagerFactory {
-  override def create(indexPath: Path): IndexLogManager = {
-    new IndexLogManagerImpl(indexPath)
+  override def create(
+      indexPath: Path,
+      configuration: Configuration = new Configuration): IndexLogManager = {
+    new IndexLogManagerImpl(indexPath, configuration)
   }
 }
 
 trait IndexDataManagerFactory {
-  def create(indexPath: Path): IndexDataManager
+  def create(indexPath: Path, configuration: Configuration): IndexDataManager
 }
 
 object IndexDataManagerFactoryImpl extends IndexDataManagerFactory {
-  override def create(indexPath: Path): IndexDataManager = {
-    new IndexDataManagerImpl(indexPath)
+  override def create(
+      indexPath: Path,
+      configuration: Configuration = new Configuration): IndexDataManager = {
+    new IndexDataManagerImpl(indexPath, configuration)
   }
 }
 
 trait FileSystemFactory {
-  def create(path: Path): FileSystem
+  def create(path: Path, configuration: Configuration): FileSystem
 }
 
 object FileSystemFactoryImpl extends FileSystemFactory {
-  private val configuration = new Configuration
-
-  override def create(path: Path): FileSystem = path.getFileSystem(configuration)
+  override def create(path: Path, configuration: Configuration = new Configuration): FileSystem =
+    path.getFileSystem(configuration)
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/default/DefaultFileBasedSource.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/default/DefaultFileBasedSource.scala
@@ -18,7 +18,6 @@ package com.microsoft.hyperspace.index.sources.default
 
 import java.util.Locale
 
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -94,7 +93,8 @@ class DefaultFileBasedSource(private val spark: SparkSession) extends FileBasedS
             // This logic is picked from the globbing logic at:
             // https://github.com/apache/spark/blob/v2.4.4/sql/core/src/main/scala/org/apache/
             // spark/sql/execution/datasources/DataSource.scala#L540
-            val fs = filesFromIndex(location).head.getPath.getFileSystem(new Configuration)
+            val fs = filesFromIndex(location).head.getPath
+              .getFileSystem(spark.sessionState.newHadoopConf())
             val globPaths = pattern
               .split(",")
               .map(_.trim)

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/delta/DeltaLakeFileBasedSource.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/delta/DeltaLakeFileBasedSource.scala
@@ -84,7 +84,10 @@ class DeltaLakeFileBasedSource(private val spark: SparkSession) extends FileBase
           ("versionAsOf" -> location.tableVersion.toString) ++ basePathOpt
         Some(
           Relation(
-            Seq(PathUtils.makeAbsolute(location.path).toString),
+            Seq(
+              PathUtils
+                .makeAbsolute(location.path.toString, spark.sessionState.newHadoopConf())
+                .toString),
             Hdfs(sourceDataProperties),
             dataSchema.json,
             fileFormatName,

--- a/src/main/scala/com/microsoft/hyperspace/util/FileUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/util/FileUtils.scala
@@ -58,8 +58,10 @@ object FileUtils {
    * @param directoryPath the directory path.
    * @return the size in byte of the directory.
    */
-  def getDirectorySize(directoryPath: Path): Long = {
-    val fileSystem = directoryPath.getFileSystem(new Configuration)
+  def getDirectorySize(
+      directoryPath: Path,
+      hadoopConfiguration: Configuration = new Configuration): Long = {
+    val fileSystem = directoryPath.getFileSystem(hadoopConfiguration)
     fileSystem.getContentSummary(directoryPath).getLength
   }
 
@@ -68,8 +70,10 @@ object FileUtils {
    *
    * @param dirPath the directory path.
    */
-  def createDirectory(dirPath: Path): Unit = {
-    val fileSystem = dirPath.getFileSystem(new Configuration)
+  def createDirectory(
+      dirPath: Path,
+      hadoopConfiguration: Configuration = new Configuration): Unit = {
+    val fileSystem = dirPath.getFileSystem(hadoopConfiguration)
     if (!fileSystem.exists(dirPath)) {
       fileSystem.mkdirs(dirPath)
     }
@@ -81,8 +85,11 @@ object FileUtils {
    * @param dirPath the directory path to be deleted.
    * @param isRecursive option to delete recursively.
    */
-  def delete(dirPath: Path, isRecursive: Boolean = true): Unit = {
-    dirPath.getFileSystem(new Configuration).delete(dirPath, isRecursive)
+  def delete(
+      dirPath: Path,
+      hadoopConfiguration: Configuration = new Configuration,
+      isRecursive: Boolean = true): Unit = {
+    dirPath.getFileSystem(hadoopConfiguration).delete(dirPath, isRecursive)
   }
 
   /**

--- a/src/main/scala/com/microsoft/hyperspace/util/PathUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/util/PathUtils.scala
@@ -20,10 +20,11 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path, PathFilter}
 
 object PathUtils {
-  def makeAbsolute(path: String): Path = makeAbsolute(new Path(path))
+  def makeAbsolute(path: String, hadoopConfiguration: Configuration = new Configuration): Path =
+    makeAbsolute(new Path(path), hadoopConfiguration)
 
-  def makeAbsolute(path: Path): Path = {
-    val fs = path.getFileSystem(new Configuration)
+  def makeAbsolute(path: Path, hadoopConfiguration: Configuration): Path = {
+    val fs = path.getFileSystem(hadoopConfiguration)
     fs.makeQualified(path)
   }
 

--- a/src/test/scala/com/microsoft/hyperspace/index/CreateIndexTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/CreateIndexTest.scala
@@ -44,7 +44,7 @@ class CreateIndexTest extends HyperspaceSuite with SQLHelper {
     super.beforeAll()
 
     hyperspace = new Hyperspace(spark)
-    FileUtils.delete(new Path(testDir), true)
+    FileUtils.delete(new Path(testDir), isRecursive = true)
 
     val dataColumns = Seq("Date", "RGUID", "Query", "imprs", "clicks")
     // save test data non-partitioned.
@@ -57,7 +57,7 @@ class CreateIndexTest extends HyperspaceSuite with SQLHelper {
   }
 
   override def afterAll(): Unit = {
-    FileUtils.delete(new Path(testDir), true)
+    FileUtils.delete(new Path(testDir), isRecursive = true)
     super.afterAll()
   }
 

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
@@ -16,6 +16,7 @@
 
 package com.microsoft.hyperspace.index
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.apache.spark.SparkFunSuite
 import org.mockito.ArgumentMatchers.any
@@ -28,7 +29,7 @@ import com.microsoft.hyperspace.index.IndexConstants.{REFRESH_MODE_FULL, REFRESH
 class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
   private val indexSystemPath = "src/test/resources/indexLocation"
   private val testLogManagerFactory: IndexLogManagerFactory = new IndexLogManagerFactory {
-    override def create(indexPath: Path): IndexLogManager =
+    override def create(indexPath: Path, hadoopConfiguration: Configuration): IndexLogManager =
       new IndexLogManager {
         override def getLog(id: Int): Option[LogEntry] = Some(testLogEntry)
         override def getLatestId(): Option[Int] = Some(0)
@@ -70,7 +71,7 @@ class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
   override def beforeAll(): Unit = {
     super.beforeAll()
     spark.conf.set(IndexConstants.INDEX_SYSTEM_PATH, indexSystemPath)
-    when(mockFileSystemFactory.create(any[Path])).thenReturn(mockFileSystem)
+    when(mockFileSystemFactory.create(any[Path], any[Configuration])).thenReturn(mockFileSystem)
 
     indexCollectionManager = new IndexCollectionManager(
       spark,

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogManagerImplTest.scala
@@ -80,11 +80,11 @@ class IndexLogManagerImplTest
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    FileUtils.delete(new Path(testRoot), true)
+    FileUtils.delete(new Path(testRoot), isRecursive = true)
   }
 
   override def afterAll(): Unit = {
-    FileUtils.delete(new Path(testRoot), true)
+    FileUtils.delete(new Path(testRoot), isRecursive = true)
     super.afterAll()
   }
 

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTest.scala
@@ -50,7 +50,7 @@ class IndexManagerTest extends HyperspaceSuite with SQLHelper {
   }
 
   after {
-    FileUtils.delete(systemPath, true)
+    FileUtils.delete(systemPath, isRecursive = true)
   }
 
   override def afterAll(): Unit = {
@@ -795,8 +795,8 @@ class IndexManagerTest extends HyperspaceSuite with SQLHelper {
               Map())),
           Content.fromDirectory(
             PathUtils.makeAbsolute(
-              new Path(s"$systemPath/${indexConfig.indexName}" +
-                s"/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0")),
+              s"$systemPath/${indexConfig.indexName}" +
+                s"/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0"),
             fileIdTracker),
           Source(SparkPlan(sourcePlanProperties)),
           Map())

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexStatisticsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexStatisticsTest.scala
@@ -36,14 +36,14 @@ class IndexStatisticsTest extends QueryTest with HyperspaceSuite {
     super.beforeAll()
 
     hyperspace = new Hyperspace(spark)
-    FileUtils.delete(new Path(dataPath), true)
+    FileUtils.delete(new Path(dataPath), isRecursive = true)
 
     SampleData.save(spark, dataPath, dataColumns)
     dataDF = spark.read.parquet(dataPath)
   }
 
   override def afterAll(): Unit = {
-    FileUtils.delete(new Path(dataPath), true)
+    FileUtils.delete(new Path(dataPath), isRecursive = true)
     super.afterAll()
   }
 


### PR DESCRIPTION
### What is the context for this pull request?

 - **Tracking Issue**: #322 
 - **Parent Issue**: N/A
 - **Dependencies**: N/A
 - Fixes: #322 

### What changes were proposed in this pull request?

Use `spark.sessionState.newHadoopConf()` instead of `new Configuration()` in the sections where there is interaction with the file system.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

1. All already present tests are passing
2. Locally & Databricks Runtime 5.5 LTS & 6.4 tests with ADL storage