### PR TITLE
Fix e2e tests on managed tables and enable external table tests.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,8 +37,7 @@ libraryDependencies ++= Seq(
   "org.mockito" %% "mockito-scala" % "0.4.0" % "test",
   "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "test" classifier "tests",
   "org.apache.spark" %% "spark-core" % sparkVersion.value % "test" classifier "tests",
-  "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test" classifier "tests",
-  "org.apache.spark" %% "spark-hive" % sparkVersion.value % "test" classifier "tests"
+  "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test" classifier "tests"
 )
 
 assemblyMergeStrategy in assembly := {

--- a/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTest.scala
@@ -281,62 +281,85 @@ class E2EHyperspaceRulesTest extends QueryTest with HyperspaceSuite {
     }
   }
 
-  ignore("E2E test for join query on external catalog tables") {
-    // TODO: Ignoring this test as it depends on hive for testing.
-    withTable("t1", "t2") {
-      // save tables on hive metastore as external tables
-      spark.sql(s"""
-          |CREATE EXTERNAL TABLE t1
-          |(c1 string, c3 string)
-          |STORED AS PARQUET
-          |LOCATION '$nonPartitionedDataPath'
-        """.stripMargin)
-      spark.sql(s"""
-          |CREATE EXTERNAL TABLE t2
-          |(c3 string, c4 int)
-          |STORED AS PARQUET
-          |LOCATION '$nonPartitionedDataPath'
-        """.stripMargin)
+  test("E2E test for join query on external catalog tables") {
+    Seq(true, false).map { useDDL =>
+      withTable("t1", "t2") {
+        if (useDDL) {
+          spark.sql(s"""
+              |CREATE TABLE t1
+              |(c1 string, c3 string)
+              |USING PARQUET
+              |LOCATION '$nonPartitionedDataPath'
+            """.stripMargin)
+          spark.sql(s"""
+              |CREATE TABLE t2
+              |(c3 string, c4 int)
+              |USING PARQUET
+              |LOCATION '$nonPartitionedDataPath'
+            """.stripMargin)
+        } else {
+          val table1Location = testDir + "tables/t1"
+          val table2Location = testDir + "tables/t2"
+          val originalDf = spark.read.parquet(nonPartitionedDataPath)
+          originalDf.select("c1", "c3").write.option("path", table1Location).saveAsTable("t1")
+          originalDf.select("c3", "c4").write.option("path", table2Location).saveAsTable("t2")
+        }
 
-      val leftDf = spark.table("t1")
-      val rightDf = spark.table("t2")
+        assert(spark.catalog.getTable("t1").tableType == "EXTERNAL")
+        assert(spark.catalog.getTable("t2").tableType == "EXTERNAL")
 
-      val leftDfIndexConfig = IndexConfig("leftIndex", Seq("c3"), Seq("c1"))
-      val rightDfIndexConfig = IndexConfig("rightIndex", Seq("c3"), Seq("c4"))
+        val leftDf = spark.table("t1")
+        val rightDf = spark.table("t2")
+        val leftDfIndexConfig = IndexConfig("leftIndex", Seq("c3"), Seq("c1"))
+        val rightDfIndexConfig = IndexConfig("rightIndex", Seq("c3"), Seq("c4"))
+        hyperspace.createIndex(leftDf, leftDfIndexConfig)
+        hyperspace.createIndex(rightDf, rightDfIndexConfig)
 
-      hyperspace.createIndex(leftDf, leftDfIndexConfig)
-      hyperspace.createIndex(rightDf, rightDfIndexConfig)
-
-      // Test whether indexes work with catalog tables or not
-      def query(): DataFrame = spark.sql("SELECT t1.c1, t2.c4 FROM t1, t2 WHERE t1.c3 = t2.c3")
-      verifyIndexUsage(
-        query,
-        getIndexFilesPath(leftDfIndexConfig.indexName) ++
-          getIndexFilesPath(rightDfIndexConfig.indexName))
+        // Test whether indexes work with catalog tables or not.
+        def query(): DataFrame = spark.sql("SELECT t1.c1, t2.c4 FROM t1, t2 WHERE t1.c3 = t2.c3")
+        verifyIndexUsage(
+          query,
+          getIndexFilesPath(leftDfIndexConfig.indexName) ++
+            getIndexFilesPath(rightDfIndexConfig.indexName))
+      }
     }
   }
 
   test("E2E test for join query on managed catalog tables") {
-    withTable("t1", "t2") {
-      val table1Location = testDir + "tables/t1"
-      val table2Location = testDir + "tables/t2"
-      val originalDf = spark.read.parquet(nonPartitionedDataPath)
-      originalDf.select("c1", "c3").write.option("path", table1Location).saveAsTable("t1")
-      originalDf.select("c3", "c4").write.option("path", table2Location).saveAsTable("t2")
+    Seq(true, false).map { useDDL =>
+      withTable("t1", "t2") {
+        if (useDDL) {
+          withView("tv1", "tv2") {
+            val originalDf = spark.read.parquet(nonPartitionedDataPath)
+            originalDf.select("c1", "c3").createOrReplaceTempView("tv1")
+            originalDf.select("c3", "c4").createOrReplaceTempView("tv2")
+            spark.sql("CREATE TABLE t1 USING PARQUET AS SELECT * FROM tv1")
+            spark.sql("CREATE TABLE t2 USING PARQUET AS SELECT * FROM tv2")
+          }
+        } else {
+          val originalDf = spark.read.parquet(nonPartitionedDataPath)
+          originalDf.select("c1", "c3").write.saveAsTable("t1")
+          originalDf.select("c3", "c4").write.saveAsTable("t2")
+        }
 
-      val leftDf = spark.table("t1")
-      val rightDf = spark.table("t2")
-      val leftDfIndexConfig = IndexConfig("leftIndex", Seq("c3"), Seq("c1"))
-      val rightDfIndexConfig = IndexConfig("rightIndex", Seq("c3"), Seq("c4"))
-      hyperspace.createIndex(leftDf, leftDfIndexConfig)
-      hyperspace.createIndex(rightDf, rightDfIndexConfig)
+        assert(spark.catalog.getTable("t1").tableType == "MANAGED")
+        assert(spark.catalog.getTable("t2").tableType == "MANAGED")
 
-      // Test whether indexes work with catalog tables or not
-      def query(): DataFrame = spark.sql("SELECT t1.c1, t2.c4 FROM t1, t2 WHERE t1.c3 = t2.c3")
-      verifyIndexUsage(
-        query,
-        getIndexFilesPath(leftDfIndexConfig.indexName) ++
-          getIndexFilesPath(rightDfIndexConfig.indexName))
+        val leftDf = spark.table("t1")
+        val rightDf = spark.table("t2")
+        val leftDfIndexConfig = IndexConfig("leftIndex", Seq("c3"), Seq("c1"))
+        val rightDfIndexConfig = IndexConfig("rightIndex", Seq("c3"), Seq("c4"))
+        hyperspace.createIndex(leftDf, leftDfIndexConfig)
+        hyperspace.createIndex(rightDf, rightDfIndexConfig)
+
+        // Test whether indexes work with catalog tables or not.
+        def query(): DataFrame =
+          spark.sql("SELECT t1.c1, t2.c4 FROM t1, t2 WHERE t1.c3 = t2.c3")
+        verifyIndexUsage(
+          query,
+          getIndexFilesPath(leftDfIndexConfig.indexName) ++
+            getIndexFilesPath(rightDfIndexConfig.indexName))
+      }
     }
   }
 

--- a/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTest.scala
@@ -282,7 +282,7 @@ class E2EHyperspaceRulesTest extends QueryTest with HyperspaceSuite {
   }
 
   test("E2E test for join query on external catalog tables") {
-    Seq(true, false).map { useDDL =>
+    Seq(true, false).foreach { useDDL =>
       withIndex("leftIndex", "rightIndex") {
         withTable("t1", "t2") {
           if (useDDL) {
@@ -322,7 +322,7 @@ class E2EHyperspaceRulesTest extends QueryTest with HyperspaceSuite {
   }
 
   test("E2E test for join query on managed catalog tables") {
-    Seq(true, false).map { useDDL =>
+    Seq(true, false).foreach { useDDL =>
       withIndex("leftIndex", "rightIndex") {
         withTable("t1", "t2") {
           if (useDDL) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.

The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->
This PR fixes the "E2E test for join query on managed catalog tables" test in `E2EHyperspaceRulesTest` where an external table is created instead of managed table.

This also enables the test case on the external tables. This was disabled due to the Hive dependency. If Hive table is needed, we can create a separate PR to follow up.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New test cases.