### PR TITLE
Remove linefeed check from gold standard plan comparison

### DIFF
--- a/src/test/scala/com/microsoft/hyperspace/goldstandard/PlanStabilitySuite.scala
+++ b/src/test/scala/com/microsoft/hyperspace/goldstandard/PlanStabilitySuite.scala
@@ -100,7 +100,7 @@ trait PlanStabilitySuite extends TPCDSBase with SQLHelper with Logging {
   private def isApproved(dir: File, actualSimplifiedPlan: String): Boolean = {
     val file = new File(dir, "simplified.txt")
     val expected = FileUtils.readFileToString(file, StandardCharsets.UTF_8)
-    expected == actualSimplifiedPlan
+    expected.replaceAll("[\\r\\n]+", "") == actualSimplifiedPlan.replaceAll("[\\r\\n]+", "")
   }
 
   /**


### PR DESCRIPTION
### What is the context for this pull request?
Linux and Windows have different notions of end of line (CRLF vs LF, \r\n vs \n) which causes gold standard tests to fail when the golden file is created on one setup and tested on another.

 - **Parent Issue**: #334

### What changes were proposed in this pull request?
Remove linefeeds before comparing plans.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
https://github.com/microsoft/hyperspace/pull/376 sanity check will be added to build process and will start passing for windows.