### PR TITLE
Support Iceberg table format

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % sparkVersion.value % "provided" withSources(),
   "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "provided" withSources(),
   "io.delta" %% "delta-core" % "0.6.1" % "provided" withSources(),
-  "org.apache.iceberg" % "iceberg-spark-runtime" % "0.10.0" % "provided" withSources(),
+  "org.apache.iceberg" % "iceberg-spark-runtime" % "0.11.0" % "provided" withSources(),
 
   // Test dependencies
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % sparkVersion.value % "provided" withSources(),
   "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "provided" withSources(),
   "io.delta" %% "delta-core" % "0.6.1" % "provided" withSources(),
+  "org.apache.iceberg" % "iceberg-spark-runtime" % "0.10.0" % "provided" withSources(),
 
   // Test dependencies
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/iceberg/IcebergFileBasedSource.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/iceberg/IcebergFileBasedSource.scala
@@ -29,9 +29,9 @@ import com.microsoft.hyperspace.index.sources.{FileBasedRelation, FileBasedSourc
  *
  * This source can support relations that meet the following criteria:
  *   - The relation is with [[DataSourceV2Relation]]
+ *   - The source of [[DataSourceV2Relation]] is an [[IcebergSource]]
  */
-class IcebergFileBasedSource(private val spark: SparkSession)
-    extends FileBasedSourceProvider {
+class IcebergFileBasedSource(private val spark: SparkSession) extends FileBasedSourceProvider {
 
   private val ICEBERG_FORMAT_STR = "iceberg"
 
@@ -64,15 +64,14 @@ class IcebergFileBasedSource(private val spark: SparkSession)
     }
   }
 
-
   /**
-   * Returns true if the given logical plan is a relation for Delta Lake.
+   * Returns true if the given logical plan is a relation for Iceberg.
    *
    * @param plan Logical plan to check if it's supported.
    * @return Some(true) if the given plan is a supported relation, otherwise None.
    */
-  def isSupportedRelation(plan: LogicalPlan): Option[Boolean] = plan match {
-    case _ @ DataSourceV2Relation(_: IcebergSource, _, _, _, _) =>
+  override def isSupportedRelation(plan: LogicalPlan): Option[Boolean] = plan match {
+    case _ @DataSourceV2Relation(_: IcebergSource, _, _, _, _) =>
       Some(true)
     case _ => None
   }
@@ -84,7 +83,7 @@ class IcebergFileBasedSource(private val spark: SparkSession)
    * @param plan Logical plan to wrap to [[FileBasedRelation]]
    * @return [[FileBasedRelation]] that wraps the given logical plan.
    */
-  def getRelation(plan: LogicalPlan): Option[FileBasedRelation] = plan match {
+  override def getRelation(plan: LogicalPlan): Option[FileBasedRelation] = plan match {
     case l @ DataSourceV2Relation(_: IcebergSource, _, _, _, _) =>
       Some(new IcebergRelation(spark, l))
     case _ => None

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/iceberg/IcebergFileBasedSource.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/iceberg/IcebergFileBasedSource.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index.sources.iceberg
+
+import org.apache.iceberg.spark.source.IcebergSource
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+
+import com.microsoft.hyperspace.index.Relation
+import com.microsoft.hyperspace.index.sources.{FileBasedRelation, FileBasedSourceProvider, SourceProvider, SourceProviderBuilder}
+
+/**
+ * Iceberg file-based source provider.
+ *
+ * This source can support relations that meet the following criteria:
+ *   - The relation is with [[DataSourceV2Relation]]
+ */
+class IcebergFileBasedSource(private val spark: SparkSession)
+    extends FileBasedSourceProvider {
+
+  private val ICEBERG_FORMAT_STR = "iceberg"
+
+  /**
+   * Given a [[Relation]], returns a new [[Relation]] that will have the latest source.
+   *
+   * @param relation [[Relation]] object to reconstruct [[DataFrame]] with.
+   * @return [[Relation]] object if the given 'relation' can be processed by this provider.
+   *         Otherwise, None.
+   */
+  override def refreshRelationMetadata(relation: Relation): Option[Relation] = {
+    if (relation.fileFormat.equals(ICEBERG_FORMAT_STR)) {
+      Some(relation.copy(options = relation.options - "snapshot-id" - "as-of-timestamp"))
+    } else {
+      None
+    }
+  }
+
+  /**
+   * Returns a file format name to read internal data files for a given [[Relation]].
+   *
+   * @param relation [[Relation]] object to read internal data files.
+   * @return File format to read internal data files.
+   */
+  override def internalFileFormatName(relation: Relation): Option[String] = {
+    if (relation.fileFormat.equals(ICEBERG_FORMAT_STR)) {
+      Some("parquet")
+    } else {
+      None
+    }
+  }
+
+
+  /**
+   * Returns true if the given logical plan is a relation for Delta Lake.
+   *
+   * @param plan Logical plan to check if it's supported.
+   * @return Some(true) if the given plan is a supported relation, otherwise None.
+   */
+  def isSupportedRelation(plan: LogicalPlan): Option[Boolean] = plan match {
+    case _ @ DataSourceV2Relation(_: IcebergSource, _, _, _, _) =>
+      Some(true)
+    case _ => None
+  }
+
+  /**
+   * Returns the [[FileBasedRelation]] that wraps the given logical plan if the given
+   * logical plan is a supported relation.
+   *
+   * @param plan Logical plan to wrap to [[FileBasedRelation]]
+   * @return [[FileBasedRelation]] that wraps the given logical plan.
+   */
+  def getRelation(plan: LogicalPlan): Option[FileBasedRelation] = plan match {
+    case l @ DataSourceV2Relation(_: IcebergSource, _, _, _, _) =>
+      Some(new IcebergRelation(spark, l))
+    case _ => None
+  }
+}
+
+/**
+ * Builder for building [[IcebergFileBasedSource]].
+ */
+class IcebergFileBasedSourceBuilder extends SourceProviderBuilder {
+  override def build(spark: SparkSession): SourceProvider = new IcebergFileBasedSource(spark)
+}

--- a/src/main/scala/com/microsoft/hyperspace/index/sources/iceberg/IcebergRelation.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/sources/iceberg/IcebergRelation.scala
@@ -1,0 +1,300 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index.sources.iceberg
+
+import collection.JavaConverters._
+import java.io.IOException
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.iceberg.{CombinedScanTask, FileScanTask, Table, TableProperties, TableScan}
+import org.apache.iceberg.catalog.TableIdentifier
+import org.apache.iceberg.expressions.Expressions
+import org.apache.iceberg.hadoop.HadoopTables
+import org.apache.iceberg.hive.HiveCatalogs
+import org.apache.iceberg.spark.{SparkFilters, SparkSchemaUtil}
+import org.apache.iceberg.spark.source.IcebergSource
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.execution.datasources.{FileIndex, HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.sources.v2.DataSourceOptions
+import org.apache.spark.sql.sources.v2.reader.SupportsPushDownFilters
+import org.apache.spark.sql.types.StructType
+import scala.util.Try
+
+import com.microsoft.hyperspace.index.{Content, FileIdTracker, Hdfs, IndexConstants, IndexLogEntry, Relation}
+import com.microsoft.hyperspace.index.plans.logical.IndexHadoopFsRelation
+import com.microsoft.hyperspace.index.sources.FileBasedRelation
+import com.microsoft.hyperspace.util.PathUtils
+
+/**
+ * Implementation for file-based relation used by [[IcebergFileBasedSource]]
+ */
+class IcebergRelation(spark: SparkSession, override val plan: DataSourceV2Relation)
+  extends FileBasedRelation {
+
+  /**
+   * Computes the signature of the current relation.
+   */
+  override def signature: String = plan.source match {
+    case _: IcebergSource =>
+      val table = findTable(new DataSourceOptions(plan.options.asJava))
+      val snapshotId = plan.options.getOrElse("snapshot-id",
+        table.currentSnapshot().snapshotId())
+      snapshotId + table.location()
+  }
+
+  /**
+   * All the files that the current relation references to.
+   */
+  override def allFiles: Seq[FileStatus] = plan.source match {
+    case source: IcebergSource =>
+      val dsOpts = new DataSourceOptions(plan.options.asJava)
+      val table = findTable(dsOpts)
+      val reader = source.createReader(dsOpts)
+      val filters = reader.asInstanceOf[SupportsPushDownFilters].pushedFilters()
+      tasks(table, dsOpts, filters, reader.readSchema()).flatMap { t =>
+        t.files().asScala.map(toFileStatus)
+      }
+  }
+
+  /**
+   * The optional partition base path of the current relation.
+   */
+  override def partitionBasePath: Option[String] = plan.source match {
+    case _: IcebergSource =>
+      val table = Try(findTable(new DataSourceOptions(plan.options.asJava))).toOption
+      table match {
+        case Some(t) =>
+          if (t.spec().isUnpartitioned) {
+            None
+          } else {
+            Some(
+              PathUtils.makeAbsolute(t.location(), spark.sessionState.newHadoopConf()).toString)
+          }
+        case _ => None
+      }
+    case _ => None
+  }
+
+  /**
+   * Creates [[Relation]] for IndexLogEntry using the current relation.
+   *
+   * @param fileIdTracker [[FileIdTracker]] to use when populating the data of [[Relation]].
+   * @return [[Relation]] object that describes the current relation.
+   */
+  override def createRelationMetadata(fileIdTracker: FileIdTracker): Relation = {
+    plan.source match {
+      case source: IcebergSource =>
+        val dsOpts = new DataSourceOptions(plan.options.asJava)
+        val table = findTable(dsOpts)
+        val reader = source.createReader(dsOpts)
+        val files = allFiles
+
+        val sourceDataProperties =
+          Hdfs.Properties(Content.fromLeafFiles(files, fileIdTracker).get)
+        val fileFormatName = "iceberg"
+        val currentSnapshot = table.currentSnapshot()
+        val basePathOpt = partitionBasePath.map(e => Map("basePath" -> e)).getOrElse(Map.empty)
+        val opts = plan.options - "path" +
+            ("snapshot-id" -> currentSnapshot.snapshotId().toString) +
+            ("as-of-timestamp" -> currentSnapshot.timestampMillis().toString) ++
+            basePathOpt
+
+        Relation(
+          Seq(PathUtils.makeAbsolute(table.location(),
+            spark.sessionState.newHadoopConf()).toString),
+          Hdfs(sourceDataProperties),
+          reader.readSchema().json,
+          fileFormatName,
+          opts)
+    }
+  }
+
+  /**
+   * Returns whether the current relation has parquet source files or not.
+   *
+   * @return Always true since delta lake files are stored as Parquet.
+   */
+  override def hasParquetAsSourceFormat: Boolean = true
+
+  /**
+   * Returns list of pairs of (file path, file id) to build lineage column.
+   *
+   * File paths should be the same format as "input_file_name()" of the given relation type.
+   * For [[IcebergRelation]], each file path should be in this format:
+   *   `file:/path/to/file`
+   *
+   * @param fileIdTracker [[FileIdTracker]] to create the list of (file path, file id).
+   * @return List of pairs of (file path, file id).
+   */
+  override def lineagePairs(fileIdTracker: FileIdTracker): Seq[(String, Long)] = {
+    fileIdTracker.getFileToIdMap.toSeq.map { kv =>
+      (kv._1._1, kv._2)
+    }
+  }
+
+  /**
+   * Options of the current relation.
+   */
+  override def options: Map[String, String] = plan.options
+
+  /**
+   * The partition schema of the current relation.
+   */
+  override def partitionSchema: StructType = plan.source match {
+    case _: IcebergSource =>
+      val dsOpts = new DataSourceOptions(plan.options.asJava)
+      val table = findTable(dsOpts)
+      SparkSchemaUtil.convert(table.spec().schema())
+
+  }
+
+  /**
+   * Creates [[HadoopFsRelation]] based on the current relation.
+   *
+   * This is mainly used in conjunction with [[createLogicalRelation]].
+   */
+  override def createHadoopFsRelation(location: FileIndex,
+      dataSchema: StructType,
+      options: Map[String, String]): HadoopFsRelation = plan.source match {
+    case _: IcebergSource =>
+      HadoopFsRelation(
+        location,
+        new StructType(),
+        dataSchema,
+        None,
+        new ParquetFileFormat,
+        options + IndexConstants.INDEX_RELATION_IDENTIFIER)(spark)
+  }
+
+  /**
+   * Creates [[LogicalRelation]] based on the current relation.
+   *
+   * This is mainly used to read the index files.
+   */
+  override def createLogicalRelation(
+      hadoopFsRelation: HadoopFsRelation,
+      newOutput: Seq[AttributeReference]): LogicalRelation = {
+    val updatedOutput =
+      newOutput.filter(attr => hadoopFsRelation.schema.fieldNames.contains(attr.name))
+    new LogicalRelation(hadoopFsRelation, updatedOutput, None, false)
+  }
+
+  private def findTable(options: DataSourceOptions): Table = {
+    val conf = spark.sessionState.newHadoopConf()
+    val path = options.get("path")
+    if (!path.isPresent) {
+      throw new IllegalArgumentException("Cannot open table: path is not set")
+    }
+    if (path.get.contains("/")) {
+      val tables = new HadoopTables(conf)
+      tables.load(path.get)
+    }
+    else {
+      val hiveCatalog = HiveCatalogs.loadCatalog(conf)
+      val tableIdentifier = TableIdentifier.parse(path.get)
+      hiveCatalog.loadTable(tableIdentifier)
+    }
+  }
+
+  // TODO: need Iceberg's `tasks()` method to be public to get rid of this method
+  private def tasks(table: Table, options: DataSourceOptions, pushedFilters: Seq[Filter],
+      requestedSchema: StructType): Seq[CombinedScanTask] = {
+
+    val caseSensitive = spark.conf.get("spark.sql.caseSensitive").toBoolean
+    val snapshotId = Try(options.get("snapshot-id").get().toLong).toOption
+    val asOfTimestamp = Try(options.get("as-of-timestamp").get().toLong).toOption
+    val startSnapshotId = Try(options.get("start-snapshot-id").get().toLong).toOption
+    val endSnapshotId = Try(options.get("end-snapshot-id").get().toLong).toOption
+    val splitSize = Try(options.get("split-size").get().toLong).toOption
+    val splitLookBack = Try(options.get("lookback").get().toInt).toOption
+    val splitOpenFileCost = Try(options.get("file-open-cost").get().toLong).toOption
+    val pushedExpressions = pushedFilters.map(SparkFilters.convert)
+    val lazySchema = if (requestedSchema != null) {
+      SparkSchemaUtil.prune(
+        table.schema,
+        requestedSchema,
+        pushedExpressions.reduceOption(Expressions.and).getOrElse(Expressions.alwaysTrue()),
+        caseSensitive)
+    } else {
+      table.schema
+    }
+
+    var scan: TableScan = table.newScan.caseSensitive(caseSensitive).project(lazySchema)
+
+    if (snapshotId.isDefined) {
+      scan = scan.useSnapshot(snapshotId.get)
+    }
+    if (asOfTimestamp.isDefined) {
+      scan = scan.asOfTime(asOfTimestamp.get)
+    }
+    if (startSnapshotId.isDefined) {
+      if (endSnapshotId.isDefined) {
+        scan = scan.appendsBetween(startSnapshotId.get, endSnapshotId.get)
+      } else {
+        scan = scan.appendsAfter(startSnapshotId.get)
+      }
+    }
+    if (splitSize.isDefined) {
+      scan = scan.option(TableProperties.SPLIT_SIZE, splitSize.get.toString)
+    }
+    if (splitLookBack.isDefined) {
+      scan = scan.option(TableProperties.SPLIT_LOOKBACK, splitLookBack.get.toString)
+    }
+    if (splitOpenFileCost.isDefined) {
+      scan = scan.option(TableProperties.SPLIT_OPEN_FILE_COST, splitOpenFileCost.get.toString)
+    }
+
+    pushedExpressions.foreach { f =>
+      scan = scan.filter(f)
+    }
+
+    try {
+      scan.planTasks().asScala.toSeq
+    } catch {
+      case e: IOException =>
+        throw new RuntimeException(s"Failed to close table scan: $scan", e)
+    }
+  }
+
+  private def toFileStatus(fileScanTask: FileScanTask): FileStatus = {
+    val jPath = new Path(fileScanTask.file().path().toString)
+    val fs = jPath.getFileSystem(spark.sessionState.newHadoopConf())
+    val fullPath = if (!jPath.isAbsolute) {
+      new Path(s"${fs.getWorkingDirectory.toString}/${jPath.toString}")
+    } else {
+      jPath
+    }
+    val modTime = fs.listStatus(fullPath).head.getModificationTime
+    toFileStatus(
+      fileScanTask.file().fileSizeInBytes(),
+      modTime,
+      fullPath)
+  }
+
+  private def toFileStatus(fileSize: Long, modificationTime: Long, path: Path): FileStatus = {
+    new FileStatus(
+      /* length */ fileSize,
+      /* isDir */ false,
+      /* blockReplication */ 0,
+      /* blockSize */ 1,
+      /* modificationTime */ modificationTime,
+      path)
+  }
+}

--- a/src/test/scala/com/microsoft/hyperspace/index/HybridScanForIcebergTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/HybridScanForIcebergTest.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index
+
+import org.apache.hadoop.fs.Path
+import org.apache.iceberg.{PartitionSpec => IcebergPartitionSpec, Table, TableProperties}
+import org.apache.iceberg.hadoop.HadoopTables
+import org.apache.iceberg.spark.SparkSchemaUtil
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import scala.collection.JavaConverters._
+
+import com.microsoft.hyperspace.{Hyperspace, TestConfig}
+
+class HybridScanForIcebergTest extends HybridScanSuite {
+  override protected val fileFormat = "iceberg"
+  override protected val fileFormat2 = "iceberg"
+
+  override def beforeAll() {
+    super.beforeAll()
+    spark.conf.set(
+      "spark.hyperspace.index.sources.fileBasedBuilders",
+      "com.microsoft.hyperspace.index.sources.iceberg.IcebergFileBasedSourceBuilder," +
+        "com.microsoft.hyperspace.index.sources.default.DefaultFileBasedSourceBuilder")
+    hyperspace = new Hyperspace(spark)
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    spark.conf.unset("spark.hyperspace.index.sources.fileBasedBuilders")
+  }
+
+  override def setupIndexAndChangeData(
+      sourceFileFormat: String,
+      sourcePath: String,
+      indexConfig: IndexConfig,
+      appendCnt: Int,
+      deleteCnt: Int): (Seq[String], Seq[String]) = {
+    // Use partition to control the number of appended and deleted files.
+    val dfFromSampleRenamed = dfFromSample.withColumnRenamed("Date", "date")
+    val icebergTable = createIcebergTable(sourcePath, dfFromSampleRenamed, Seq("RGUID"))
+    dfFromSampleRenamed.write.format(sourceFileFormat).mode("overwrite").save(sourcePath)
+    val df = spark.read.format(sourceFileFormat).load(sourcePath)
+    hyperspace.createIndex(df, indexConfig)
+    icebergTable.refresh()
+    val inputFiles = icebergTable
+      .currentSnapshot()
+      .addedFiles()
+      .asScala
+      .toSeq
+      .map(f => s"${f.path().toString}")
+
+    // Create a new version by deleting entries.
+    if (deleteCnt > 0) {
+      val filesToDelete = inputFiles.dropRight(inputFiles.size - deleteCnt)
+      val deleteAction = icebergTable.newDelete()
+      filesToDelete.foreach(deleteAction.deleteFile)
+      deleteAction.commit()
+    }
+    if (appendCnt > 0) {
+      dfFromSampleRenamed
+        .limit(appendCnt)
+        .write
+        .format(sourceFileFormat)
+        .mode("append")
+        .save(sourcePath)
+    }
+
+    icebergTable.refresh()
+
+    val inputFilesA = inputFiles.map(f => s"file:/${f.replaceAll("^/", "")}")
+    val inputFilesB = icebergTable
+      .newScan()
+      .planFiles()
+      .iterator()
+      .asScala
+      .toSeq
+      .map(f => s"file:/${f.file().path().toString.replaceAll("^/", "")}")
+    (inputFilesB diff inputFilesA, inputFilesA diff inputFilesB)
+  }
+
+  test(
+    "Append-only: filter rule & parquet format, " +
+      "index relation should include appended file paths.") {
+    // This test is for verifying plan transformation if appended files could be load with index
+    // data scan node. Currently, it's applied for a very specific case: FilterIndexRule,
+    // Parquet source format, no partitioning, no deleted files.
+
+    withTempPathAsString { testPath =>
+      {
+        // Create data & index without helper function as non-partitioned data is required.
+        createIcebergTable(testPath, dfFromSample)
+        dfFromSample.write.format("iceberg").mode("overwrite").save(testPath)
+        val df = spark.read.format("iceberg").load(testPath)
+        hyperspace.createIndex(df, indexConfig1.copy(indexName = "index_Append"))
+
+        dfFromSample
+          .limit(2)
+          .write
+          .format("iceberg")
+          .mode("append")
+          .save(testPath)
+      }
+
+      val df = spark.read.format("iceberg").load(testPath)
+      def filterQuery: DataFrame =
+        df.filter(df("clicks") <= 2000).select(df("query"))
+
+      val baseQuery = filterQuery
+      val basePlan = baseQuery.queryExecution.optimizedPlan
+
+      withSQLConf(IndexConstants.INDEX_HYBRID_SCAN_ENABLED -> "false") {
+        val filter = filterQuery
+        assert(basePlan.equals(filter.queryExecution.optimizedPlan))
+      }
+
+      val sourcePath = new Path(testPath).toString
+
+      withSQLConf(TestConfig.HybridScanEnabledAppendOnly: _*) {
+        val filter = filterQuery
+        val planWithHybridScan = filter.queryExecution.optimizedPlan
+        assert(!basePlan.equals(planWithHybridScan))
+
+        // Check appended file is added to relation node or not.
+        val nodes = planWithHybridScan.collect {
+          case p @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _) =>
+            // Verify appended file is included or not.
+            val files = fsRelation.location.inputFiles
+            assert(files.count(_.contains(sourcePath)) === 2)
+            // Verify number of index data files.
+            assert(files.count(_.contains("index_Append")) === 4)
+            assert(files.length === 6)
+            p
+        }
+        // Filter Index and Parquet format source file can be handled with 1 LogicalRelation.
+        assert(nodes.length === 1)
+        checkAnswer(baseQuery, filter)
+      }
+    }
+  }
+
+  def createIcebergTable(
+      dataPath: String,
+      sourceDf: DataFrame,
+      partitionCols: Seq[String] = Seq.empty): Table = {
+    val props = Map(TableProperties.WRITE_NEW_DATA_LOCATION -> dataPath).asJava
+    val schema = SparkSchemaUtil.convert(sourceDf.schema)
+    val spec = if (partitionCols.nonEmpty) {
+      val s = IcebergPartitionSpec.builderFor(schema)
+      partitionCols.foreach(s.identity)
+      s.build()
+    } else {
+      IcebergPartitionSpec.unpartitioned()
+    }
+    new HadoopTables().create(schema, spec, props, dataPath)
+  }
+}

--- a/src/test/scala/com/microsoft/hyperspace/index/IcebergIntegrationTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IcebergIntegrationTest.scala
@@ -406,7 +406,7 @@ class IcebergIntegrationTest extends QueryTest with HyperspaceSuite {
         .append("<----:     +- *(1) Filter isnotnull(Col1#1)---->")
         .append(defaultDisplayMode.newLine)
         .append("<----:        +- *(1) ScanV2 iceberg[Col1#, Col2#] (Filters: [isnotnull(Col1#)], Options: " +
-            truncate(s"[path=$dataPath,paths=[]]") + ")---->")
+          truncate(s"[path=$dataPath,paths=[]]") + ")---->")
         .append(defaultDisplayMode.newLine)
         .append("<----+- *(2) Sort [Col1#21 ASC NULLS FIRST], false, 0---->")
         .append(defaultDisplayMode.newLine)
@@ -415,7 +415,7 @@ class IcebergIntegrationTest extends QueryTest with HyperspaceSuite {
         .append("      <----+- *(2) Filter isnotnull(Col1#)---->")
         .append(defaultDisplayMode.newLine)
         .append("         <----+- *(2) ScanV2 iceberg[Col1#, Col2#] (Filters: [isnotnull(Col1#)], Options: " +
-            truncate(s"[path=$dataPath,paths=[]]") + ")---->")
+          truncate(s"[path=$dataPath,paths=[]]") + ")---->")
         .append(defaultDisplayMode.newLine)
         .append(defaultDisplayMode.newLine)
         .append("=============================================================")

--- a/src/test/scala/com/microsoft/hyperspace/index/IcebergIntegrationTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IcebergIntegrationTest.scala
@@ -1,0 +1,541 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index
+
+import org.apache.commons.lang.StringUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.iceberg.{PartitionSpec => IcebergPartitionSpec, Table, TableProperties}
+import org.apache.iceberg.hadoop.HadoopTables
+import org.apache.iceberg.spark.SparkSchemaUtil
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources._
+import scala.collection.JavaConverters._
+
+import com.microsoft.hyperspace.{Hyperspace, Implicits, SampleData, TestConfig}
+import com.microsoft.hyperspace.TestUtils.latestIndexLogEntry
+import com.microsoft.hyperspace.index.IndexConstants.REFRESH_MODE_QUICK
+import com.microsoft.hyperspace.index.plananalysis.{PlainTextMode, PlanAnalyzer}
+import com.microsoft.hyperspace.util.PathUtils
+import com.microsoft.hyperspace.util.PathUtils.DataPathFilter
+
+class IcebergIntegrationTest extends QueryTest with HyperspaceSuite {
+  override val systemPath = PathUtils.makeAbsolute("src/test/resources/icebergIntegrationTest")
+
+  private val sampleData = SampleData.testData
+  private var hyperspace: Hyperspace = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(
+      "spark.hyperspace.index.sources.fileBasedBuilders",
+      "com.microsoft.hyperspace.index.sources.iceberg.IcebergFileBasedSourceBuilder," +
+        "com.microsoft.hyperspace.index.sources.default.DefaultFileBasedSourceBuilder")
+    hyperspace = new Hyperspace(spark)
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    spark.conf.unset("spark.hyperspace.index.sources.fileBasedBuilders")
+  }
+
+  before {
+    spark.enableHyperspace()
+  }
+
+  after {
+    spark.disableHyperspace()
+  }
+
+  test("Verify createIndex and refreshIndex on Iceberg table.") {
+    withTempPathAsString { dataPath =>
+      import spark.implicits._
+
+      val indexConfig = IndexConfig("iceIndex", Seq("clicks"), Seq("Query"))
+      val dfFromSample = sampleData.toDF("Date", "RGUID", "Query", "imprs", "clicks")
+
+      val iceTable = createIcebergTable(dataPath, dfFromSample)
+      dfFromSample.write.format("iceberg").mode("overwrite").save(dataPath)
+
+      val iceDf = spark.read.format("iceberg").load(dataPath)
+      hyperspace.createIndex(iceDf, indexConfig)
+
+      withIndex("iceIndex") {
+        def query(version: Option[Long] = None): DataFrame = {
+          if (version.isDefined) {
+            val iceDf =
+              spark.read.format("iceberg").option("snapshot-id", version.get).load(dataPath)
+            iceDf.filter(iceDf("clicks") <= 2000).select(iceDf("query"))
+          } else {
+            val iceDf = spark.read.format("iceberg").load(dataPath)
+            iceDf.filter(iceDf("clicks") <= 2000).select(iceDf("query"))
+          }
+        }
+
+        assert(isIndexUsed(query().queryExecution.optimizedPlan, indexConfig.indexName))
+
+        val currentIceSnapshot = iceTable.currentSnapshot()
+        val fileToDelete =
+          currentIceSnapshot.addedFiles().asScala.toSeq.map(_.path().toString).head
+
+        // Create a new version by deleting entries.
+        iceTable.newDelete().deleteFile(fileToDelete).commit()
+
+        // The index should not be applied for the updated version.
+        assert(!isIndexUsed(query().queryExecution.optimizedPlan, indexConfig.indexName))
+
+        // The index should be applied for the version at index creation.
+        assert(
+          isIndexUsed(
+            query(Some(currentIceSnapshot.snapshotId())).queryExecution.optimizedPlan,
+            indexConfig.indexName))
+
+        hyperspace.refreshIndex(indexConfig.indexName)
+
+        // The index should be applied for the updated version.
+        assert(isIndexUsed(query().queryExecution.optimizedPlan, "iceIndex/v__=1"))
+
+        // The index should not be applied for the version at index creation.
+        assert(
+          !isIndexUsed(
+            query(Some(currentIceSnapshot.snapshotId())).queryExecution.optimizedPlan,
+            indexConfig.indexName))
+      }
+    }
+  }
+
+  test("Verify incremental refresh index properly adds hive-partition columns.") {
+    withTempPathAsString { testPath =>
+      val absoluteTestPath = PathUtils.makeAbsolute(testPath).toString
+      import spark.implicits._
+      val (testData, appendData) = SampleData.testData.partition(_._1 != "2019-10-03")
+      assert(testData.nonEmpty)
+      assert(appendData.nonEmpty)
+
+      val dfFromSample = testData
+        .toDF("Date", "RGUID", "Query", "imprs", "clicks")
+
+      createIcebergTableWithDayPartition(testPath, dfFromSample)
+
+      dfFromSample.write
+        .format("iceberg")
+        .mode("overwrite")
+        .save(testPath)
+
+      val df = spark.read.format("iceberg").load(testPath)
+      hyperspace.createIndex(df, IndexConfig("index", Seq("clicks"), Seq("Date")))
+
+      withIndex("index") {
+        // Check if partition columns are correctly stored in index contents.
+        val indexDf1 = spark.read.parquet(s"$systemPath/index").where("Date != '2019-10-03'")
+        assert(testData.size == indexDf1.count())
+        val oldEntry = latestIndexLogEntry(systemPath, "index")
+        assert(oldEntry.relations.head.options("basePath").equals(absoluteTestPath))
+
+        // Append data creating new partition and refresh index.
+        appendData
+          .toDF("Date", "RGUID", "Query", "imprs", "clicks")
+          .write
+          .mode("append")
+          .format("iceberg")
+          .save(testPath)
+        hyperspace.refreshIndex("index", "incremental")
+
+        // Check if partition columns are correctly stored in index contents.
+        val indexDf2 = spark.read.parquet(s"$systemPath/index").where("Date = '2019-10-03'")
+        assert(appendData.size == indexDf2.count())
+        val newEntry = latestIndexLogEntry(systemPath, "index")
+        assert(newEntry.relations.head.options("basePath").equals(absoluteTestPath))
+      }
+    }
+  }
+
+  test(
+    "Verify JoinIndexRule utilizes indexes correctly after quick refresh when some file " +
+      "gets deleted and some appended to source data.") {
+    withTempPathAsString { testPath =>
+      import spark.implicits._
+
+      val indexConfig = IndexConfig("index", Seq("c2"), Seq("c4"))
+      val dfFromSample = SampleData.testData.toDF("c1", "c2", "c3", "c4", "c5").limit(10)
+
+      val iceTable = createIcebergTable(testPath, dfFromSample)
+      dfFromSample.write.format("iceberg").mode("overwrite").save(testPath)
+
+      val df = spark.read.format("iceberg").load(testPath)
+      val oldFiles = iceTable.currentSnapshot().addedFiles().asScala.toSeq.map(_.path().toString)
+
+      withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
+        hyperspace.createIndex(df, indexConfig)
+      }
+
+      withIndex(indexConfig.indexName) {
+        // Create a new version by deleting a file.
+        iceTable.newDelete().deleteFile(oldFiles.head).commit()
+
+        // Append to original data.
+        SampleData.testData
+          .toDF("c1", "c2", "c3", "c4", "c5")
+          .limit(3)
+          .write
+          .format("iceberg")
+          .mode("append")
+          .save(testPath)
+
+        // Refresh index.
+        hyperspace.refreshIndex(indexConfig.indexName, REFRESH_MODE_QUICK)
+
+        {
+          // Create a join query.
+          val leftDf = spark.read.format("iceberg").load(testPath)
+          val rightDf = spark.read.format("iceberg").load(testPath)
+
+          def query(): DataFrame = {
+            leftDf
+              .join(rightDf, leftDf("c2") === rightDf("c2"))
+              .select(leftDf("c2"), rightDf("c4"))
+          }
+
+          val appendedFiles = leftDf.inputFiles.diff(oldFiles)
+
+          // Verify indexes are used, and all index files are picked.
+          isIndexUsed(
+            query().queryExecution.optimizedPlan,
+            s"${indexConfig.indexName}/v__=0" +: appendedFiles: _*)
+
+          // Verify correctness of results.
+          spark.disableHyperspace()
+          val dfWithHyperspaceDisabled = query()
+          spark.enableHyperspace()
+          val dfWithHyperspaceEnabled = query()
+          checkAnswer(dfWithHyperspaceDisabled, dfWithHyperspaceEnabled)
+        }
+
+        // Append to original data again.
+        SampleData.testData
+          .toDF("c1", "c2", "c3", "c4", "c5")
+          .limit(1)
+          .write
+          .mode("append")
+          .format("iceberg")
+          .save(testPath)
+
+        {
+          // Create a join query with updated dataset.
+          val leftDf = spark.read.format("iceberg").load(testPath)
+          val rightDf = spark.read.format("iceberg").load(testPath)
+
+          def query(): DataFrame = {
+            leftDf
+              .join(rightDf, leftDf("c2") === rightDf("c2"))
+              .select(leftDf("c2"), rightDf("c4"))
+          }
+
+          // Refreshed index as quick mode won't be applied with additional appended files.
+          withSQLConf(IndexConstants.INDEX_HYBRID_SCAN_ENABLED -> "false") {
+            spark.disableHyperspace()
+            val dfWithHyperspaceDisabled = query()
+            val basePlan = dfWithHyperspaceDisabled.queryExecution.optimizedPlan
+            spark.enableHyperspace()
+            val dfWithHyperspaceEnabled = query()
+            assert(basePlan.equals(dfWithHyperspaceEnabled.queryExecution.optimizedPlan))
+          }
+
+          // Refreshed index as quick mode can be applied with Hybrid Scan config.
+          withSQLConf(TestConfig.HybridScanEnabled: _*) {
+            spark.disableHyperspace()
+            val dfWithHyperspaceDisabled = query()
+            val basePlan = dfWithHyperspaceDisabled.queryExecution.optimizedPlan
+            spark.enableHyperspace()
+            val dfWithHyperspaceEnabled = query()
+            assert(!basePlan.equals(dfWithHyperspaceEnabled.queryExecution.optimizedPlan))
+            checkAnswer(dfWithHyperspaceDisabled, dfWithHyperspaceEnabled)
+          }
+        }
+      }
+    }
+  }
+
+  test("Verify Hybrid Scan on Iceberg table.") {
+    withTempPathAsString { dataPath =>
+      import spark.implicits._
+      val dfFromSample = sampleData.toDF("Date", "RGUID", "Query", "imprs", "clicks")
+
+      val iceTable = createIcebergTable(dataPath, dfFromSample)
+      dfFromSample.write.format("iceberg").mode("overwrite").save(dataPath)
+
+      val iceDf = spark.read.format("iceberg").load(dataPath)
+      withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
+        hyperspace.createIndex(iceDf, IndexConfig("iceIndex", Seq("clicks"), Seq("Query")))
+      }
+
+      withIndex("iceIndex") {
+        def query(version: Option[Long] = None): DataFrame = {
+          if (version.isDefined) {
+            val iceDf =
+              spark.read.format("iceberg").option("snapshot-id", version.get).load(dataPath)
+            iceDf.filter(iceDf("clicks") <= 2000).select(iceDf("query"))
+          } else {
+            val iceDf = spark.read.format("iceberg").load(dataPath)
+            iceDf.filter(iceDf("clicks") <= 2000).select(iceDf("query"))
+          }
+        }
+
+        assert(isIndexUsed(query().queryExecution.optimizedPlan, "iceIndex"))
+
+        // Create a new version by deleting a file.
+        val file = iceTable
+          .currentSnapshot()
+          .addedFiles()
+          .iterator()
+          .asScala
+          .toSeq
+          .map(_.path().toString)
+          .head
+        iceTable.newDelete().deleteFile(file).commit()
+
+        withSQLConf(TestConfig.HybridScanEnabled: _*) {
+          // The index should be applied for the updated version.
+          assert(isIndexUsed(query().queryExecution.optimizedPlan, "iceIndex"))
+
+          // Append data.
+          dfFromSample
+            .limit(3)
+            .write
+            .format("iceberg")
+            .mode("append")
+            .save(dataPath)
+
+          iceTable.refresh()
+          val appendedFiles = iceTable
+            .currentSnapshot()
+            .addedFiles()
+            .asScala
+            .toSeq
+            .map(_.path().toString)
+
+          // The index should be applied for the updated version.
+          assert(
+            isIndexUsed(query().queryExecution.optimizedPlan, "iceIndex" +: appendedFiles: _*))
+        }
+      }
+    }
+  }
+
+  test("Explain is correct") {
+    withTempPathAsString { dataPath =>
+      spark.conf.set("spark.sql.autoBroadcastJoinThreshold", -1)
+      spark.disableHyperspace()
+
+      import spark.implicits._
+
+      val sampleData = Seq(("data1", 1), ("data2", 2), ("data3", 3))
+      val dfFromSample = sampleData.toDF("Col1", "Col2")
+
+      createIcebergTable(dataPath, dfFromSample)
+
+      dfFromSample.write.format("iceberg").mode("overwrite").save(dataPath)
+
+      val iceDf = spark.read.format("iceberg").load(dataPath)
+
+      val indexConfig = IndexConfig("joinIndex", Seq("Col1"), Seq("Col2"))
+      hyperspace.createIndex(iceDf, indexConfig)
+
+      val defaultDisplayMode = new PlainTextMode(getHighlightConf("", ""))
+
+      // Constructing expected output for given query from explain API
+      val expectedOutput = new StringBuilder
+      val joinIndexFilePath = getIndexFilesPath("joinIndex")
+      val joinIndexPath = getIndexRootPath("joinIndex")
+
+      // The format of the explain output looks as follows:
+      // scalastyle:off filelinelengthchecker
+      expectedOutput
+        .append("=============================================================")
+        .append(defaultDisplayMode.newLine)
+        .append("Plan with indexes:")
+        .append(defaultDisplayMode.newLine)
+        .append("=============================================================")
+        .append(defaultDisplayMode.newLine)
+        .append("SortMergeJoin [Col1#11], [Col1#21], Inner")
+        .append(defaultDisplayMode.newLine)
+        .append("<----:- *(1) Project [Col1#11, Col2#12]---->")
+        .append(defaultDisplayMode.newLine)
+        .append("<----:  +- *(1) Filter isnotnull(Col1#11)---->")
+        .append(defaultDisplayMode.newLine)
+        .append(s"<----:     +- *(1) FileScan Hyperspace(Type: CI, Name: joinIndex, LogVersion: 1) [Col1#11,Col2#12] Batched: true, Format: Parquet, Location: " +
+          truncate(s"InMemoryFileIndex[$joinIndexFilePath]") +
+          ", PartitionFilters: [], PushedFilters: [IsNotNull(Col1)], ReadSchema: struct<Col1:string,Col2:int>, SelectedBucketsCount: 200 out of 200---->")
+        .append(defaultDisplayMode.newLine)
+        .append("<----+- *(2) Project [Col1#21, Col2#22]---->")
+        .append(defaultDisplayMode.newLine)
+        .append("   <----+- *(2) Filter isnotnull(Col1#21)---->")
+        .append(defaultDisplayMode.newLine)
+        .append(s"      <----+- *(2) FileScan Hyperspace(Type: CI, Name: joinIndex, LogVersion: 1) [Col1#21,Col2#22] Batched: true, Format: Parquet, Location: " +
+          truncate(s"InMemoryFileIndex[$joinIndexFilePath]") +
+          ", PartitionFilters: [], PushedFilters: [IsNotNull(Col1)], ReadSchema: struct<Col1:string,Col2:int>, SelectedBucketsCount: 200 out of 200---->")
+        .append(defaultDisplayMode.newLine)
+        .append(defaultDisplayMode.newLine)
+        .append("=============================================================")
+        .append(defaultDisplayMode.newLine)
+        .append("Plan without indexes:")
+        .append(defaultDisplayMode.newLine)
+        .append("=============================================================")
+        .append(defaultDisplayMode.newLine)
+        .append("SortMergeJoin [Col1#11], [Col1#21], Inner")
+        .append(defaultDisplayMode.newLine)
+        .append("<----:- *(1) Sort [Col1#11 ASC NULLS FIRST], false, 0---->")
+        .append(defaultDisplayMode.newLine)
+        .append("<----:  +- *(1) Project [Col1#1, Col2#2]---->")
+        .append(defaultDisplayMode.newLine)
+        .append("<----:     +- *(1) Filter isnotnull(Col1#1)---->")
+        .append(defaultDisplayMode.newLine)
+        .append("<----:        +- *(1) ScanV2 iceberg[Col1#, Col2#] (Filters: [isnotnull(Col1#)], Options: " +
+            truncate(s"[path=$dataPath,paths=[]]") + ")---->")
+        .append(defaultDisplayMode.newLine)
+        .append("<----+- *(2) Sort [Col1#21 ASC NULLS FIRST], false, 0---->")
+        .append(defaultDisplayMode.newLine)
+        .append("   <----+- *(2) Project [Col1#, Col2#]---->")
+        .append(defaultDisplayMode.newLine)
+        .append("      <----+- *(2) Filter isnotnull(Col1#)---->")
+        .append(defaultDisplayMode.newLine)
+        .append("         <----+- *(2) ScanV2 iceberg[Col1#, Col2#] (Filters: [isnotnull(Col1#)], Options: " +
+            truncate(s"[path=$dataPath,paths=[]]") + ")---->")
+        .append(defaultDisplayMode.newLine)
+        .append(defaultDisplayMode.newLine)
+        .append("=============================================================")
+        .append(defaultDisplayMode.newLine)
+        .append("Indexes used:")
+        .append(defaultDisplayMode.newLine)
+        .append("=============================================================")
+        .append(defaultDisplayMode.newLine)
+        .append(s"joinIndex:$joinIndexPath")
+        .append(defaultDisplayMode.newLine)
+        .append(defaultDisplayMode.newLine)
+        .append("=============================================================")
+        .append(defaultDisplayMode.newLine)
+        .append("Physical operator stats:")
+        .append(defaultDisplayMode.newLine)
+        .append("=============================================================")
+        .append(defaultDisplayMode.newLine)
+        .append("+----------------------------------------------------------+-------------------+------------------+----------+")
+        .append(defaultDisplayMode.newLine)
+        .append("|                                         Physical Operator|Hyperspace Disabled|Hyperspace Enabled|Difference|")
+        .append(defaultDisplayMode.newLine)
+        .append("+----------------------------------------------------------+-------------------+------------------+----------+")
+        .append(defaultDisplayMode.newLine)
+        .append("|                                         *DataSourceV2Scan|                  2|                 0|        -2|")
+        .append(defaultDisplayMode.newLine)
+        .append("|*Scan Hyperspace(Type: CI, Name: joinIndex, LogVersion: 1)|                  0|                 2|         2|")
+        .append(defaultDisplayMode.newLine)
+        .append("|                                                     *Sort|                  2|                 0|        -2|")
+        .append(defaultDisplayMode.newLine)
+        .append("|                                                    Filter|                  2|                 2|         0|")
+        .append(defaultDisplayMode.newLine)
+        .append("|                                              InputAdapter|                  2|                 2|         0|")
+        .append(defaultDisplayMode.newLine)
+        .append("|                                                   Project|                  2|                 2|         0|")
+        .append(defaultDisplayMode.newLine)
+        .append("|                                             SortMergeJoin|                  1|                 1|         0|")
+        .append(defaultDisplayMode.newLine)
+        .append("|                                         WholeStageCodegen|                  3|                 3|         0|")
+        .append(defaultDisplayMode.newLine)
+        .append("+----------------------------------------------------------+-------------------+------------------+----------+")
+        .append(defaultDisplayMode.newLine)
+        .append(defaultDisplayMode.newLine)
+      // scalastyle:on filelinelengthchecker
+
+      val selfJoinDf = iceDf.join(iceDf, iceDf("Col1") === iceDf("Col1"))
+      verifyExplainOutput(selfJoinDf, expectedOutput.toString(), verbose = true) { df =>
+        df
+      }
+    }
+  }
+
+  def isIndexUsed(plan: LogicalPlan, expectedPathsSubStr: String*): Boolean = {
+    val rootPaths = plan.collect {
+      case LogicalRelation(
+          HadoopFsRelation(location: InMemoryFileIndex, _, _, _, _, _),
+          _,
+          _,
+          _) =>
+        location.rootPaths
+    }.flatten
+    rootPaths.nonEmpty && rootPaths.forall(p =>
+      expectedPathsSubStr.exists(p.toString.contains(_))) && expectedPathsSubStr.forall(p =>
+      rootPaths.exists(_.toString.contains(p)))
+  }
+
+  def createIcebergTable(dataPath: String, sourceDf: DataFrame): Table = {
+    val props = Map(TableProperties.WRITE_NEW_DATA_LOCATION -> dataPath).asJava
+    val schema = SparkSchemaUtil.convert(sourceDf.schema)
+    val part = IcebergPartitionSpec.builderFor(schema).build()
+    new HadoopTables().create(schema, part, props, dataPath)
+  }
+
+  def createIcebergTableWithDayPartition(dataPath: String, sourceDf: DataFrame): Table = {
+    val props = Map(TableProperties.WRITE_NEW_DATA_LOCATION -> dataPath).asJava
+    val schema = SparkSchemaUtil.convert(sourceDf.schema)
+    val part = IcebergPartitionSpec.builderFor(schema).identity("Date").build()
+    new HadoopTables().create(schema, part, props, dataPath)
+  }
+
+  private def truncate(s: String): String = {
+    StringUtils.abbreviate(s, 100)
+  }
+
+  private def getHighlightConf(
+      highlightBegin: String,
+      highlightEnd: String): Map[String, String] = {
+    Map[String, String](
+      IndexConstants.HIGHLIGHT_BEGIN_TAG -> highlightBegin,
+      IndexConstants.HIGHLIGHT_END_TAG -> highlightEnd)
+  }
+
+  private def getIndexRootPath(indexName: String): Path =
+    new Path(systemPath, s"$indexName/v__=0")
+
+  private def getIndexFilesPath(indexName: String): Path = {
+    val path = getIndexRootPath(indexName)
+    val fs = path.getFileSystem(new Configuration)
+    // Pick any files path but remove the _SUCCESS file.
+    fs.listStatus(path).filter(s => DataPathFilter.accept(s.getPath)).head.getPath
+  }
+
+  private def verifyExplainOutput(df: DataFrame, expected: String, verbose: Boolean)(
+      query: DataFrame => DataFrame) {
+    def normalize(str: String): String = {
+      // Expression ids are removed before comparison since they can be different for each run.
+      str.replaceAll("""#(\d+)|subquery(\d+)""", "#")
+    }
+
+    val dfWithHyperspaceDisabled = query(df)
+    val actual1 =
+      PlanAnalyzer.explainString(dfWithHyperspaceDisabled, spark, hyperspace.indexes, verbose)
+    assert(!spark.isHyperspaceEnabled())
+    assert(normalize(actual1) === normalize(expected))
+
+    // Run with Hyperspace enabled and it shouldn't affect the result of `explainString`.
+    spark.enableHyperspace()
+    val dfWithHyperspaceEnabled = query(df)
+    val actual2 =
+      PlanAnalyzer.explainString(dfWithHyperspaceEnabled, spark, hyperspace.indexes, verbose)
+    assert(spark.isHyperspaceEnabled())
+    assert(normalize(actual2) === normalize(expected))
+  }
+}


### PR DESCRIPTION
### What is the context for this pull request?

 - **Tracking Issue**: #306
 - **Proposal**: #318
 - **Dependencies**: #355 
 - Fixes: #306
 - Fixes: #318
 - Closes: #321 
 - Closes: #320 

### What changes were proposed in this pull request?

This PR adds support for Iceberg.

The following changes are in this PR and each of them are separate commits:

- Add Iceberg source.
- Add support for incremental refresh. This is based on #301 PR from @sezruby.
- Add integration test

### Does this PR introduce _any_ user-facing change?

No. The main changes to user-facing APIs are in the #321 PR. Detailed information can be found in the #318 proposal.

### How was this patch tested?

1. Integration test added for the new functionality
2. Locally & Databricks Runtime tests

- Local build

```
sbt publishLocal
```

- Run Spark shell with Hyperspace and Iceberg libraries loaded

```
$ spark-shell \
--driver-memory 4g \
--packages "com.microsoft.hyperspace:hyperspace-core_2.11:0.4.0-SNAPSHOT,org.apache.iceberg:iceberg-spark-runtime:0.10.0" \
--driver-java-options "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006 -XX:+UseG1GC -Dlog4j.debug=true"
```

- Paste the following code

```
import org.apache.spark.sql._
import com.microsoft.hyperspace._
import com.microsoft.hyperspace.index._
import scala.collection.JavaConverters._
import org.apache.iceberg.PartitionSpec
import org.apache.iceberg.TableProperties
import org.apache.iceberg.spark._
import org.apache.iceberg.hadoop._

val hs = new Hyperspace(spark)

// create Iceberg table
val props = Map(TableProperties.WRITE_NEW_DATA_LOCATION -> "table3").asJava
val sourceDf = Seq((1, "name1"), (2, "name2")).toDF("id", "name")
val schema = SparkSchemaUtil.convert(sourceDf.schema)
val part = PartitionSpec.builderFor(schema).build()
val icebergTable = new HadoopTables().create(schema, part, props, "table3")
sourceDf.write.mode("overwrite").format("iceberg").save("./table3")

// read created table
val iceDf = spark.read.format("iceberg").load("./table3")

// create indexes
hs.createIndex(iceDf, IndexConfig("index_ice0", indexedColumns = Seq("id"), includedColumns = Seq("name")))
hs.createIndex(iceDf, IndexConfig("index_ice1", indexedColumns = Seq("name")))

// verify plans
val query = iceDf.filter(iceDf("id") === 1).select("name")
hs.explain(query, verbose = true)
```
