### PR TITLE
Disable Spark 3.1 on Windows build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,16 +80,6 @@ jobs:
           sparkVersionUnderBar: "3_0"
           scalaVersion: "2.12.8"
 
-  - job: Build_Spark3_1_2_12_WIN
-    displayName: 'Build sources and run unit tests for Spark 3.1 / Scala 2.12 on Windows'
-    pool:
-      vmImage: 'windows-2019'
-    steps:
-      - template: 'ci/windows_test.yml'
-        parameters:
-          sparkVersionUnderBar: "3_1"
-          scalaVersion: "2.12.8"
-
   - job: PythonTest
     displayName: 'Run Python tests'
     pool:


### PR DESCRIPTION
Until the issue #484 is fixed.

### What is the context for this pull request?
 - **Tracking Issue**: #484
 - **Parent Issue**: N/A
 - **Dependencies**: N/A

### What changes were proposed in this pull request?
Disable Windows / Spark 3.1 CI test.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
N/A
