### PR TITLE
Fix ResolverUtils to handle StructType column properly

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/util/ResolverUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/util/ResolverUtils.scala
@@ -226,5 +226,7 @@ object ResolverUtils {
           throw HyperspaceException("Map types are not supported")
         case f => Seq(f.name)
       }
+     case Nil =>
+      Seq()
   }
 }

--- a/src/main/scala/com/microsoft/hyperspace/util/ResolverUtils.scala
+++ b/src/main/scala/com/microsoft/hyperspace/util/ResolverUtils.scala
@@ -226,7 +226,6 @@ object ResolverUtils {
           throw HyperspaceException("Map types are not supported")
         case f => Seq(f.name)
       }
-     case Nil =>
-      Seq()
+     case _ => Nil
   }
 }

--- a/src/test/scala/com/microsoft/hyperspace/index/CreateIndexNestedTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/CreateIndexNestedTest.scala
@@ -222,6 +222,19 @@ class CreateIndexNestedTest extends HyperspaceSuite with SQLHelper {
           .contains("Hyperspace(Type: CI, Name: index1"))
     }
     {
+      val filter = nonPartitionedDataDF.filter("nested.id = \"id1\"").select("nested", "clicks")
+      assert(
+        filter.queryExecution.optimizedPlan.toString
+          .contains("Hyperspace(Type: CI, Name: index1"))
+    }
+    {
+      val filter =
+        nonPartitionedDataDF.filter("nested.id = \"id1\"").select("nested.id", "clicks")
+      assert(
+        filter.queryExecution.optimizedPlan.toString
+          .contains("Hyperspace(Type: CI, Name: index1"))
+    }
+    {
       val filter = nonPartitionedDataDF.filter("clicks = 1000").select("nested", "clicks")
       assert(
         filter.queryExecution.optimizedPlan.toString

--- a/src/test/scala/com/microsoft/hyperspace/index/CreateIndexNestedTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/index/CreateIndexNestedTest.scala
@@ -98,7 +98,8 @@ class CreateIndexNestedTest extends HyperspaceSuite with SQLHelper {
       "Indexed columns with wrong case are stored in metadata")
     assert(
       indexes.head
-        .getAs[Map[String, String]]("additionalStats")("includedColumns") == "__hs_nested.nested.leaf.cnt",
+        .getAs[Map[String, String]]("additionalStats")("includedColumns") ==
+        "__hs_nested.nested.leaf.cnt",
       "Included columns with wrong case are stored in metadata")
   }
 

--- a/src/test/scala/com/microsoft/hyperspace/util/ResolverUtilsTest.scala
+++ b/src/test/scala/com/microsoft/hyperspace/util/ResolverUtilsTest.scala
@@ -88,6 +88,18 @@ class ResolverUtilsTest extends SparkFunSuite with SparkInvolvedSuite {
             ResolvedColumn("nested.n.n.n.f2", true),
             ResolvedColumn("nested.n.n.nf1_b", true),
             ResolvedColumn("nested.nf1", true))))
+    assert(
+      ResolverUtils
+        .resolve(
+          spark,
+          Seq("nm", "nested", "nested.n", "nested.n.n", "nested.nf1"),
+          df.queryExecution.analyzed)
+        .contains(Seq(
+          ResolvedColumn("nm", false),
+          ResolvedColumn("nested", false),
+          ResolvedColumn("nested.n", true),
+          ResolvedColumn("nested.n.n", true),
+          ResolvedColumn("nested.nf1", true))))
   }
 
   test("Verify testResolve against dataframe - unsupported nested field names") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/docs/contributing.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/microsoft/hyperspace/blob/master/docs/developer.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What is the context for this pull request?
<!--
Please clarify the context for the changes you are contributing. The purpose of this section is to outline information information to help reviewers have enough context.
-->

 - **Tracking Issue**: n/a
 - **Parent Issue**: n/a
 - **Dependencies**: n/a

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.

The purpose of this section is to outline the changes and how this PR introduces those changes. 

If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some code by changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some existing feature, you can provide some explanation on why your approach is correct.
  3. If there is design documentation, please add it here (with images, if necessary).
  4. If there is a discussion elsewhere (e.g., another GitHub issue, StackOverflow etc.), please add the link.
-->
Fix ResolverUtils to handle nested StructType column properly.

Without the fix, the following exception is thrown while resolving nested StructType column.

```
// nestedC schema
StructField(nestedC,StructType(
  StructField(id,StringType,true), 
  StructField(leaf,StructType(
    StructField(id,StringType,true), 
    StructField(cnt,IntegerType,true)),
    true)),
  true))
//
scala> hs.createIndex(dff, IndexConfig("nestedIndex2", Seq("nestedC"), Seq("hsh")))
scala.MatchError: List() (of class scala.collection.immutable.Nil$)
  at com.microsoft.hyperspace.util.ResolverUtils$.com$microsoft$hyperspace$util$ResolverUtils$$getColumnNameFromSchema(ResolverUtils.scala:215)
  at com.microsoft.hyperspace.util.ResolverUtils$.com$microsoft$hyperspace$util$ResolverUtils$$getColumnNameFromSchema(ResolverUtils.scala:220)
  at com.microsoft.hyperspace.util.ResolverUtils$$anonfun$1$$anonfun$apply$2.apply(ResolverUtils.scala:174)
  at com.microsoft.hyperspace.util.ResolverUtils$$anonfun$1$$anonfun$apply$2.apply(ResolverUtils.scala:171)
  at scala.Option.map(Option.scala:146)
  at com.microsoft.hyperspace.util.ResolverUtils$$anonfun$1.apply(ResolverUtils.scala:171)
  at com.microsoft.hyperspace.util.ResolverUtils$$anonfun$1.apply(ResolverUtils.scala:168)
  at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
  at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
  at scala.collection.immutable.List.foreach(List.scala:392)
  at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
  at scala.collection.immutable.List.map(List.scala:296)
  at com.microsoft.hyperspace.util.ResolverUtils$.resolve(ResolverUtils.scala:168)
  at com.microsoft.hyperspace.actions.CreateAction.isValidIndexSchema(CreateAction.scala:77)
  at com.microsoft.hyperspace.actions.CreateAction.validate(CreateAction.scala:60)
  at com.microsoft.hyperspace.actions.Action$class.run(Action.scala:89)
  at com.microsoft.hyperspace.actions.CreateAction.run(CreateAction.scala:29)
  at com.microsoft.hyperspace.index.IndexCollectionManager.create(IndexCollectionManager.scala:47)
  at com.microsoft.hyperspace.index.CachingIndexCollectionManager.create(CachingIndexCollectionManager.scala:78)
  at com.microsoft.hyperspace.Hyperspace$$anonfun$createIndex$1.apply$mcV$sp(Hyperspace.scala:45)
  at com.microsoft.hyperspace.Hyperspace.withHyperspaceRuleDisabled(Hyperspace.scala:188)
  at com.microsoft.hyperspace.Hyperspace.createIndex(Hyperspace.scala:44)
  ... 54 elided

```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, fixes the bug described above

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test
