### PR TITLE
Remove deleted threshold condition for append-only Hybrid Scan

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/RuleUtils.scala
@@ -101,10 +101,8 @@ object RuleUtils {
         appendedBytesRatio < HyperspaceConf.hybridScanAppendedRatioThreshold(spark) &&
         deletedBytesRatio < HyperspaceConf.hybridScanDeletedRatioThreshold(spark)
 
-
       // For append-only Hybrid Scan, deleted files are not allowed.
-      lazy val isAppendOnlyCandidate = !hybridScanDeleteEnabled && deletedCnt == 0 &&
-        commonCnt > 0 &&
+      lazy val isAppendOnlyCandidate = deletedCnt == 0 && commonCnt > 0 &&
         appendedBytesRatio < HyperspaceConf.hybridScanAppendedRatioThreshold(spark)
 
       val isCandidate = isAppendAndDeleteCandidate || isAppendOnlyCandidate

--- a/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/rules/RuleUtilsTest.scala
@@ -136,7 +136,7 @@ class RuleUtilsTest extends HyperspaceRuleSuite with SQLHelper {
             plan: LogicalPlan,
             hybridScanEnabled: Boolean,
             hybridScanDeleteEnabled: Boolean,
-            numExpectCandidateIndex: Int,
+            numExpectedCandidateIndex: Int,
             expectedHybridScanTag: Option[Boolean],
             expectedCommonSourceBytes: Option[Long]): Unit = {
           withSQLConf(
@@ -145,16 +145,19 @@ class RuleUtilsTest extends HyperspaceRuleSuite with SQLHelper {
             IndexConstants.INDEX_HYBRID_SCAN_DELETED_RATIO_THRESHOLD ->
               (if (hybridScanDeleteEnabled) "0.99" else "0")) {
             val indexes = RuleUtils
-              .getCandidateIndexes(spark, allIndexes, plan).sortBy(_.name)
-            if (numExpectCandidateIndex > 0) {
-              assert(indexes.length === numExpectCandidateIndex)
+              .getCandidateIndexes(spark, allIndexes, plan)
+              .sortBy(_.name)
+            if (numExpectedCandidateIndex > 0) {
+              assert(indexes.length === numExpectedCandidateIndex)
               assert(indexes.head.name === "index1")
-              assert(
-                indexes.head.getTagValue(plan, IndexLogEntryTags.HYBRIDSCAN_REQUIRED)
-                  === expectedHybridScanTag)
-              assert(
-                indexes.head.getTagValue(plan, IndexLogEntryTags.COMMON_SOURCE_SIZE_IN_BYTES)
-                  === expectedCommonSourceBytes)
+              indexes.foreach { index =>
+                assert(
+                  index.getTagValue(plan, IndexLogEntryTags.HYBRIDSCAN_REQUIRED)
+                    === expectedHybridScanTag)
+                assert(
+                  index.getTagValue(plan, IndexLogEntryTags.COMMON_SOURCE_SIZE_IN_BYTES)
+                    === expectedCommonSourceBytes)
+              }
             } else {
               assert(indexes.isEmpty)
             }
@@ -169,14 +172,14 @@ class RuleUtilsTest extends HyperspaceRuleSuite with SQLHelper {
             optimizedPlan,
             hybridScanEnabled = false,
             hybridScanDeleteEnabled = false,
-            numExpectCandidateIndex = 2,
+            numExpectedCandidateIndex = 2,
             expectedHybridScanTag = None,
             expectedCommonSourceBytes = None)
           verify(
             optimizedPlan,
             hybridScanEnabled = true,
             hybridScanDeleteEnabled = false,
-            numExpectCandidateIndex = 2,
+            numExpectedCandidateIndex = 2,
             expectedHybridScanTag = Some(false),
             expectedCommonSourceBytes = Some(expectedCommonSourceBytes))
         }
@@ -190,14 +193,14 @@ class RuleUtilsTest extends HyperspaceRuleSuite with SQLHelper {
             optimizedPlan,
             hybridScanEnabled = false,
             hybridScanDeleteEnabled = false,
-            numExpectCandidateIndex = 0,
+            numExpectedCandidateIndex = 0,
             expectedHybridScanTag = None,
             expectedCommonSourceBytes = None)
           verify(
             optimizedPlan,
             hybridScanEnabled = true,
             hybridScanDeleteEnabled = false,
-            numExpectCandidateIndex = 2,
+            numExpectedCandidateIndex = 2,
             expectedHybridScanTag = Some(true),
             expectedCommonSourceBytes = Some(expectedCommonSourceBytes))
         }
@@ -214,21 +217,21 @@ class RuleUtilsTest extends HyperspaceRuleSuite with SQLHelper {
             optimizedPlan,
             hybridScanEnabled = false,
             hybridScanDeleteEnabled = false,
-            numExpectCandidateIndex = 0,
+            numExpectedCandidateIndex = 0,
             expectedHybridScanTag = None,
             expectedCommonSourceBytes = None)
           verify(
             optimizedPlan,
             hybridScanEnabled = true,
             hybridScanDeleteEnabled = false,
-            numExpectCandidateIndex = 0,
+            numExpectedCandidateIndex = 0,
             expectedHybridScanTag = None,
             expectedCommonSourceBytes = None)
           verify(
             optimizedPlan,
             hybridScanEnabled = true,
             hybridScanDeleteEnabled = true,
-            numExpectCandidateIndex = 1,
+            numExpectedCandidateIndex = 1,
             expectedHybridScanTag = Some(true),
             expectedCommonSourceBytes = Some(updatedExpectedCommonSourceBytes))
         }
@@ -242,14 +245,14 @@ class RuleUtilsTest extends HyperspaceRuleSuite with SQLHelper {
             optimizedPlan,
             hybridScanEnabled = false,
             hybridScanDeleteEnabled = false,
-            numExpectCandidateIndex = 0,
+            numExpectedCandidateIndex = 0,
             expectedHybridScanTag = None,
             expectedCommonSourceBytes = None)
           verify(
             optimizedPlan,
             hybridScanEnabled = true,
             hybridScanDeleteEnabled = true,
-            numExpectCandidateIndex = 0,
+            numExpectedCandidateIndex = 0,
             expectedHybridScanTag = None,
             expectedCommonSourceBytes = None)
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What is the context for this pull request?
<!--
Please clarify the context for the changes you are contributing. The purpose of this section is to outline information information to help reviewers have enough context.
-->

 - **Tracking Issue**: n/a
 - **Parent Issue**: n/a
 - **Dependencies**: n/a

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.

The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->
For append-only hybrid scan, the ratio threshold of deleted files shouldn't matter. 
Previously, we have different config for Hybrid Scan (append only & append + delete) but now we only have 1 config for Hybrid Scan, we don't need to check the delete threshold.
The condition blocks to apply the index if hybrid scan is enabled & maxDeletedRatio config is non-zero.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, fixes the bug described above.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test