### PR TITLE
Support index creation on nested fields

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateAction.scala
@@ -19,7 +19,6 @@ package com.microsoft.hyperspace.actions
 import scala.util.Try
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.types.StructType
 
 import com.microsoft.hyperspace.{Hyperspace, HyperspaceException}
 import com.microsoft.hyperspace.actions.Constants.States.{ACTIVE, CREATING, DOESNOTEXIST}
@@ -51,7 +50,7 @@ class CreateAction(
     }
 
     // schema validity checks
-    if (!isValidIndexSchema(indexConfig, df.schema)) {
+    if (!isValidIndexSchema(indexConfig, df)) {
       throw HyperspaceException("Index config is not applicable to dataframe schema.")
     }
 
@@ -65,10 +64,13 @@ class CreateAction(
     }
   }
 
-  private def isValidIndexSchema(config: IndexConfig, schema: StructType): Boolean = {
-    // Resolve index config columns from available column names present in the schema.
+  private def isValidIndexSchema(config: IndexConfig, dataFrame: DataFrame): Boolean = {
+    // Resolve index config columns from available column names present in the dataframe.
     ResolverUtils
-      .resolve(spark, config.indexedColumns ++ config.includedColumns, schema.fieldNames)
+      .resolve(
+        spark,
+        config.indexedColumns ++ config.includedColumns,
+        dataFrame.queryExecution.analyzed)
       .isDefined
   }
 

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
@@ -93,8 +93,10 @@ private[actions] abstract class RefreshActionBase(
     val ddColumns = previousIndexLogEntry.derivedDataset.properties.columns
     IndexConfig(
       previousIndexLogEntry.name,
-      SchemaUtils.removePrefixNestedFieldNames(ddColumns.indexed),
-      SchemaUtils.removePrefixNestedFieldNames(ddColumns.included))
+      // As indexed & included columns in previousLogEntry are resolved & prefixed names,
+      // need to remove the prefix to resolve with the dataframe for refresh.
+      SchemaUtils.removePrefixNestedFieldNames(ddColumns.indexed).map(_._1),
+      SchemaUtils.removePrefixNestedFieldNames(ddColumns.included).map(_._1))
   }
 
   final override val transientState: String = REFRESHING

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshActionBase.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.types.{DataType, StructType}
 import com.microsoft.hyperspace.{Hyperspace, HyperspaceException}
 import com.microsoft.hyperspace.actions.Constants.States.{ACTIVE, REFRESHING}
 import com.microsoft.hyperspace.index._
+import com.microsoft.hyperspace.util.SchemaUtils
 
 /**
  * Base abstract class containing common code for different types of index refresh actions.
@@ -90,7 +91,10 @@ private[actions] abstract class RefreshActionBase(
 
   protected lazy val indexConfig: IndexConfig = {
     val ddColumns = previousIndexLogEntry.derivedDataset.properties.columns
-    IndexConfig(previousIndexLogEntry.name, ddColumns.indexed, ddColumns.included)
+    IndexConfig(
+      previousIndexLogEntry.name,
+      SchemaUtils.removePrefixNestedFieldNames(ddColumns.indexed),
+      SchemaUtils.removePrefixNestedFieldNames(ddColumns.included))
   }
 
   final override val transientState: String = REFRESHING

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshIncrementalAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshIncrementalAction.scala
@@ -23,6 +23,7 @@ import com.microsoft.hyperspace.{Hyperspace, HyperspaceException}
 import com.microsoft.hyperspace.index._
 import com.microsoft.hyperspace.index.DataFrameWriterExtensions.Bucketizer
 import com.microsoft.hyperspace.telemetry.{AppInfo, HyperspaceEvent, RefreshIncrementalActionEvent}
+import com.microsoft.hyperspace.util.SchemaUtils
 
 /**
  * Action to refresh indexes with newly appended files and deleted files in an incremental way.
@@ -91,7 +92,7 @@ class RefreshIncrementalAction(
         refreshDF,
         indexDataPath.toString,
         previousIndexLogEntry.numBuckets,
-        indexConfig.indexedColumns,
+        SchemaUtils.prefixNestedFieldNames(indexConfig.indexedColumns),
         writeMode)
     }
   }

--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshIncrementalAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshIncrementalAction.scala
@@ -23,7 +23,6 @@ import com.microsoft.hyperspace.{Hyperspace, HyperspaceException}
 import com.microsoft.hyperspace.index._
 import com.microsoft.hyperspace.index.DataFrameWriterExtensions.Bucketizer
 import com.microsoft.hyperspace.telemetry.{AppInfo, HyperspaceEvent, RefreshIncrementalActionEvent}
-import com.microsoft.hyperspace.util.SchemaUtils
 
 /**
  * Action to refresh indexes with newly appended files and deleted files in an incremental way.
@@ -92,7 +91,8 @@ class RefreshIncrementalAction(
         refreshDF,
         indexDataPath.toString,
         previousIndexLogEntry.numBuckets,
-        SchemaUtils.prefixNestedFieldNames(indexConfig.indexedColumns),
+        // previousIndexLogEntry should contain the resolved and prefixed field names.
+        previousIndexLogEntry.derivedDataset.properties.columns.indexed,
         writeMode)
     }
   }
@@ -114,10 +114,6 @@ class RefreshIncrementalAction(
         "Index refresh (to handle deleted source data) is " +
           "only supported on an index with lineage.")
     }
-  }
-
-  override protected def event(appInfo: AppInfo, message: String): HyperspaceEvent = {
-    RefreshIncrementalActionEvent(appInfo, logEntry.asInstanceOf[IndexLogEntry], message)
   }
 
   /**
@@ -143,5 +139,9 @@ class RefreshIncrementalAction(
       // New entry.
       entry
     }
+  }
+
+  override protected def event(appInfo: AppInfo, message: String): HyperspaceEvent = {
+    RefreshIncrementalActionEvent(appInfo, logEntry.asInstanceOf[IndexLogEntry], message)
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -557,10 +557,6 @@ case class IndexLogEntry(
     config.hashCode + signature.hashCode + numBuckets.hashCode + content.hashCode
   }
 
-  def usesNestedFields: Boolean = {
-    SchemaUtils.containsNestedFieldNames(indexedColumns ++ includedColumns)
-  }
-
   /**
    * A mutable map for holding auxiliary information of this index log entry while applying rules.
    */

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.types.{DataType, StructType}
 
 import com.microsoft.hyperspace.HyperspaceException
 import com.microsoft.hyperspace.actions.Constants
