### PR TITLE
Add support for index schema change during refresh

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/Hyperspace.scala
+++ b/src/main/scala/com/microsoft/hyperspace/Hyperspace.scala
@@ -19,7 +19,7 @@ package com.microsoft.hyperspace
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 import com.microsoft.hyperspace.index._
-import com.microsoft.hyperspace.index.IndexConstants.{OPTIMIZE_MODE_QUICK, REFRESH_MODE_FULL}
+import com.microsoft.hyperspace.index.IndexConstants.{NO_INDEX_SCHEMA_CHANGE, OPTIMIZE_MODE_QUICK, REFRESH_MODE_FULL}
 import com.microsoft.hyperspace.index.plananalysis.PlanAnalyzer
 import com.microsoft.hyperspace.index.sources.FileBasedSourceProviderManager
 
@@ -87,7 +87,14 @@ class Hyperspace(spark: SparkSession) {
    * @param mode Refresh mode. Currently supported modes are `incremental` and `full`.
    */
   def refreshIndex(indexName: String, mode: String): Unit = {
-    indexManager.refresh(indexName, mode)
+    refreshIndex(indexName, mode, NO_INDEX_SCHEMA_CHANGE)
+  }
+
+  def refreshIndex(
+      indexName: String,
+      mode: String,
+      indexSchemaChange: IndexSchemaChange): Unit = {
+    indexManager.refresh(indexName, mode, indexSchemaChange)
   }
 
   /**

--- a/src/main/scala/com/microsoft/hyperspace/Hyperspace.scala
+++ b/src/main/scala/com/microsoft/hyperspace/Hyperspace.scala
@@ -19,7 +19,7 @@ package com.microsoft.hyperspace
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 import com.microsoft.hyperspace.index._
-import com.microsoft.hyperspace.index.IndexConstants.{NO_INDEX_SCHEMA_CHANGE, OPTIMIZE_MODE_QUICK, REFRESH_MODE_FULL}
+import com.microsoft.hyperspace.index.IndexConstants.{OPTIMIZE_MODE_QUICK, REFRESH_MODE_FULL}
 import com.microsoft.hyperspace.index.plananalysis.PlanAnalyzer
 import com.microsoft.hyperspace.index.sources.FileBasedSourceProviderManager
 
@@ -87,7 +87,7 @@ class Hyperspace(spark: SparkSession) {
    * @param mode Refresh mode. Currently supported modes are `incremental` and `full`.
    */
   def refreshIndex(indexName: String, mode: String): Unit = {
-    refreshIndex(indexName, mode, NO_INDEX_SCHEMA_CHANGE)
+    refreshIndex(indexName, mode, IndexSchemaChange.NO_CHANGE)
   }
 
   def refreshIndex(

--- a/src/main/scala/com/microsoft/hyperspace/actions/IndexSchemaChange.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/IndexSchemaChange.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.actions
+
+import java.util.Locale
+
+import org.apache.spark.sql.types.StructType
+
+case class IndexSchemaChange(includeColumns: StructType, excludeColumns: Seq[String]) {
+  val lowerCaseExcludeColumns = excludeColumns.map(_.toLowerCase(Locale.ROOT))
+  val lowerCaseExcludeColumnsSet = excludeColumns.toSet
+
+  if (lowerCaseExcludeColumnsSet.size < lowerCaseExcludeColumns.size) {
+    throw new IllegalArgumentException("Duplicate exclude column names are not allowed.")
+  }
+
+  if (includeColumns.fieldNames
+        .map(_.toLowerCase(Locale.ROOT))
+        .exists(lowerCaseExcludeColumnsSet.contains)) {
+    throw new IllegalArgumentException(
+      "Duplicate column names in include and exclude columns are not allowed.")
+  }
+}

--- a/src/main/scala/com/microsoft/hyperspace/actions/OptimizeAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/OptimizeAction.scala
@@ -105,6 +105,10 @@ class OptimizeAction(
       throw HyperspaceException(s"Unsupported optimize mode '$mode' found.")
     }
 
+    if (previousIndexLogEntry.hasSchemaChange) {
+      throw HyperspaceException("Optimize is not supported on an index with schema changes.")
+    }
+
     if (filesToOptimize.isEmpty) {
       throw NoChangesException(
         "Optimize aborted as no optimizable index files smaller than " +

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
@@ -33,8 +33,9 @@ import com.microsoft.hyperspace.telemetry.{AppInfo, HyperspaceEvent, RefreshActi
 class RefreshAction(
     spark: SparkSession,
     logManager: IndexLogManager,
-    dataManager: IndexDataManager)
-    extends RefreshActionBase(spark, logManager, dataManager) {
+    dataManager: IndexDataManager,
+    indexSchemaChange: IndexSchemaChange = IndexConstants.NO_INDEX_SCHEMA_CHANGE)
+    extends RefreshActionBase(spark, logManager, dataManager, indexSchemaChange) {
 
   override def logEntry: LogEntry = getIndexLogEntry(spark, df, indexConfig, indexDataPath)
 

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshAction.scala
@@ -34,7 +34,7 @@ class RefreshAction(
     spark: SparkSession,
     logManager: IndexLogManager,
     dataManager: IndexDataManager,
-    indexSchemaChange: IndexSchemaChange = IndexConstants.NO_INDEX_SCHEMA_CHANGE)
+    indexSchemaChange: IndexSchemaChange = IndexSchemaChange.NO_CHANGE)
     extends RefreshActionBase(spark, logManager, dataManager, indexSchemaChange) {
 
   override def logEntry: LogEntry = getIndexLogEntry(spark, df, indexConfig, indexDataPath)

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
@@ -37,7 +37,8 @@ import com.microsoft.hyperspace.index._
 private[actions] abstract class RefreshActionBase(
     spark: SparkSession,
     final override protected val logManager: IndexLogManager,
-    dataManager: IndexDataManager)
+    dataManager: IndexDataManager,
+    indexSchemaChange: IndexSchemaChange)
     extends CreateActionBase(dataManager)
     with Action {
   private lazy val previousLogEntry: LogEntry = {

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshIncrementalAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshIncrementalAction.scala
@@ -125,7 +125,12 @@ class RefreshIncrementalAction(
    * @return Refreshed index log entry.
    */
   override def logEntry: LogEntry = {
-    val entry = getIndexLogEntry(spark, df, indexConfig, indexDataPath)
+    val entry = if (indexSchemaChange.equals(IndexConstants.NO_INDEX_SCHEMA_CHANGE)) {
+      getIndexLogEntry(spark, df, indexConfig, indexDataPath)
+    } else {
+      getIndexLogEntry(spark, df, indexConfig, indexDataPath).copyWithDerivedDatasetProperties(
+        Map(IndexConstants.INDEX_SCHEMA_CHANGED -> "true"))
+    }
 
     // If there is no deleted files, there are index data files only for appended data in this
     // version and we need to add the index data files of previous index version.

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshIncrementalAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshIncrementalAction.scala
@@ -18,6 +18,7 @@ package com.microsoft.hyperspace.actions
 
 import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{LongType, StructField}
 
 import com.microsoft.hyperspace.HyperspaceException
 import com.microsoft.hyperspace.index._
@@ -72,6 +73,7 @@ class RefreshIncrementalAction(
       // deleted source data files as those entries are no longer valid.
       val refreshDF =
         spark.read
+          .schema(indexSchema.add(StructField(IndexConstants.DATA_FILE_NAME_ID, LongType)))
           .parquet(previousIndexLogEntry.content.files.map(_.toString): _*)
           .filter(!col(IndexConstants.DATA_FILE_NAME_ID).isin(deletedFiles.map(_.id): _*))
 

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshIncrementalAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshIncrementalAction.scala
@@ -47,8 +47,9 @@ import com.microsoft.hyperspace.telemetry.{AppInfo, HyperspaceEvent, RefreshIncr
 class RefreshIncrementalAction(
     spark: SparkSession,
     logManager: IndexLogManager,
-    dataManager: IndexDataManager)
-    extends RefreshActionBase(spark, logManager, dataManager) {
+    dataManager: IndexDataManager,
+    indexSchemaChange: IndexSchemaChange = IndexConstants.NO_INDEX_SCHEMA_CHANGE)
+    extends RefreshActionBase(spark, logManager, dataManager, indexSchemaChange) {
 
   final override def op(): Unit = {
     logInfo(

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshQuickAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshQuickAction.scala
@@ -33,7 +33,11 @@ class RefreshQuickAction(
     spark: SparkSession,
     logManager: IndexLogManager,
     dataManager: IndexDataManager)
-    extends RefreshActionBase(spark, logManager, dataManager) {
+    extends RefreshActionBase(
+      spark,
+      logManager,
+      dataManager,
+      IndexConstants.NO_INDEX_SCHEMA_CHANGE) {
   final override def op(): Unit = {
     logInfo(
       s"Refresh index is updating metadata only with ${deletedFiles.size} of deleted " +

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshQuickAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshQuickAction.scala
@@ -37,7 +37,7 @@ class RefreshQuickAction(
       spark,
       logManager,
       dataManager,
-      IndexConstants.NO_INDEX_SCHEMA_CHANGE) {
+      IndexSchemaChange.NO_CHANGE) {
   final override def op(): Unit = {
     logInfo(
       s"Refresh index is updating metadata only with ${deletedFiles.size} of deleted " +

--- a/src/main/scala/com/microsoft/hyperspace/index/CachingIndexCollectionManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/CachingIndexCollectionManager.scala
@@ -92,9 +92,12 @@ class CachingIndexCollectionManager(
     super.vacuum(indexName)
   }
 
-  override def refresh(indexName: String, mode: String): Unit = {
+  override def refresh(
+      indexName: String,
+      mode: String,
+      indexSchemaChange: IndexSchemaChange): Unit = {
     clearCache()
-    super.refresh(indexName, mode)
+    super.refresh(indexName, mode, indexSchemaChange)
   }
 
   override def optimize(indexName: String, mode: String): Unit = {
@@ -117,6 +120,7 @@ object CachingIndexCollectionManager {
  * An implementation of cache to store indexes that uses entry's last reset time to check
  * validity of cache entry.
  * Cache entry is stale if it has been in the cache for some (configurable) time.
+ *
  * @param spark Spark session
  */
 class CreationTimeBasedIndexCache(spark: SparkSession) extends Cache[Seq[IndexLogEntry]] {
@@ -149,6 +153,7 @@ class CreationTimeBasedIndexCache(spark: SparkSession) extends Cache[Seq[IndexLo
 
   /**
    * Reset cache content with new entry and reset cache time
+   *
    * @param entry new entry to cache
    */
   override def set(entry: Seq[IndexLogEntry]): Unit = {

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.internal.SQLConf
 import com.microsoft.hyperspace.HyperspaceException
 import com.microsoft.hyperspace.actions._
 import com.microsoft.hyperspace.actions.Constants.States.DOESNOTEXIST
-import com.microsoft.hyperspace.index.IndexConstants.{NO_INDEX_SCHEMA_CHANGE, REFRESH_MODE_FULL, REFRESH_MODE_INCREMENTAL, REFRESH_MODE_QUICK}
+import com.microsoft.hyperspace.index.IndexConstants.{REFRESH_MODE_FULL, REFRESH_MODE_INCREMENTAL, REFRESH_MODE_QUICK}
 
 class IndexCollectionManager(
     spark: SparkSession,
@@ -76,7 +76,7 @@ class IndexCollectionManager(
       } else if (mode.equalsIgnoreCase(REFRESH_MODE_FULL)) {
         new RefreshAction(spark, logManager, dataManager, indexSchemaChange).run()
       } else if (mode.equalsIgnoreCase(REFRESH_MODE_QUICK)) {
-        if (!indexSchemaChange.equals(NO_INDEX_SCHEMA_CHANGE)) {
+        if (!indexSchemaChange.equals(IndexSchemaChange.NO_CHANGE)) {
           throw HyperspaceException("Index schema change is no supported refresh quick mode.")
         }
         new RefreshQuickAction(spark, logManager, dataManager).run()

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexCollectionManager.scala
@@ -64,7 +64,10 @@ class IndexCollectionManager(
     }
   }
 
-  override def refresh(indexName: String, mode: String): Unit = {
+  override def refresh(
+      indexName: String,
+      mode: String,
+      indexSchemaChange: IndexSchemaChange): Unit = {
     withLogManager(indexName) { logManager =>
       val indexPath = PathResolver(spark.sessionState.conf).getIndexPath(indexName)
       val dataManager = indexDataManagerFactory.create(indexPath)

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -17,6 +17,7 @@
 package com.microsoft.hyperspace.index
 
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
 
 object IndexConstants {
   val INDEXES_DIR = "indexes"
@@ -111,4 +112,6 @@ object IndexConstants {
   // To provide multiple paths in the globbing pattern, separate them with commas, e.g.
   // "/temp/1/*, /temp/2/*"
   val GLOBBING_PATTERN_KEY = "spark.hyperspace.source.globbingPattern"
+
+  val NO_INDEX_SCHEMA_CHANGE = IndexSchemaChange(new StructType(), Seq[String]())
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -114,4 +114,5 @@ object IndexConstants {
   val GLOBBING_PATTERN_KEY = "spark.hyperspace.source.globbingPattern"
 
   val NO_INDEX_SCHEMA_CHANGE = IndexSchemaChange(new StructType(), Seq[String]())
+  val INDEX_SCHEMA_CHANGED = "schemaChanged"
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexConstants.scala
@@ -113,6 +113,5 @@ object IndexConstants {
   // "/temp/1/*, /temp/2/*"
   val GLOBBING_PATTERN_KEY = "spark.hyperspace.source.globbingPattern"
 
-  val NO_INDEX_SCHEMA_CHANGE = IndexSchemaChange(new StructType(), Seq[String]())
   val INDEX_SCHEMA_CHANGED = "schemaChanged"
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexManager.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexManager.scala
@@ -65,7 +65,7 @@ trait IndexManager {
    *
    * @param indexName Name of the index to refresh.
    */
-  def refresh(indexName: String, mode: String): Unit
+  def refresh(indexName: String, mode: String, indexSchemaChange: IndexSchemaChange): Unit
 
   /**
    * Optimize index by changing the underlying index data layout (e.g., compaction).

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexSchemaChange.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexSchemaChange.scala
@@ -1,19 +1,41 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.microsoft.hyperspace.index
+
 import java.util.Locale
 
 import org.apache.spark.sql.types.StructType
 
 case class IndexSchemaChange(includeColumns: StructType, excludeColumns: Seq[String]) {
+  val loweCaseIncludedColumnsName =
+    includeColumns.fieldNames.map(_.toLowerCase(Locale.ROOT)).toSeq
+  val loweCaseIncludedColumnsNameSet = loweCaseIncludedColumnsName.toSet
   val lowerCaseExcludeColumns = excludeColumns.map(_.toLowerCase(Locale.ROOT))
   val lowerCaseExcludeColumnsSet = excludeColumns.toSet
+
+  if (loweCaseIncludedColumnsNameSet.size < loweCaseIncludedColumnsName.size) {
+    throw new IllegalArgumentException("Duplicate include column names are not allowed.")
+  }
 
   if (lowerCaseExcludeColumnsSet.size < lowerCaseExcludeColumns.size) {
     throw new IllegalArgumentException("Duplicate exclude column names are not allowed.")
   }
 
-  if (includeColumns.fieldNames
-        .map(_.toLowerCase(Locale.ROOT))
-        .exists(lowerCaseExcludeColumnsSet.contains)) {
+  if (loweCaseIncludedColumnsNameSet.exists(lowerCaseExcludeColumnsSet.contains)) {
     throw new IllegalArgumentException(
       "Duplicate column names in include and exclude columns are not allowed.")
   }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexSchemaChange.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexSchemaChange.scala
@@ -40,3 +40,7 @@ case class IndexSchemaChange(includeColumns: StructType, excludeColumns: Seq[Str
       "Duplicate column names in include and exclude columns are not allowed.")
   }
 }
+
+object IndexSchemaChange {
+  val NO_CHANGE = IndexSchemaChange(new StructType(), Seq[String]())
+}

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexSchemaChange.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexSchemaChange.scala
@@ -1,21 +1,4 @@
-/*
- * Copyright (2020) The Hyperspace Project Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package com.microsoft.hyperspace.actions
-
+package com.microsoft.hyperspace.index
 import java.util.Locale
 
 import org.apache.spark.sql.types.StructType

--- a/src/test/scala/com/microsoft/hyperspace/SampleData.scala
+++ b/src/test/scala/com/microsoft/hyperspace/SampleData.scala
@@ -48,4 +48,17 @@ object SampleData {
         df.write.parquet(path)
     }
   }
+
+  def appendWithSchemaChange(spark: SparkSession, columns: Seq[String], path: String): Unit = {
+    val data = Seq(
+      ("2020-12-6", "facebook", "Menlo Park", "CA", 94025),
+      ("2019-10-16", "donde", "New York", "NY", 10001))
+
+    import spark.implicits._
+    data
+      .toDF(columns: _*)
+      .write
+      .mode("append")
+      .parquet(path)
+  }
 }

--- a/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/actions/RefreshActionTest.scala
@@ -78,7 +78,8 @@ class RefreshActionTest extends SparkFunSuite with SparkInvolvedSuite {
         CoveringIndex.Properties(
           CoveringIndex.Properties
             .Columns(Seq("clicks"), Seq()),
-          "schema",
+          s"""{\"type\":\"struct\",\"fields\":[{\"name\":\"clicks\",""" +
+            s"""\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}""",
           10,
           Map())),
       Content(Directory("dirPath")),

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
@@ -119,32 +119,32 @@ class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
     assert(actual.equals(expected))
   }
 
-  test("delete() throws exception if index is not found") {
+  test("delete() throws exception if index is not found.") {
     when(mockFileSystem.exists(new Path(indexSystemPath, "idx4"))).thenReturn(false)
     intercept[HyperspaceException](indexCollectionManager.delete("idx4"))
   }
 
-  test("vacuum() throws exception if index is not found") {
+  test("vacuum() throws exception if index is not found.") {
     when(mockFileSystem.exists(new Path(indexSystemPath, "idx4"))).thenReturn(false)
     intercept[HyperspaceException](indexCollectionManager.vacuum("idx4"))
   }
 
-  test("restore() throws exception if index is not found") {
+  test("restore() throws exception if index is not found.") {
     when(mockFileSystem.exists(new Path(indexSystemPath, "idx4"))).thenReturn(false)
     intercept[HyperspaceException](indexCollectionManager.restore("idx4"))
   }
 
-  test("refresh() with mode = 'full' throws exception if index is not found") {
+  test("refresh() with mode = 'full' throws exception if index is not found.") {
     when(mockFileSystem.exists(new Path(indexSystemPath, "idx4"))).thenReturn(false)
     intercept[HyperspaceException](
       indexCollectionManager
-        .refresh("idx4", REFRESH_MODE_FULL, IndexConstants.NO_INDEX_SCHEMA_CHANGE))
+        .refresh("idx4", REFRESH_MODE_FULL, IndexSchemaChange.NO_CHANGE))
   }
 
-  test("refresh() with mode = 'incremental' throws exception if index is not found") {
+  test("refresh() with mode = 'incremental' throws exception if index is not found.") {
     when(mockFileSystem.exists(new Path(indexSystemPath, "idx4"))).thenReturn(false)
     intercept[HyperspaceException](
       indexCollectionManager
-        .refresh("idx4", REFRESH_MODE_INCREMENTAL, IndexConstants.NO_INDEX_SCHEMA_CHANGE))
+        .refresh("idx4", REFRESH_MODE_INCREMENTAL, IndexSchemaChange.NO_CHANGE))
   }
 }

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexCollectionManagerTest.scala
@@ -136,12 +136,15 @@ class IndexCollectionManagerTest extends SparkFunSuite with SparkInvolvedSuite {
 
   test("refresh() with mode = 'full' throws exception if index is not found") {
     when(mockFileSystem.exists(new Path(indexSystemPath, "idx4"))).thenReturn(false)
-    intercept[HyperspaceException](indexCollectionManager.refresh("idx4", REFRESH_MODE_FULL))
+    intercept[HyperspaceException](
+      indexCollectionManager
+        .refresh("idx4", REFRESH_MODE_FULL, IndexConstants.NO_INDEX_SCHEMA_CHANGE))
   }
 
   test("refresh() with mode = 'incremental' throws exception if index is not found") {
     when(mockFileSystem.exists(new Path(indexSystemPath, "idx4"))).thenReturn(false)
     intercept[HyperspaceException](
-      indexCollectionManager.refresh("idx4", REFRESH_MODE_INCREMENTAL))
+      indexCollectionManager
+        .refresh("idx4", REFRESH_MODE_INCREMENTAL, IndexConstants.NO_INDEX_SCHEMA_CHANGE))
   }
 }


### PR DESCRIPTION
### What is the context for this pull request?
This PR is part of changes to add support for indexing datasets with evolving schema. Check proposal #263 for more details.
This PR extends `refreshIndex` API so that user can make index schema changes when updating index.
A schema change is valid if:
- New column(s) are added as included columns, and/or
- Some existing included column(s) are excluded. 

**Tracking Issue**: #229
**Design Proposal**: #263 

### What changes were proposed in this pull request?
This PR adds changes to `refreshIndex` API by extending it to support index schema change in the `full` and `incremental` modes.

**Example**
val indexConfig = IndexConfig("index", Seq("c3"), Seq("c1", "c5"))
hyperspace.createIndex(df, indexConfig)

// Some source data changes happen and user decides to refresh index,
// as part of refresh, the user decides to:
// 1. Remove column `c5` from current included columns;
// 2. Adds a new column, `c6` to included columns.

val schemaChange = IndexSchemaChange(StructType(Seq(StructField("c6", StringType))), Seq("c5"))
hyperspace.refreshIndex(indexConfig.indexName, REFRESH_MODE_INCREMENTAL, schemaChange)

### Does this PR introduce _any_ user-facing change?
Yes, it extends `refreshIndex` API.

### How was this patch tested?
Unit testing.