### PR TITLE
Refactoring for an extensible Index API: Part 2

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/actions/RefreshIncrementalAction.scala
+++ b/src/main/scala/com/microsoft/hyperspace/actions/RefreshIncrementalAction.scala
@@ -72,8 +72,14 @@ class RefreshIncrementalAction(
     } else {
       None
     }
-    updatedIndex = Some(previousIndexLogEntry.derivedDataset
-      .refreshIncremental(this, appendedSourceData, deletedFiles, previousIndexLogEntry.content))
+    val (updatedIndex, updateMode) =
+      previousIndexLogEntry.derivedDataset.refreshIncremental(
+        this,
+        appendedSourceData,
+        deletedFiles,
+        previousIndexLogEntry.content)
+    updatedIndexOpt = Some(updatedIndex)
+    updateModeOpt = Some(updateMode)
   }
 
   /**
@@ -95,7 +101,8 @@ class RefreshIncrementalAction(
     }
   }
 
-  private var updatedIndex: Option[Index] = None
+  private var updatedIndexOpt: Option[Index] = None
+  private var updateModeOpt: Option[Index.UpdateMode] = None
 
   /**
    * Create a log entry with all source data files, and all required index content. This contains
@@ -106,15 +113,11 @@ class RefreshIncrementalAction(
    * @return Refreshed index log entry.
    */
   override def logEntry: LogEntry = {
-    val index = updatedIndex.getOrElse(previousIndexLogEntry.derivedDataset)
+    val index = updatedIndexOpt.getOrElse(previousIndexLogEntry.derivedDataset)
     val entry =
       getIndexLogEntry(spark, df, previousIndexLogEntry.name, index, indexDataPath, endId)
 
-    // If there is no deleted files, there are index data files only for appended data in this
-    // version and we need to add the index data files of previous index version.
-    // Otherwise, as previous index data is rewritten in this version while excluding
-    // indexed rows from deleted files, all necessary index data files exist in this version.
-    if (deletedFiles.isEmpty) {
+    if (updateModeOpt.contains(Index.UpdateMode.Merge)) {
       // Merge new index files with old index files.
       val mergedContent = Content(previousIndexLogEntry.content.root.merge(entry.content.root))
       entry.copy(content = mergedContent)

--- a/src/main/scala/com/microsoft/hyperspace/index/Index.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/Index.scala
@@ -118,14 +118,17 @@ trait Index {
    * @param deletedSourceDataFiles Source data files deleted from the source
    *   since the creation of this index
    * @param indexContent Unrefreshed index data files
-   * @return Updated index resulting from the indexing operation, or this
-   *         index if no update is needed
+   * @return Pair of (updated index, update mode) where the first value is an
+   *         updated index resulting from the indexing operation or this index
+   *         if no update is needed, and the second value is whether the
+   *         updated index data needs to be merged to the existing index data
+   *         or the existing index data should be overwritten
    */
   def refreshIncremental(
       ctx: IndexerContext,
       appendedSourceData: Option[DataFrame],
       deletedSourceDataFiles: Seq[FileInfo],
-      indexContent: Content): Index
+      indexContent: Content): (Index, Index.UpdateMode)
 
   /**
    * Indexes the source data and returns an updated index and index data.
@@ -140,4 +143,24 @@ trait Index {
    *         index if no update is needed
    */
   def refreshFull(ctx: IndexerContext, sourceData: DataFrame): (Index, DataFrame)
+
+  /**
+   * Returns true if and only if this index equals to that.
+   *
+   * Indexes only differing in their [[properties]] should be considered equal.
+   */
+  def equals(that: Any): Boolean
+
+  /**
+   * Returns the hash code for this index.
+   */
+  def hashCode: Int
+}
+
+object Index {
+  sealed trait UpdateMode
+  object UpdateMode {
+    case object Merge extends UpdateMode
+    case object Overwrite extends UpdateMode
+  }
 }


### PR DESCRIPTION
### What is the context for this pull request?
 - **Tracking Issue**: #441 
 - **Parent Issue**: N/A
 - **Dependencies**:
   - #473 

### What changes were proposed in this pull request?
- Change the return type of refreshIncremental so that implementations
  can choose what the framework should do after the incremental refresh
  regarding the index data files.
- Move CoveringIndex.resolveConfig to IndexUtils.resolveColumns to make
  it available to other index implementations.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
With existing tests