-import com.microsoft.hyperspace.util.PathUtils
+import com.microsoft.hyperspace.util.{PathUtils, SchemaUtils}
 
 // IndexLogEntry-specific fingerprint to be temporarily used where fingerprint is not defined.
 case class NoOpFingerprint() {
@@ -555,6 +555,10 @@ case class IndexLogEntry(
 
   override def hashCode(): Int = {
     config.hashCode + signature.hashCode + numBuckets.hashCode + content.hashCode
+  }
+
+  def usesNestedFields: Boolean = {
+    SchemaUtils.containsNestedFieldNames(indexedColumns ++ includedColumns)
   }
 
   /**

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -305,8 +305,8 @@ object JoinIndexRule
     val rRequiredIndexedCols = lRMap.values.toSeq
 
     // All required columns resolved with base relation.
-    val lRequiredAllCols = resolve(spark, allRequiredCols(left), leftRelation.plan).get
-    val rRequiredAllCols = resolve(spark, allRequiredCols(right), rightRelation.plan).get
+    val lRequiredAllCols = resolve(spark, allRequiredCols(left), leftRelation.plan).get.map(_._1)
+    val rRequiredAllCols = resolve(spark, allRequiredCols(right), rightRelation.plan).get.map(_._1)
 
     // Make sure required indexed columns are subset of all required columns for a subplan
     require(resolve(spark, lRequiredIndexedCols, lRequiredAllCols).isDefined)

--- a/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/rules/JoinIndexRule.scala
@@ -305,8 +305,8 @@ object JoinIndexRule
     val rRequiredIndexedCols = lRMap.values.toSeq
 
     // All required columns resolved with base relation.
-    val lRequiredAllCols = resolve(spark, allRequiredCols(left), lBaseAttrs).get
-    val rRequiredAllCols = resolve(spark, allRequiredCols(right), rBaseAttrs).get
+    val lRequiredAllCols = resolve(spark, allRequiredCols(left), leftRelation.plan).get
+    val rRequiredAllCols = resolve(spark, allRequiredCols(right), rightRelation.plan).get
 
     // Make sure required indexed columns are subset of all required columns for a subplan
     require(resolve(spark, lRequiredIndexedCols, lRequiredAllCols).isDefined)

--- a/src/main/scala/com/microsoft/hyperspace/util/ResolverUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/util/ResolverUtils.scala
@@ -18,6 +18,11 @@ package com.microsoft.hyperspace.util
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.Resolver
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Expression, ExtractValue, GetArrayStructFields, GetMapValue, GetStructField}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.types.{ArrayType, MapType, StructField, StructType}
+
+import com.microsoft.hyperspace.HyperspaceException
 
 /**
  * [[ResolverUtils]] provides utility functions to resolve strings based on spark's resolver.
@@ -70,5 +75,82 @@ object ResolverUtils {
       requiredStrings: Seq[String],
       availableStrings: Seq[String]): Option[Seq[String]] = {
     Some(requiredStrings.map(resolve(spark, _, availableStrings).getOrElse { return None }))
+  }
+
+  /**
+   * Finds all resolved strings for requiredStrings, from the given logical plan. Returns
+   * optional seq of resolved strings if all required strings are resolved, otherwise None.
+   *
+   * @param spark Spark session.
+   * @param requiredStrings List of strings to resolve.
+   * @param plan Logical plan to resolve against.
+   * @return Optional Seq of resolved strings if all required strings are resolved. Else, None.
+   */
+  def resolve(
+      spark: SparkSession,
+      requiredStrings: Seq[String],
+      plan: LogicalPlan): Option[Seq[String]] = {
+    val schema = plan.schema
+    val resolver = spark.sessionState.conf.resolver
+    val resolved = requiredStrings.map { requiredField =>
+      plan
+        .resolveQuoted(requiredField, resolver)
+        .map { expr =>
+          val resolvedColNameParts = extractColumnName(expr)
+          validateResolvedColumnName(requiredField, resolvedColNameParts)
+          getColumnNameFromSchema(schema, resolvedColNameParts, resolver).mkString(".")
+        }
+        .getOrElse { return None }
+    }
+    Some(resolved)
+  }
+
+  // Extracts the parts of a nested field access path from an expression.
+  private def extractColumnName(expr: Expression): Seq[String] = {
+    expr match {
+      case a: Attribute =>
+        Seq(a.name)
+      case g @ GetStructField(_, _, Some(name)) =>
+        extractColumnName(g.child) :+ name
+      case _: GetArrayStructFields =>
+        // TODO: Nested arrays will be supported later
+        throw HyperspaceException("Array types are not supported.")
+      case _: GetMapValue =>
+        // TODO: Nested maps will be supported later
+        throw HyperspaceException("Map types are not supported.")
+      case Alias(nested: ExtractValue, _) =>
+        extractColumnName(nested)
+    }
+  }
+
+  // Validate the resolved column name by checking if nested columns have dots in its field names.
+  private def validateResolvedColumnName(
+      origCol: String,
+      resolvedColNameParts: Seq[String]): Unit = {
+    if (resolvedColNameParts.length > 1 && resolvedColNameParts.exists(_.contains("."))) {
+      throw HyperspaceException(
+        s"Hyperspace does not support the nested column whose name contains dots: $origCol")
+    }
+  }
+
+  // Given resolved column name parts, return new column name parts using the name in the given
+  // schema to use the original name in order to preserve the casing.
+  private def getColumnNameFromSchema(
+      schema: StructType,
+      resolvedColNameParts: Seq[String],
+      resolver: Resolver): Seq[String] = resolvedColNameParts match {
+    case h :: tail =>
+      val field = schema.find(f => resolver(f.name, h)).get
+      field match {
+        case StructField(name, s: StructType, _, _) =>
+          name +: getColumnNameFromSchema(s, tail, resolver)
+        case StructField(_, _: ArrayType, _, _) =>
+          // TODO: Nested arrays will be supported later
+          throw HyperspaceException("Array types are not supported.")
+        case StructField(_, _: MapType, _, _) =>
+          // TODO: Nested maps will be supported later
+          throw HyperspaceException("Map types are not supported")
+        case f => Seq(f.name)
+      }
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/util/SchemaUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/util/SchemaUtils.scala
@@ -22,8 +22,9 @@ object SchemaUtils {
   val NESTED_FIELD_PREFIX_REGEX = "^__hs_nested\\."
 
   /**
-   * The method prefixes a nested field name. The field name must be
-   * nested (it should contain a `.`).
+   * The method prefixes a nested field name that hasn't already been prefixed.
+   * The field name must be nested (it should contain a `.` and its type
+   * should be of [[org.apache.spark.sql.types.StructType]]).
    *
    * The inverse operation is [[removePrefixNestedFieldName]].
    *
@@ -39,16 +40,23 @@ object SchemaUtils {
   }
 
   /**
-   * The method prefixes the nested field names from a collection. The field names
-   * that are not nested will not be changed.
+   * The method prefixes the nested field names from a map where the keys are
+   * the field names and the values are the nested state of that field
+   * which should be the result of [[ResolverUtils.resolve]].
+   * The field names that are not marked as nested will not be changed.
    *
-   * See [[prefixNestedFieldName]] method.
+   * See [[prefixNestedFieldName]] and [[ResolverUtils.resolve]] methods.
    *
-   * @param fieldNames The collection of field names to prefix.
+   * @param fieldNames A sequence of tuples of field names and nested status.
    * @return A collection with prefixed nested fields.
    */
-  def prefixNestedFieldNames(fieldNames: Seq[String]): Seq[String] = {
-    fieldNames.map(prefixNestedFieldName)
+  def prefixNestedFieldNames(fieldNames: Seq[(String, Boolean)]): Seq[String] = {
+    fieldNames.map {
+      case (fieldName, true) =>
+        prefixNestedFieldName(fieldName)
+      case (fieldName, false) =>
+        fieldName
+    }
   }
 
   /**
@@ -66,14 +74,21 @@ object SchemaUtils {
 
   /**
    * The method removes the prefix from a collection of prefixed nested field names.
+   * It returns the original sequence of tuples of field names and nested state.
    *
    * The inverse operation is [[prefixNestedFieldNames]].
    *
    * @param fieldNames The collection of prefixed field names.
-   * @return A collection with original nested field names.
+   * @return A sequence of tuples of field names and nested status.
    */
-  def removePrefixNestedFieldNames(fieldNames: Seq[String]): Seq[String] = {
-    fieldNames.map(removePrefixNestedFieldName)
+  def removePrefixNestedFieldNames(fieldNames: Seq[String]): Seq[(String, Boolean)] = {
+    fieldNames.map { fieldName =>
+      if (SchemaUtils.isFieldNamePrefixed(fieldName)) {
+        removePrefixNestedFieldName(fieldName) -> true
+      } else {
+        fieldName -> false
+      }
+    }
   }
 
   /**

--- a/src/main/scala/com/microsoft/hyperspace/util/SchemaUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/util/SchemaUtils.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.util
+
+object SchemaUtils {
+
+  val NESTED_FIELD_PREFIX = "__hs_nested."
+  val NESTED_FIELD_PREFIX_REGEX = "^__hs_nested\\."
+
+  /**
+   * The method prefixes a nested field name. The field name must be
+   * nested (it should contain a `.`).
+   *
+   * The inverse operation is [[removePrefixNestedFieldName]].
+   *
+   * @param fieldName The nested field name to prefix.
+   * @return A new prefixed field name.
+   */
+  def prefixNestedFieldName(fieldName: String): String = {
+    if (fieldName.contains(".") && !fieldName.startsWith(NESTED_FIELD_PREFIX)) {
+      s"$NESTED_FIELD_PREFIX$fieldName"
+    } else {
+      fieldName
+    }
+  }
+
+  /**
+   * The method prefixes the nested field names from a collection. The field names
+   * that are not nested will not be changed.
+   *
+   * See [[prefixNestedFieldName]] method.
+   *
+   * @param fieldNames The collection of field names to prefix.
+   * @return A collection with prefixed nested fields.
+   */
+  def prefixNestedFieldNames(fieldNames: Seq[String]): Seq[String] = {
+    fieldNames.map(prefixNestedFieldName)
+  }
+
+  /**
+   * The method removes the prefix from a prefixed nested field name. It returns
+   * the original nested field name.
+   *
+   * The inverse operation is [[prefixNestedFieldName]].
+   *
+   * @param fieldName The prefixed nested field name from which to remove the prefix.
+   * @return The original field name without prefix.
+   */
+  def removePrefixNestedFieldName(fieldName: String): String = {
+    fieldName.replaceAll(NESTED_FIELD_PREFIX_REGEX, "")
+  }
+
+  /**
+   * The method removes the prefix from a collection of prefixed nested field names.
+   *
+   * The inverse operation is [[prefixNestedFieldNames]].
+   *
+   * @param fieldNames The collection of prefixed field names.
+   * @return A collection with original nested field names.
+   */
+  def removePrefixNestedFieldNames(fieldNames: Seq[String]): Seq[String] = {
+    fieldNames.map(removePrefixNestedFieldName)
+  }
+
+  /**
+   * The method checks if the given field name is prefixed.
+   *
+   * @param fieldName The field name that to check for prefix.
+   * @return True if is prefixed otherwise false.
+   */
+  def isFieldNamePrefixed(fieldName: String): Boolean = {
+    fieldName.startsWith(NESTED_FIELD_PREFIX)
+  }
+
+  /**
+   * The method checks if the collection of field names contains a nested one
+   * by checking the prefix.
+   *
+   * @param fieldNames The collection of field names to check.
+   * @return True is at leas one field name is prefixed.
+   */
+  def containsNestedFieldNames(fieldNames: Seq[String]): Boolean = {
+    fieldNames.exists(isFieldNamePrefixed)
+  }
+}

--- a/src/test/scala/com/microsoft/hyperspace/SampleNestedData.scala
+++ b/src/test/scala/com/microsoft/hyperspace/SampleNestedData.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace
+
+import org.apache.spark.sql.SparkSession
+
+/**
+ * Sample data for testing.
+ */
+object SampleNestedData {
+
+  val testData = Seq(
+    ("2017-09-03", "810a20a2baa24ff3ad493bfbf064569a", "donde", 2, 1000,
+        SampleNestedDataStruct("id1", SampleNestedDataLeaf("leaf_id1", 1))),
+    ("2017-09-03", "fd093f8a05604515957083e70cb3dceb", "facebook", 1, 3000,
+        SampleNestedDataStruct("id1", SampleNestedDataLeaf("leaf_id1", 2))),
+    ("2017-09-03", "af3ed6a197a8447cba8bc8ea21fad208", "facebook", 1, 3000,
+        SampleNestedDataStruct("id2", SampleNestedDataLeaf("leaf_id7", 1))),
+    ("2017-09-03", "975134eca06c4711a0406d0464cbe7d6", "facebook", 1, 4000,
+        SampleNestedDataStruct("id2", SampleNestedDataLeaf("leaf_id7", 2))),
+    ("2018-09-03", "e90a6028e15b4f4593eef557daf5166d", "ibraco", 2, 3000,
+        SampleNestedDataStruct("id2", SampleNestedDataLeaf("leaf_id7", 5))),
+    ("2018-09-03", "576ed96b0d5340aa98a47de15c9f87ce", "facebook", 2, 3000,
+        SampleNestedDataStruct("id2", SampleNestedDataLeaf("leaf_id9", 1))),
+    ("2018-09-03", "50d690516ca641438166049a6303650c", "ibraco", 2, 1000,
+        SampleNestedDataStruct("id3", SampleNestedDataLeaf("leaf_id9", 10))),
+    ("2019-10-03", "380786e6495d4cd8a5dd4cc8d3d12917", "facebook", 2, 3000,
+        SampleNestedDataStruct("id4", SampleNestedDataLeaf("leaf_id9", 12))),
+    ("2019-10-03", "ff60e4838b92421eafc3e6ee59a9e9f1", "miperro", 2, 2000,
+        SampleNestedDataStruct("id5", SampleNestedDataLeaf("leaf_id9", 21))),
+    ("2019-10-03", "187696fe0a6a40cc9516bc6e47c70bc1", "facebook", 4, 3000,
+        SampleNestedDataStruct("id6", SampleNestedDataLeaf("leaf_id9", 22))))
+
+  def save(
+      spark: SparkSession,
+      path: String,
+      columns: Seq[String],
+      partitionColumns: Option[Seq[String]] = None): Unit = {
+    val df = spark.createDataFrame(
+      spark.sparkContext.parallelize(testData)
+    ).toDF(columns: _*)
+    partitionColumns match {
+      case Some(pcs) =>
+        df.write.partitionBy(pcs: _*).parquet(path)
+      case None =>
+        df.write.parquet(path)
+    }
+  }
+}
+
+case class SampleNestedDataStruct(id: String, leaf: SampleNestedDataLeaf)
+case class SampleNestedDataLeaf(id: String, cnt: Int)

--- a/src/test/scala/com/microsoft/hyperspace/actions/CreateActionTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/actions/CreateActionTest.scala
@@ -125,7 +125,13 @@ class CreateActionTest extends SparkFunSuite with SparkInvolvedSuite with SQLHel
       val ex = intercept[HyperspaceException](action.op())
       assert(
         ex.getMessage.contains("Columns 'rgUID,dATE' could not be resolved from available " +
-          "source columns 'Date,RGUID,Query,imprs,clicks'"))
+          "source columns:\n" +
+            "root\n " +
+            "|-- Date: string (nullable = true)\n " +
+            "|-- RGUID: string (nullable = true)\n " +
+            "|-- Query: string (nullable = true)\n " +
+            "|-- imprs: integer (nullable = true)\n " +
+            "|-- clicks: integer (nullable = true)"))
     }
   }
 

--- a/src/test/scala/com/microsoft/hyperspace/index/CreateIndexNestedTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/CreateIndexNestedTest.scala
@@ -16,6 +16,7 @@
 
 package com.microsoft.hyperspace.index
 
+import scala.collection.immutable.ListMap
 import scala.collection.mutable.WrappedArray
 
 import org.apache.hadoop.conf.Configuration
@@ -159,8 +160,9 @@ class CreateIndexNestedTest extends HyperspaceSuite with SQLHelper {
       // should be added to index schema if they are not already among index config columns.
       assert(
         indexRecordsDF.schema.fieldNames.sorted ===
-          (SchemaUtils.prefixNestedFieldNames(indexConfig2.indexedColumns ++
-            indexConfig2.includedColumns) ++
+          (SchemaUtils.prefixNestedFieldNames(
+            indexConfig2.indexedColumns.zip(Seq(true)) ++
+            indexConfig2.includedColumns.zip(Seq(true))) ++
             Seq(IndexConstants.DATA_FILE_NAME_ID) ++ partitionKeys).sorted)
     }
   }
@@ -174,8 +176,9 @@ class CreateIndexNestedTest extends HyperspaceSuite with SQLHelper {
       // For non-partitioned data, only file name lineage column should be added to index schema.
       assert(
         indexRecordsDF.schema.fieldNames.sorted ===
-          (SchemaUtils.prefixNestedFieldNames(indexConfig1.indexedColumns ++
-            indexConfig1.includedColumns) ++
+          (SchemaUtils.prefixNestedFieldNames(
+            indexConfig1.indexedColumns.zip(Seq(true)) ++
+            indexConfig1.includedColumns.zip(Seq(false, true))) ++
             Seq(IndexConstants.DATA_FILE_NAME_ID)).sorted)
     }
   }

--- a/src/test/scala/com/microsoft/hyperspace/index/CreateIndexNestedTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/CreateIndexNestedTest.scala
@@ -1,0 +1,207 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index
+
+import scala.collection.mutable.WrappedArray
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.catalyst.plans.SQLHelper
+import org.apache.spark.sql.functions._
+
+import com.microsoft.hyperspace.{Hyperspace, HyperspaceException, SampleNestedData}
+import com.microsoft.hyperspace.util.{FileUtils, SchemaUtils}
+
+class CreateIndexNestedTest extends HyperspaceSuite with SQLHelper {
+  override val systemPath = new Path("src/test/resources/indexLocation")
+  private val testDir = "src/test/resources/createIndexTests/"
+  private val nonPartitionedDataPath = testDir + "samplenestedparquet"
+  private val partitionedDataPath = testDir + "samplenestedpartitionedparquet"
+  private val partitionKeys = Seq("Date", "Query")
+  private val indexConfig1 =
+    IndexConfig("index1", Seq("nested.leaf.id"), Seq("Date", "nested.leaf.cnt"))
+  private val indexConfig2 = IndexConfig("index3", Seq("nested.leaf.id"), Seq("nested.leaf.cnt"))
+  private var nonPartitionedDataDF: DataFrame = _
+  private var partitionedDataDF: DataFrame = _
+  private var hyperspace: Hyperspace = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    hyperspace = new Hyperspace(spark)
+    FileUtils.delete(new Path(testDir), isRecursive = true)
+
+    val dataColumns = Seq("Date", "RGUID", "Query", "imprs", "clicks", "nested")
+    // Save test data non-partitioned.
+    SampleNestedData.save(spark, nonPartitionedDataPath, dataColumns)
+    nonPartitionedDataDF = spark.read.parquet(nonPartitionedDataPath)
+
+    // Save test data partitioned.
+    SampleNestedData.save(spark, partitionedDataPath, dataColumns, Some(partitionKeys))
+    partitionedDataDF = spark.read.parquet(partitionedDataPath)
+  }
+
+  override def afterAll(): Unit = {
+    FileUtils.delete(new Path(testDir), isRecursive = true)
+    super.afterAll()
+  }
+
+  after {
+    FileUtils.delete(systemPath)
+  }
+
+  test("Index creation with nested indexed and included columns.") {
+    hyperspace.createIndex(nonPartitionedDataDF, indexConfig1)
+    assert(hyperspace.indexes.where(s"name = 'index1' ").count == 1)
+    assert(
+      hyperspace.indexes
+        .where(array_contains(col("indexedColumns"), "__hs_nested.nested.leaf.id"))
+        .count == 1)
+    assert(
+      hyperspace.indexes
+        .where(array_contains(col("includedColumns"), "__hs_nested.nested.leaf.cnt"))
+        .count == 1)
+    val colTypes = hyperspace.indexes
+      .select("schema")
+      .collect()
+      .map(r => r.getString(0))
+      .head
+    assert(colTypes.contains("__hs_nested.nested.leaf.id"))
+    assert(colTypes.contains("__hs_nested.nested.leaf.cnt"))
+  }
+
+  test("Index creation passes with columns of different case if case-sensitivity is false.") {
+    hyperspace.createIndex(
+      nonPartitionedDataDF,
+      IndexConfig("index1", Seq("Nested.leaF.id"), Seq("nested.leaf.CNT")))
+    val indexes = hyperspace.indexes.where(s"name = 'index1' ")
+    assert(indexes.count == 1)
+    assert(
+      indexes.head
+        .getAs[WrappedArray[String]]("indexedColumns")
+        .head == "__hs_nested.nested.leaf.id",
+      "Indexed columns with wrong case are stored in metadata")
+    assert(
+      indexes.head
+        .getAs[WrappedArray[String]]("includedColumns")
+        .head == "__hs_nested.nested.leaf.cnt",
+      "Included columns with wrong case are stored in metadata")
+  }
+
+  test("Index creation fails with columns of different case if case-sensitivity is true.") {
+    withSQLConf("spark.sql.caseSensitive" -> "true") {
+      val exception = intercept[HyperspaceException] {
+        hyperspace.createIndex(
+          nonPartitionedDataDF,
+          IndexConfig("index1", Seq("Nested.leaF.id"), Seq("nested.leaf.CNT")))
+      }
+      assert(exception.getMessage.contains("Index config is not applicable to dataframe schema."))
+    }
+  }
+
+  test("Index creation fails since the dataframe has a filter node.") {
+    val dfWithFilter = nonPartitionedDataDF.filter("nested.leaf.id='leaf_id1'")
+    val exception = intercept[HyperspaceException] {
+      hyperspace.createIndex(dfWithFilter, indexConfig1)
+    }
+    assert(
+      exception.getMessage.contains(
+        "Only creating index over HDFS file based scan nodes is supported."))
+  }
+
+  test("Index creation fails since the dataframe has a projection node.") {
+    val dfWithSelect = nonPartitionedDataDF.select("nested.leaf.id")
+    val exception = intercept[HyperspaceException] {
+      hyperspace.createIndex(dfWithSelect, indexConfig1)
+    }
+    assert(
+      exception.getMessage.contains(
+        "Only creating index over HDFS file based scan nodes is supported."))
+  }
+
+  test("Index creation fails since the dataframe has a join node.") {
+    val dfJoin = nonPartitionedDataDF
+      .join(nonPartitionedDataDF, nonPartitionedDataDF("Query") === nonPartitionedDataDF("Query"))
+      .select(
+        nonPartitionedDataDF("RGUID"),
+        nonPartitionedDataDF("Query"),
+        nonPartitionedDataDF("nested.leaf.cnt"))
+    val exception = intercept[HyperspaceException] {
+      hyperspace.createIndex(dfJoin, indexConfig1)
+    }
+    assert(
+      exception.getMessage.contains(
+        "Only creating index over HDFS file based scan nodes is supported."))
+  }
+
+  test("Check lineage in index records for partitioned data when partition key is not in config.") {
+    withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
+      hyperspace.createIndex(partitionedDataDF, indexConfig2)
+      val indexRecordsDF = spark.read.parquet(
+        s"$systemPath/${indexConfig2.indexName}/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0")
+
+      // For partitioned data, beside file name lineage column all partition keys columns
+      // should be added to index schema if they are not already among index config columns.
+      assert(
+        indexRecordsDF.schema.fieldNames.sorted ===
+          (SchemaUtils.prefixNestedFieldNames(indexConfig2.indexedColumns ++
+            indexConfig2.includedColumns) ++
+            Seq(IndexConstants.DATA_FILE_NAME_ID) ++ partitionKeys).sorted)
+    }
+  }
+
+  test("Check lineage in index records for non-partitioned data.") {
+    withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
+      hyperspace.createIndex(nonPartitionedDataDF, indexConfig1)
+      val indexRecordsDF = spark.read.parquet(
+        s"$systemPath/${indexConfig1.indexName}/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0")
+
+      // For non-partitioned data, only file name lineage column should be added to index schema.
+      assert(
+        indexRecordsDF.schema.fieldNames.sorted ===
+          (SchemaUtils.prefixNestedFieldNames(indexConfig1.indexedColumns ++
+            indexConfig1.includedColumns) ++
+            Seq(IndexConstants.DATA_FILE_NAME_ID)).sorted)
+    }
+  }
+
+  test("Verify content of lineage column.") {
+    withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
+      val dataPath = new Path(nonPartitionedDataPath, "*parquet")
+      val dataFilesCount = dataPath
+        .getFileSystem(new Configuration)
+        .globStatus(dataPath)
+        .length
+        .toLong
+
+      // File ids are assigned incrementally starting from 0.
+      val lineageRange = 0L to dataFilesCount
+
+      hyperspace.createIndex(nonPartitionedDataDF, indexConfig1)
+      val indexRecordsDF = spark.read.parquet(
+        s"$systemPath/${indexConfig1.indexName}/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0")
+      val lineageValues = indexRecordsDF
+        .select(IndexConstants.DATA_FILE_NAME_ID)
+        .distinct()
+        .collect()
+        .map(r => r.getLong(0))
+
+      lineageValues.forall(lineageRange.contains(_))
+    }
+  }
+}

