### PR TITLE
Add a sbt-buildinfo plugin to generate BuildInfo object

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,34 +27,37 @@ scalaVersion := scala212
 crossScalaVersions := supportedScalaVersions
 
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided" withSources(),
-  "org.apache.spark" %% "spark-core" % sparkVersion.value % "provided" withSources(),
-  "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "provided" withSources(),
-  "io.delta" %% "delta-core" % "0.6.1" % "provided" withSources(),
-  "org.apache.iceberg" % "iceberg-spark-runtime" % "0.11.0" % "provided" withSources(),
-
+  "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided" withSources (),
+  "org.apache.spark" %% "spark-core" % sparkVersion.value % "provided" withSources (),
+  "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "provided" withSources (),
+  "io.delta" %% "delta-core" % "0.6.1" % "provided" withSources (),
+  "org.apache.iceberg" % "iceberg-spark-runtime" % "0.11.0" % "provided" withSources (),
   // Test dependencies
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "org.mockito" %% "mockito-scala" % "0.4.0" % "test",
   "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "test" classifier "tests",
   "org.apache.spark" %% "spark-core" % sparkVersion.value % "test" classifier "tests",
-  "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test" classifier "tests"
-)
+  "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test" classifier "tests")
 
 assemblyMergeStrategy in assembly := {
   case PathList("run-tests.py") => MergeStrategy.first
   case x => (assemblyMergeStrategy in assembly).value(x)
 }
 
-scalacOptions ++= Seq(
-  "-target:jvm-1.8"
-)
+scalacOptions ++= Seq("-target:jvm-1.8")
 
 javaOptions += "-Xmx1024m"
 
-/*****************************
- * ScalaStyle configurations *
- *****************************/
+// The following creates target/scala-2.*/src_managed/main/sbt-buildinfo/BuildInfo.scala.
+lazy val root = (project in file("."))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoPackage := "com.microsoft.hyperspace")
+
+/**
+ * ScalaStyle configurations
+ */
 scalastyleConfig := baseDirectory.value / "scalastyle-config.xml"
 
 // Run as part of compile task.
@@ -67,10 +70,9 @@ lazy val testScalastyle = taskKey[Unit]("testScalastyle")
 testScalastyle := scalastyle.in(Test).toTask("").value
 (test in Test) := ((test in Test) dependsOn testScalastyle).value
 
-/***************************
-* Spark Packages settings *
-***************************/
-
+/**
+ * Spark Packages settings
+ */
 spName := "microsoft/hyperspace-core"
 
 spAppendScalaVersion := true
@@ -81,9 +83,9 @@ spIgnoreProvided := true
 
 packageBin in Compile := spPackage.value
 
-/***********************
- * Test configurations *
- ***********************/
+/**
+ * Test configurations
+ */
 // Tests cannot be run in parallel since mutiple Spark contexts cannot run in the same JVM.
 parallelExecution in Test := false
 
@@ -96,12 +98,11 @@ javaOptions in Test ++= Seq(
   "-Dspark.sql.shuffle.partitions=5",
   "-Ddelta.log.cacheSize=3",
   "-Dspark.sql.sources.parallelPartitionDiscovery.parallelism=5",
-  "-Xmx1024m"
-)
+  "-Xmx1024m")
 
-/**************************
- * Release configurations *
- **************************/
+/**
+ * Release configurations
+ */
 organization := "com.microsoft.hyperspace"
 organizationName := "Microsoft"
 organizationHomepage := Some(url("http://www.microsoft.com/"))
@@ -111,67 +112,53 @@ releaseCrossBuild := true
 scmInfo := Some(
   ScmInfo(
     url("https://github.com/microsoft/hyperspace"),
-    "scm:git@github.com:microsoft/hyperspace.git"
-  )
-)
+    "scm:git@github.com:microsoft/hyperspace.git"))
 
 developers := List(
   Developer(
-    id    = "rapoth",
-    name  = "Rahul Potharaju",
+    id = "rapoth",
+    name = "Rahul Potharaju",
     email = "",
-    url   = url("https://github.com/rapoth")
-  ),
+    url = url("https://github.com/rapoth")),
   Developer(
-    id    = "imback82",
-    name  = "Terry Kim",
+    id = "imback82",
+    name = "Terry Kim",
     email = "",
-    url   = url("https://github.com/imback82")
-  ),
+    url = url("https://github.com/imback82")),
   Developer(
-    id    = "apoorvedave1",
-    name  = "Apoorve Dave",
+    id = "apoorvedave1",
+    name = "Apoorve Dave",
     email = "",
-    url   = url("https://github.com/apoorvedave1")
-  ),
+    url = url("https://github.com/apoorvedave1")),
   Developer(
-    id    = "pirz",
-    name  = "Pouria Pirzadeh",
+    id = "AFFogarty",
+    name = "Andrew Fogarty",
     email = "",
-    url   = url("https://github.com/pirz")
-  ),
+    url = url("https://github.com/AFFogarty")),
   Developer(
-    id    = "AFFogarty",
-    name  = "Andrew Fogarty",
+    id = "laserljy",
+    name = "Jiying Li",
     email = "",
-    url   = url("https://github.com/AFFogarty")
-  ),
+    url = url("https://github.com/laserljy")),
   Developer(
-    id    = "laserljy",
-    name  = "Jiying Li",
+    id = "sezruby",
+    name = "Eunjin Song",
     email = "",
-    url   = url("https://github.com/laserljy")
-  ),
+    url = url("https://github.com/sezruby")),
   Developer(
-    id    = "sezruby",
-    name  = "Eunjin Song",
+    id = "thugsatbay",
+    name = "Gurleen Singh",
     email = "",
-    url   = url("https://github.com/sezruby")
-  ),
-  Developer(
-    id    = "thugsatbay",
-    name  = "Gurleen Singh",
-    email = "",
-    url   = url("https://github.com/thugsatbay")
-  )
-)
+    url = url("https://github.com/thugsatbay")))
 
 description := "Hyperspace: An Indexing Subsystem for Apache Spark"
 licenses := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 homepage := Some(url("https://github.com/microsoft/hyperspace"))
 
 // Remove all additional repository other than Maven Central from POM
-pomIncludeRepository := { _ => false }
+pomIncludeRepository := { _ =>
+  false
+}
 publishTo := {
   val nexus = "https://oss.sonatype.org/"
   if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
@@ -194,5 +181,4 @@ releaseProcess := Seq[ReleaseStep](
   tagRelease,
   publishArtifacts,
   setNextVersion,
-  commitNextVersion
-)
+  commitNextVersion)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,3 +23,5 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.6")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")


### PR DESCRIPTION
This PR adds `sbt-buildinfo` to generate `BuildInfo` so that the package version, etc. can be accessed programatically.

After this PR, `target/scala-2.*/src_managed/main/sbt-buildinfo/BuildInfo.scala` is auto-generated with a following content:
```
package com.microsoft.hyperspace

import scala.Predef._

/** This object was generated by sbt-buildinfo. */
case object BuildInfo {
  /** The value is "hyperspace-core". */
  val name: String = "hyperspace-core"
  /** The value is "0.5.0-SNAPSHOT". */
  val version: String = "0.5.0-SNAPSHOT"
  /** The value is "2.12.8". */
  val scalaVersion: String = "2.12.8"
  /** The value is "0.13.18". */
  val sbtVersion: String = "0.13.18"
  override val toString: String = {
    "name: %s, version: %s, scalaVersion: %s, sbtVersion: %s" format (
      name, version, scalaVersion, sbtVersion
    )
  }
}
```

Now, it can be simply accessed as `BuildInfo.version` in Hyperspace code base.