### PR TITLE
Correctly pass HadoopConfiguration to Content.fromDirectory

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -59,6 +59,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
       indexConfig: IndexConfig,
       path: Path,
       versionId: Int): IndexLogEntry = {
+    val hadoopConf = spark.sessionState.newHadoopConf()
     val absolutePath = PathUtils.makeAbsolute(path, spark.sessionState.newHadoopConf())
     val numBuckets = numBucketsForIndex(spark)
 
@@ -96,7 +97,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
               IndexLogEntry.schemaString(indexDataFrame.schema),
               numBuckets,
               coveringIndexProperties)),
-          Content.fromDirectory(absolutePath, fileIdTracker),
+          Content.fromDirectory(absolutePath, fileIdTracker, hadoopConf),
           Source(SparkPlan(sourcePlanProperties)),
           Map())
 

--- a/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/CreateActionBase.scala
@@ -60,7 +60,7 @@ private[actions] abstract class CreateActionBase(dataManager: IndexDataManager) 
       path: Path,
       versionId: Int): IndexLogEntry = {
     val hadoopConf = spark.sessionState.newHadoopConf()
-    val absolutePath = PathUtils.makeAbsolute(path, spark.sessionState.newHadoopConf())
+    val absolutePath = PathUtils.makeAbsolute(path, hadoopConf)
     val numBuckets = numBucketsForIndex(spark)
 
     val signatureProvider = LogicalPlanSignatureProvider.create()

--- a/src/main/scala/com/microsoft/hyperspace/actions/OptimizeAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/OptimizeAction.scala
@@ -141,18 +141,16 @@ class OptimizeAction(
     // the list of newly created index files.
     val hadoopConf = spark.sessionState.newHadoopConf()
     val absolutePath = PathUtils.makeAbsolute(indexDataPath.toString, hadoopConf)
-    val newContent =
-      Content.fromDirectory(absolutePath, fileIdTracker, hadoopConfiguration = hadoopConf)
+    val newContent = Content.fromDirectory(absolutePath, fileIdTracker, hadoopConf)
     val updatedDerivedDataset = previousIndexLogEntry.derivedDataset.copy(
       properties = previousIndexLogEntry.derivedDataset.properties
         .copy(
-          properties =
-              Hyperspace
-                .getContext(spark)
-                .sourceProviderManager
-                .enrichIndexProperties(
-                  previousIndexLogEntry.relations.head,
-                  prevIndexProperties + (IndexConstants.INDEX_LOG_VERSION -> endId.toString))))
+          properties = Hyperspace
+            .getContext(spark)
+            .sourceProviderManager
+            .enrichIndexProperties(
+              previousIndexLogEntry.relations.head,
+              prevIndexProperties + (IndexConstants.INDEX_LOG_VERSION -> endId.toString))))
 
     if (filesToIgnore.nonEmpty) {
       val filesToIgnoreDirectory = {

--- a/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/IndexLogEntry.scala
@@ -77,6 +77,7 @@ object Content {
    * @param path Starting directory path under which the files will be considered part of the
    *             Directory object.
    * @param fileIdTracker FileIdTracker to keep mapping of file properties to assigned file ids.
+   * @param hadoopConfiguration Hadoop configuration.
    * @param pathFilter Filter for accepting paths. The default filter is picked from spark
    *                   codebase, which filters out files like _SUCCESS.
    * @param throwIfNotExists Throws FileNotFoundException if path is not found. Else creates a
@@ -87,8 +88,8 @@ object Content {
   def fromDirectory(
       path: Path,
       fileIdTracker: FileIdTracker,
+      hadoopConfiguration: Configuration,
       pathFilter: PathFilter = PathUtils.DataPathFilter,
-      hadoopConfiguration: Configuration = new Configuration,
       throwIfNotExists: Boolean = false): Content =
     Content(Directory.fromDirectory(path, fileIdTracker, pathFilter, hadoopConfiguration,
       throwIfNotExists))

--- a/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/E2EHyperspaceRulesTest.scala
@@ -286,10 +286,12 @@ class E2EHyperspaceRulesTest extends QueryTest with HyperspaceSuite {
       withIndex("leftIndex", "rightIndex") {
         withTable("t1", "t2") {
           if (useDDL) {
-            spark.sql("CREATE TABLE t1 (c1 string, c3 string) USING PARQUET " +
-              s"LOCATION '$nonPartitionedDataPath'")
-            spark.sql("CREATE TABLE t2 (c3 string, c4 int) USING PARQUET " +
-              s"LOCATION '$nonPartitionedDataPath'")
+            spark.sql(
+              "CREATE TABLE t1 (c1 string, c3 string) USING PARQUET " +
+                s"LOCATION '$nonPartitionedDataPath'")
+            spark.sql(
+              "CREATE TABLE t2 (c3 string, c4 int) USING PARQUET " +
+                s"LOCATION '$nonPartitionedDataPath'")
           } else {
             val table1Location = testDir + "tables/t1"
             val table2Location = testDir + "tables/t2"
@@ -1007,7 +1009,8 @@ class E2EHyperspaceRulesTest extends QueryTest with HyperspaceSuite {
       Content
         .fromDirectory(
           new Path(systemPath, s"$indexName/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=$v"),
-          new FileIdTracker)
+          new FileIdTracker,
+          new Configuration)
         .files
     }
   }

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexLogEntryTest.scala
@@ -268,7 +268,7 @@ class IndexLogEntryTest extends SparkFunSuite with SQLHelper with BeforeAndAfter
       Content(rootDirectory, NoOpFingerprint())
     }
 
-    val actual = Content.fromDirectory(nestedDirPath, fileIdTracker)
+    val actual = Content.fromDirectory(nestedDirPath, fileIdTracker, new Configuration)
     assert(contentEquals(actual, expected))
   }
 
@@ -283,7 +283,7 @@ class IndexLogEntryTest extends SparkFunSuite with SQLHelper with BeforeAndAfter
       Content(rootDirectory, NoOpFingerprint())
     }
 
-    val actual = Content.fromDirectory(nestedDirPath, fileIdTracker)
+    val actual = Content.fromDirectory(nestedDirPath, fileIdTracker, new Configuration)
     assert(contentEquals(actual, expected))
   }
 

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTest.scala
@@ -18,7 +18,6 @@ package com.microsoft.hyperspace.index
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.execution.datasources.{BucketingUtils, HadoopFsRelation, LogicalRelation, PartitioningAwareFileIndex}

--- a/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/IndexManagerTest.scala
@@ -16,7 +16,9 @@
 
 package com.microsoft.hyperspace.index
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.execution.datasources.{BucketingUtils, HadoopFsRelation, LogicalRelation, PartitioningAwareFileIndex}
@@ -797,7 +799,8 @@ class IndexManagerTest extends HyperspaceSuite with SQLHelper {
             PathUtils.makeAbsolute(
               s"$systemPath/${indexConfig.indexName}" +
                 s"/${IndexConstants.INDEX_VERSION_DIRECTORY_PREFIX}=0"),
-            fileIdTracker),
+            fileIdTracker,
+            new Configuration),
           Source(SparkPlan(sourcePlanProperties)),
           Map())
         entry.state = state


### PR DESCRIPTION
Fixes #391.

This PR proposes to fix the issue reported in #391. We missed passing the Hadoop configuration to `Content.fromDirectory` in `CreateActionBase`. This PR removes the default value for the Hadoop configuration in `Content.fromDirectory` since it's error-prone.