--- a/src/test/scala/com/microsoft/hyperspace/index/RefreshIndexNestedTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/RefreshIndexNestedTest.scala
@@ -1,0 +1,497 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.spark.sql.{AnalysisException, QueryTest}
+
+import com.microsoft.hyperspace.{Hyperspace, HyperspaceException, MockEventLogger, SampleNestedData, TestUtils}
+import com.microsoft.hyperspace.TestUtils.{getFileIdTracker, logManager}
+import com.microsoft.hyperspace.actions.{RefreshIncrementalAction, RefreshQuickAction}
+import com.microsoft.hyperspace.index.IndexConstants.REFRESH_MODE_INCREMENTAL
+import com.microsoft.hyperspace.telemetry.RefreshIncrementalActionEvent
+import com.microsoft.hyperspace.util.{FileUtils, PathUtils}
+import com.microsoft.hyperspace.util.PathUtils.DataPathFilter
+
+/**
+ * Unit E2E test cases for RefreshIndex.
+ */
+class RefreshIndexNestedTest extends QueryTest with HyperspaceSuite {
+  override val systemPath = new Path("src/test/resources/indexLocation")
+  private val testDir = "src/test/resources/RefreshIndexDeleteTests/"
+  private val nonPartitionedDataPath = testDir + "nonpartitioned"
+  private val partitionedDataPath = testDir + "partitioned"
+  private val indexConfig = IndexConfig("index1", Seq("nested.leaf.id"), Seq("nested.leaf.cnt"))
+  private var hyperspace: Hyperspace = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    hyperspace = new Hyperspace(spark)
+    FileUtils.delete(new Path(testDir))
+  }
+
+  override def afterAll(): Unit = {
+    FileUtils.delete(new Path(testDir))
+    super.afterAll()
+  }
+
+  after {
+    FileUtils.delete(new Path(testDir))
+    FileUtils.delete(systemPath)
+  }
+
+  test("Validate incremental refresh index when some file gets deleted from the source data.") {
+    // Save test data non-partitioned.
+    SampleNestedData.save(
+      spark,
+      nonPartitionedDataPath,
+      Seq("Date", "RGUID", "Query", "imprs", "clicks", "nested"))
+    val nonPartitionedDataDF = spark.read.parquet(nonPartitionedDataPath)
+
+    // Save test data partitioned.
+    SampleNestedData.save(
+      spark,
+      partitionedDataPath,
+      Seq("Date", "RGUID", "Query", "imprs", "clicks", "nested"),
+      Some(Seq("Date", "Query")))
+    val partitionedDataDF = spark.read.parquet(partitionedDataPath)
+
+    Seq(nonPartitionedDataPath, partitionedDataPath).foreach { loc =>
+      withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
+        withIndex(indexConfig.indexName) {
+          val dfToIndex =
+            if (loc.equals(nonPartitionedDataPath)) nonPartitionedDataDF else partitionedDataDF
+          hyperspace.createIndex(dfToIndex, indexConfig)
+
+          // Delete one source data file.
+          val deletedFile = if (loc.equals(nonPartitionedDataPath)) {
+            deleteOneDataFile(nonPartitionedDataPath)
+          } else {
+            deleteOneDataFile(partitionedDataPath, true)
+          }
+
+          // Get deleted file's file id, used as lineage for its records.
+          val fileId = getFileIdTracker(systemPath, indexConfig).getFileId(
+            deletedFile.getPath.toString,
+            deletedFile.getLen,
+            deletedFile.getModificationTime)
+          assert(fileId.nonEmpty)
+
+          // Validate only index records whose lineage is the deleted file are removed.
+          val originalIndexDF = spark.read.parquet(s"$systemPath/${indexConfig.indexName}/" +
+              s"${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0")
+          val originalIndexWithoutDeletedFile = originalIndexDF
+              .filter(s"""${IndexConstants.DATA_FILE_NAME_ID} != ${fileId.get}""")
+
+          hyperspace.refreshIndex(indexConfig.indexName, REFRESH_MODE_INCREMENTAL)
+
+          val refreshedIndexDF = spark.read.parquet(s"$systemPath/${indexConfig.indexName}/" +
+              s"${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=1")
+
+          checkAnswer(originalIndexWithoutDeletedFile, refreshedIndexDF)
+        }
+      }
+    }
+  }
+
+  test(
+    "Validate incremental refresh index (to handle deletes from the source data) " +
+        "fails as expected on an index without lineage.") {
+    SampleNestedData.save(
+      spark,
+      nonPartitionedDataPath,
+      Seq("Date", "RGUID", "Query", "imprs", "clicks", "nested"))
+    val nonPartitionedDataDF = spark.read.parquet(nonPartitionedDataPath)
+
+    withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "false") {
+      hyperspace.createIndex(nonPartitionedDataDF, indexConfig)
+
+      deleteOneDataFile(nonPartitionedDataPath)
+
+      val ex = intercept[HyperspaceException](
+        hyperspace.refreshIndex(indexConfig.indexName, REFRESH_MODE_INCREMENTAL))
+      assert(
+        ex.getMessage.contains(s"Index refresh (to handle deleted source data) is " +
+            "only supported on an index with lineage."))
+    }
+  }
+
+  test(
+    "Validate incremental refresh index is a no-op if no source data file is deleted or " +
+        "appended.") {
+    SampleNestedData.save(
+      spark,
+      nonPartitionedDataPath,
+      Seq("Date", "RGUID", "Query", "imprs", "clicks", "nested"))
+    val nonPartitionedDataDF = spark.read.parquet(nonPartitionedDataPath)
+
+    withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
+      hyperspace.createIndex(nonPartitionedDataDF, indexConfig)
+
+      val latestId = logManager(systemPath, indexConfig.indexName).getLatestId().get
+
+      MockEventLogger.reset()
+      hyperspace.refreshIndex(indexConfig.indexName, REFRESH_MODE_INCREMENTAL)
+      // Check that no new log files were created in this operation.
+      assert(latestId == logManager(systemPath, indexConfig.indexName).getLatestId().get)
+
+      // Check emitted events.
+      MockEventLogger.emittedEvents match {
+        case Seq(
+        RefreshIncrementalActionEvent(_, _, "Operation started."),
+        RefreshIncrementalActionEvent(_, _, msg)) =>
+          assert(msg.contains("Refresh incremental aborted as no source data change found."))
+        case _ => fail()
+      }
+    }
+  }
+
+  test(
+    "Validate incremental refresh index (to handle deletes from the source data) " +
+        "fails as expected when all source data files are deleted.") {
+    Seq(true, false).foreach { deleteDataFolder =>
+      withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
+        SampleNestedData.save(
+          spark,
+          nonPartitionedDataPath,
+          Seq("Date", "RGUID", "Query", "imprs", "clicks", "nested"))
+        val nonPartitionedDataDF = spark.read.parquet(nonPartitionedDataPath)
+
+        hyperspace.createIndex(nonPartitionedDataDF, indexConfig)
+
+        if (deleteDataFolder) {
+          FileUtils.delete(new Path(nonPartitionedDataPath))
+
+          val ex = intercept[AnalysisException](
+            hyperspace.refreshIndex(indexConfig.indexName, REFRESH_MODE_INCREMENTAL))
+          assert(ex.getMessage.contains("Path does not exist"))
+
+        } else {
+          val dataPath = new Path(nonPartitionedDataPath, "*parquet")
+          dataPath
+              .getFileSystem(new Configuration)
+              .globStatus(dataPath)
+              .foreach(p => FileUtils.delete(p.getPath))
+
+          val ex =
+            intercept[HyperspaceException](
+              hyperspace.refreshIndex(indexConfig.indexName, REFRESH_MODE_INCREMENTAL))
+          assert(ex.getMessage.contains("Invalid plan for creating an index."))
+        }
+        FileUtils.delete(new Path(nonPartitionedDataPath))
+        FileUtils.delete(systemPath)
+      }
+    }
+  }
+
+  test(
+    "Validate incremental refresh index (to handle deletes from the source data) " +
+        "works well when file info for an existing source data file changes.") {
+    SampleNestedData.save(
+      spark,
+      nonPartitionedDataPath,
+      Seq("Date", "RGUID", "Query", "imprs", "clicks", "nested"))
+    val nonPartitionedDataDF = spark.read.parquet(nonPartitionedDataPath)
+
+    withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
+      hyperspace.createIndex(nonPartitionedDataDF, indexConfig)
+    }
+
+    // Replace a source data file with a new file with same name but different properties.
+    val deletedFile = deleteOneDataFile(nonPartitionedDataPath)
+    val sourcePath = new Path(spark.read.parquet(nonPartitionedDataPath).inputFiles.head)
+    val fs = deletedFile.getPath.getFileSystem(new Configuration)
+    fs.copyToLocalFile(sourcePath, deletedFile.getPath)
+
+    {
+      // Check the index log entry before refresh.
+      val indexLogEntry = getLatestStableLog(indexConfig.indexName)
+      assert(logManager(systemPath, indexConfig.indexName).getLatestId().get == 1)
+      assert(getIndexFilesCount(indexLogEntry, version = 0) == indexLogEntry.content.files.size)
+    }
+
+    val indexPath = PathUtils.makeAbsolute(s"$systemPath/${indexConfig.indexName}")
+    new RefreshIncrementalAction(
+      spark,
+      IndexLogManagerFactoryImpl.create(indexPath),
+      IndexDataManagerFactoryImpl.create(indexPath))
+        .run()
+
+    {
+      // Check the index log entry after RefreshIncrementalAction.
+      val indexLogEntry = getLatestStableLog(indexConfig.indexName)
+      assert(logManager(systemPath, indexConfig.indexName).getLatestId().get == 3)
+      assert(indexLogEntry.deletedFiles.isEmpty)
+      assert(indexLogEntry.appendedFiles.isEmpty)
+
+      val files = indexLogEntry.relations.head.data.properties.content.files
+      assert(files.exists(_.equals(deletedFile.getPath)))
+      assert(
+        getIndexFilesCount(indexLogEntry, version = 1) == indexLogEntry.content.fileInfos.size)
+    }
+
+    // Modify the file again.
+    val sourcePath2 = new Path(spark.read.parquet(nonPartitionedDataPath).inputFiles.last)
+    fs.copyToLocalFile(sourcePath2, deletedFile.getPath)
+
+    new RefreshIncrementalAction(
+      spark,
+      IndexLogManagerFactoryImpl.create(indexPath),
+      IndexDataManagerFactoryImpl.create(indexPath))
+        .run()
+
+    {
+      // Check non-empty deletedFiles after RefreshIncrementalAction.
+      val indexLogEntry = getLatestStableLog(indexConfig.indexName)
+      assert(indexLogEntry.deletedFiles.isEmpty)
+      assert(indexLogEntry.appendedFiles.isEmpty)
+      assert(logManager(systemPath, indexConfig.indexName).getLatestId().get == 5)
+      val files = indexLogEntry.relations.head.data.properties.content.files
+      assert(files.exists(_.equals(deletedFile.getPath)))
+      assert(
+        getIndexFilesCount(indexLogEntry, version = 2) == indexLogEntry.content.fileInfos.size)
+    }
+  }
+
+  test(
+    "Validate RefreshIncrementalAction updates appended and deleted files in metadata " +
+        "as expected, when some file gets deleted and some appended to source data.") {
+    withTempPathAsString { testPath =>
+      withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
+        withIndex(indexConfig.indexName) {
+          SampleNestedData.save(spark, testPath,
+            Seq("Date", "RGUID", "Query", "imprs", "clicks", "nested"))
+          val df = spark.read.parquet(testPath)
+          hyperspace.createIndex(df, indexConfig)
+
+          val oldFiles = listFiles(testPath, getFileIdTracker(systemPath, indexConfig)).toSet
+
+          // Delete one source data file.
+          deleteOneDataFile(testPath)
+
+          // Add some new data to source.
+          import spark.implicits._
+          SampleNestedData.testData
+              .take(3)
+              .toDF("Date", "RGUID", "Query", "imprs", "clicks", "nested")
+              .write
+              .mode("append")
+              .parquet(testPath)
+
+          val indexPath = PathUtils.makeAbsolute(s"$systemPath/${indexConfig.indexName}")
+          new RefreshIncrementalAction(
+            spark,
+            IndexLogManagerFactoryImpl.create(indexPath),
+            IndexDataManagerFactoryImpl.create(indexPath))
+              .run()
+
+          // Verify "appendedFiles" is cleared and "deletedFiles" is updated after refresh.
+          val indexLogEntry = getLatestStableLog(indexConfig.indexName)
+          assert(indexLogEntry.appendedFiles.isEmpty)
+
+          val latestFiles = listFiles(testPath, getFileIdTracker(systemPath, indexConfig)).toSet
+          val indexSourceFiles = indexLogEntry.relations.head.data.properties.content.fileInfos
+          val expectedDeletedFiles = oldFiles -- latestFiles
+          val expectedAppendedFiles = latestFiles -- oldFiles
+          assert(expectedDeletedFiles.forall(f => !indexSourceFiles.contains(f)))
+          assert(expectedAppendedFiles.forall(indexSourceFiles.contains))
+          assert(indexSourceFiles.forall(f =>
+            expectedAppendedFiles.contains(f) || oldFiles.contains(f)))
+        }
+      }
+    }
+  }
+
+  test(
+    "Validate incremental refresh index when some file gets deleted and some appended to " +
+        "source data.") {
+    withTempPathAsString { testPath =>
+      withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
+        withIndex(indexConfig.indexName) {
+          // Save test data non-partitioned.
+          SampleNestedData.save(spark, testPath,
+            Seq("Date", "RGUID", "Query", "imprs", "clicks", "nested"))
+          val df = spark.read.parquet(testPath)
+          hyperspace.createIndex(df, indexConfig)
+          val countOriginal = df.count()
+
+          // Delete one source data file.
+          deleteOneDataFile(testPath)
+          val countAfterDelete = spark.read.parquet(testPath).count()
+          assert(countAfterDelete < countOriginal)
+
+          // Add some new data to source.
+          import spark.implicits._
+          SampleNestedData.testData
+              .take(3)
+              .toDF("Date", "RGUID", "Query", "imprs", "clicks", "nested")
+              .write
+              .mode("append")
+              .parquet(testPath)
+
+          val countAfterAppend = spark.read.parquet(testPath).count()
+          assert(countAfterDelete + 3 == countAfterAppend)
+
+          hyperspace.refreshIndex(indexConfig.indexName, REFRESH_MODE_INCREMENTAL)
+
+          // Check if refreshed index is updated appropriately.
+          val indexDf = spark.read
+              .parquet(s"$systemPath/${indexConfig.indexName}/" +
+                  s"${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=1")
+
+          assert(indexDf.count() == countAfterAppend)
+        }
+      }
+    }
+  }
+
+  test(
+    "Validate the configs for incremental index data is consistent with" +
+        "the previous version.") {
+    withTempPathAsString { testPath =>
+      SampleNestedData.save(spark, testPath,
+        Seq("Date", "RGUID", "Query", "imprs", "clicks", "nested"))
+      val df = spark.read.parquet(testPath)
+
+      withSQLConf(
+        IndexConstants.INDEX_LINEAGE_ENABLED -> "false",
+        IndexConstants.INDEX_NUM_BUCKETS -> "20") {
+        hyperspace.createIndex(df, indexConfig)
+      }
+
+      // Add some new data to source.
+      import spark.implicits._
+      SampleNestedData.testData
+          .take(3)
+          .toDF("Date", "RGUID", "Query", "imprs", "clicks", "nested")
+          .write
+          .mode("append")
+          .parquet(testPath)
+
+      withSQLConf(
+        IndexConstants.INDEX_LINEAGE_ENABLED -> "true",
+        IndexConstants.INDEX_NUM_BUCKETS -> "10") {
+        hyperspace.refreshIndex(indexConfig.indexName, REFRESH_MODE_INCREMENTAL)
+      }
+
+      val indexLogEntry = getLatestStableLog(indexConfig.indexName)
+      assert(!indexLogEntry.hasLineageColumn)
+      assert(indexLogEntry.numBuckets === 20)
+    }
+  }
+
+  test(
+    "Validate RefreshQuickAction updates appended and deleted files in metadata " +
+        "as expected, when some file gets deleted and some appended to source data.") {
+    withTempPathAsString { testPath =>
+      withSQLConf(IndexConstants.INDEX_LINEAGE_ENABLED -> "true") {
+        withIndex(indexConfig.indexName) {
+          SampleNestedData.save(spark, testPath,
+            Seq("Date", "RGUID", "Query", "imprs", "clicks", "nested"))
+          val df = spark.read.parquet(testPath)
+          hyperspace.createIndex(df, indexConfig)
+
+          val oldFiles = listFiles(testPath, getFileIdTracker(systemPath, indexConfig)).toSet
+
+          // Delete one source data file.
+          deleteOneDataFile(testPath)
+
+          // Add some new data to source.
+          import spark.implicits._
+          SampleNestedData.testData
+              .take(3)
+              .toDF("Date", "RGUID", "Query", "imprs", "clicks", "nested")
+              .write
+              .mode("append")
+              .parquet(testPath)
+
+          val prevIndexLogEntry = getLatestStableLog(indexConfig.indexName)
+
+          val indexPath = PathUtils.makeAbsolute(s"$systemPath/${indexConfig.indexName}")
+          new RefreshQuickAction(
+            spark,
+            IndexLogManagerFactoryImpl.create(indexPath),
+            IndexDataManagerFactoryImpl.create(indexPath))
+              .run()
+
+          val indexLogEntry = getLatestStableLog(indexConfig.indexName)
+          val latestFiles = listFiles(testPath, getFileIdTracker(systemPath, indexConfig)).toSet
+          val expectedDeletedFiles = oldFiles -- latestFiles
+          val expectedAppendedFiles = latestFiles -- oldFiles
+
+          val signatureProvider = LogicalPlanSignatureProvider.create()
+          val latestDf = spark.read.parquet(testPath)
+          val expectedLatestSignature =
+            signatureProvider.signature(latestDf.queryExecution.optimizedPlan).get
+
+          // Check `Update` is collected properly.
+          assert(indexLogEntry.sourceUpdate.isDefined)
+          assert(
+            indexLogEntry.source.plan.properties.fingerprint.properties.signatures.head.value
+                == expectedLatestSignature)
+          assert(indexLogEntry.appendedFiles === expectedAppendedFiles)
+          assert(indexLogEntry.deletedFiles === expectedDeletedFiles)
+
+          // Check index data files and source data files are not updated.
+          assert(
+            indexLogEntry.relations.head.data.properties.content.fileInfos
+                === prevIndexLogEntry.relations.head.data.properties.content.fileInfos)
+          assert(indexLogEntry.content.fileInfos === prevIndexLogEntry.content.fileInfos)
+        }
+      }
+    }
+  }
+
+  /**
+   * Delete one file from a given path.
+   *
+   * @param path Path to the parent folder containing data files.
+   * @param isPartitioned Is data folder partitioned or not.
+   * @return Deleted file's FileStatus.
+   */
+  private def deleteOneDataFile(path: String, isPartitioned: Boolean = false): FileStatus = {
+    val dataPath = if (isPartitioned) s"$path/*/*" else path
+    TestUtils.deleteFiles(dataPath, "*parquet", 1).head
+  }
+
+  private def listFiles(path: String, fileIdTracker: FileIdTracker): Seq[FileInfo] = {
+    val absolutePath = PathUtils.makeAbsolute(path)
+    val fs = absolutePath.getFileSystem(new Configuration)
+    fs.listStatus(absolutePath)
+        .toSeq
+        .filter(f => DataPathFilter.accept(f.getPath))
+        .map(f => FileInfo(f, fileIdTracker.addFile(f), asFullPath = true))
+  }
+
+  private def getLatestStableLog(indexName: String): IndexLogEntry = {
+    val entry = logManager(systemPath, indexName).getLatestStableLog()
+    assert(entry.isDefined)
+    assert(entry.get.isInstanceOf[IndexLogEntry])
+    entry.get.asInstanceOf[IndexLogEntry]
+  }
+
+  private def getIndexFilesCount(
+      entry: IndexLogEntry,
+      version: Int,
+      allowEmpty: Boolean = false) = {
+    val cnt = entry.content.fileInfos
+        .count(_.name.contains(s"${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=$version"))
+    assert(allowEmpty || cnt > 0)
+    cnt
+  }
+}

--- a/src/test/scala/com/microsoft/hyperspace/util/ResolverUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/util/ResolverUtilsTest.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.util
+
+import org.apache.spark.SparkFunSuite
+
+import com.microsoft.hyperspace.{HyperspaceException, SparkInvolvedSuite}
+
+class ResolverUtilsTest extends SparkFunSuite with SparkInvolvedSuite {
+
+  test("testResolve against dataframe - simple") {
+    import spark.implicits._
+
+    val coll = Seq((1, "a", "a2"))
+    val df = coll.toDF("id", "name", "other")
+
+    assert(
+      ResolverUtils
+        .resolve(spark, Seq("id", "name"), df.queryExecution.analyzed)
+        .contains(Seq("id", "name")))
+    assert(
+      ResolverUtils.resolve(spark, Seq("unknown", "name"), df.queryExecution.analyzed).isEmpty)
+    assert(
+      ResolverUtils
+        .resolve(spark, Seq.empty[String], df.queryExecution.analyzed)
+        .contains(Seq.empty[String]))
+  }
+
+  test("testResolve against dataframe - case sensitiveness false") {
+    import spark.implicits._
+
+    val coll = Seq((1, "a", "a2"))
+    val df = coll.toDF("Id", "Name", "Other")
+
+    assert(
+      ResolverUtils
+        .resolve(spark, Seq("iD", "nAme"), df.queryExecution.analyzed)
+        .contains(Seq("Id", "Name")))
+  }
+
+  test("testResolve against dataframe - case sensitiveness true") {
+    import spark.implicits._
+
+    val coll = Seq((1, "a", "a2"))
+    val df = coll.toDF("Id", "Name", "Other")
+
+    val prevCaseSensitivity = spark.conf.get("spark.sql.caseSensitive")
+    spark.conf.set("spark.sql.caseSensitive", "true")
+    assert(ResolverUtils.resolve(spark, Seq("iD", "nAme"), df.queryExecution.analyzed).isEmpty)
+    spark.conf.set("spark.sql.caseSensitive", prevCaseSensitivity)
+  }
+
+  test("testResolve against dataframe - nested") {
+    import spark.implicits._
+
+    val coll =
+      Seq((1, "a", NType2("n1", NType3("m1", NType4("o1", NType("p1", 1L))))))
+    val df = coll.toDF("id", "nm", "nested")
+
+    assert(
+      ResolverUtils
+        .resolve(spark, Seq("id", "nm"), df.queryExecution.analyzed)
+        .contains(Seq("id", "nm")))
+    assert(
+      ResolverUtils
+        .resolve(
+          spark,
+          Seq("nm", "nested.n.n.n.f2", "nested.n.n.nf1_b", "nested.nf1"),
+          df.queryExecution.analyzed)
+        .contains(Seq("nm", "nested.n.n.n.f2", "nested.n.n.nf1_b", "nested.nf1")))
+  }
+
+  test("testResolve against dataframe - unsupported nested field names") {
+    import spark.implicits._
+
+    val coll = Seq((1, "a", NType5("m1", "s1")))
+    val df = coll.toDF("id", "nm", "nested")
+
+    assert(
+      ResolverUtils
+        .resolve(spark, Seq("id", "nm", "nested.n__y"), df.queryExecution.analyzed)
+        .contains(Seq("id", "nm", "nested.n__y")))
+    val exc = intercept[HyperspaceException] {
+      ResolverUtils.resolve(spark, Seq("nm", "nested.`nf9.x`"), df.queryExecution.analyzed)
+    }
+    assert(
+      exc.getMessage.contains("Hyperspace does not support the nested column whose name " +
+        "contains dots: nested.`nf9.x`"))
+  }
+
+  test("testResolve against dataframe - unsupported nested array types") {
+    import spark.implicits._
+
+    val coll = Seq((1, "a", NType7("f1", Seq[NType](NType("ff1", 11L)))))
+    val df = coll.toDF("id", "nm", "nested")
+    val exc = intercept[HyperspaceException] {
+      ResolverUtils.resolve(spark, Seq("nested.arr.f1"), df.queryExecution.analyzed)
+    }
+    assert(exc.getMessage.contains("Array types are not supported."))
+  }
+
+  test("testResolve against dataframe - unsupported nested map types") {
+    import spark.implicits._
+
+    val coll =
+      Seq((1, "a", NType8("f1", Map[NType, NType](NType("k1", 110L) -> NType("v1", 111L)))))
+    val df = coll.toDF("id", "nm", "nested")
+    val exc = intercept[HyperspaceException] {
+      ResolverUtils.resolve(spark, Seq("nested.maps.value.f1"), df.queryExecution.analyzed)
+    }
+    assert(exc.getMessage.contains("Map types are not supported."))
+    val exc2 = intercept[HyperspaceException] {
+      ResolverUtils.resolve(spark, Seq("nested.maps.keys.f1"), df.queryExecution.analyzed)
+    }
+    assert(exc2.getMessage.contains("Map types are not supported."))
+  }
+}
+
+case class NType8(f1: String, maps: Map[NType, NType])
+case class NType7(f1: String, arr: Seq[NType])
+case class NType6(`nf.1`: String, `n.2`: NType5)
+case class NType5(`nf9.x`: String, n__y: String)
+case class NType4(nf1_b: String, n: NType)
+case class NType3(nf_a: String, n: NType4)
+case class NType2(nf1: String, n: NType3)
+case class NType(f1: String, f2: Long)

--- a/src/test/scala/com/microsoft/hyperspace/util/SchemaUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/util/SchemaUtilsTest.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (2020) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.util
+
+import org.apache.spark.SparkFunSuite
+
+import com.microsoft.hyperspace.SparkInvolvedSuite
+
+class SchemaUtilsTest extends SparkFunSuite with SparkInvolvedSuite {
+
+  val originals = Seq(
+    "id",
+    "a.b.c",
+    "__hs_nested",
+    "__hs_nested_a",
+    "a.__hs_nested",
+    "a.__hs_nested.b",
+    "a.__hs_nested.b",
+    "a.nested..b",
+    "a.`g.c`.b",
+    "a.g-c.b",
+    "a-b")
+  val prefixed = Seq(
+    "id",
+    "__hs_nested.a.b.c",
+    "__hs_nested",
+    "__hs_nested_a",
+    "__hs_nested.a.__hs_nested",
+    "__hs_nested.a.__hs_nested.b",
+    "__hs_nested.a.__hs_nested.b",
+    "__hs_nested.a.nested..b",
+    "__hs_nested.a.`g.c`.b",
+    "__hs_nested.a.g-c.b",
+    "a-b")
+
+  test("prefixNestedFieldName") {
+    originals.zipWithIndex.foreach {
+      case (v, i) =>
+        assert(SchemaUtils.prefixNestedFieldName(v) == prefixed(i))
+    }
+    assert(
+      SchemaUtils.prefixNestedFieldName("__hs_nested.already.prefixed") ==
+        "__hs_nested.already.prefixed")
+  }
+
+  test("prefixNestedFieldNames") {
+    assert(prefixed == SchemaUtils.prefixNestedFieldNames(originals))
+  }
+
+  test("removePrefixNestedFieldName") {
+    prefixed.zipWithIndex.foreach {
+      case (v, i) =>
+        assert(SchemaUtils.removePrefixNestedFieldName(v) == originals(i))
+    }
+  }
+
+  test("removePrefixNestedFieldNames") {
+    assert(originals == SchemaUtils.removePrefixNestedFieldNames(prefixed))
+  }
+
+  test("isFieldNamePrefixed") {
+    val expectedBools1 =
+      Seq(false, false, false, false, false, false, false, false, false, false, false)
+    originals.zipWithIndex.foreach {
+      case (v, i) =>
+        assert(SchemaUtils.isFieldNamePrefixed(v) == expectedBools1(i))
+    }
+    val expectedBools2 =
+      Seq(false, true, false, false, true, true, true, true, true, true, false)
+    prefixed.zipWithIndex.foreach {
+      case (v, i) =>
+        assert(SchemaUtils.isFieldNamePrefixed(v) == expectedBools2(i))
+    }
+  }
+
+  test("containsNestedFieldNames") {
+    assert(!SchemaUtils.containsNestedFieldNames(originals))
+    assert(SchemaUtils.containsNestedFieldNames(prefixed))
+  }
+}


### PR DESCRIPTION
### What is the context for this pull request?

 - **Proposal**: #347
 - **Discussion**: #312
 - Fixes: #347

### What changes were proposed in this pull request?

This PR adds support for creating indexes over nested fields (ie: structs). 

Given the `nestedDataset` dataset with schema

```
root
 |-- id: integer (nullable = true)
 |-- name: string (nullable = true)
 |-- nested: struct (nullable = true)
 |    |-- field1: string (nullable = true)
 |    |-- nst: struct (nullable = true)
 |    |    |-- field1: string (nullable = true)
 |    |    |-- field2: string (nullable = true)
```

and the following data

```
+---+-----+-----------------+
|id |name |nested           |
+---+-----+-----------------+
|2  |name2|[va2, [wa2, wb2]]|
|1  |name1|[va1, [wa1, wb1]]|
+---+-----+-----------------+
```

Creating the index on nested fields would be:

```
hs.createIndex(
  nestedDataset, 
  IndexConfig(
    "idx_nested", 
    indexedColumns = Seq("nested.nst.field1"), 
    includedColumns = Seq("id", "name", "nested.nst.field2")))
```

The following index dataset will be created

```
root
 |-- __hs_nested.nested.nst.field1: string (nullable = true)
 |-- id: integer (nullable = true)
 |-- name: string (nullable = true)
 |-- __hs_nested.nested.nst.field2: string (nullable = true)
```

```
+-----------------------------+---+-----+-----------------------------+
|__hs_nested.nested.nst.field1| id| name|__hs_nested.nested.nst.field2|
+-----------------------------+---+-----+-----------------------------+
|                          wa1|  1|name1|                          wb1|
|                          wa2|  2|name2|                          wb2|
+-----------------------------+---+-----+-----------------------------+
```

It is important to understand that the name of the field of the index column is a non-nested column and it gets prefixed by `__hs_nested.` prefix to recognise that the field in the index data frame is for a nested field (ie: `nested.nst.field1` into `__hs_nested.nested.nst.field1`).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Existing unit and integration tests for not breaking the existing functionalities.
- Unit and integration test added for the new functionalities.
