### PR TITLE
Add CoveringIndexTrait and CoveringIndexConfigTrait

### DIFF
--- a/src/main/scala/com/microsoft/hyperspace/index/covering/CoveringIndexConfig.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/covering/CoveringIndexConfig.scala
@@ -16,8 +16,6 @@
 
 package com.microsoft.hyperspace.index.covering
 
-import java.util.Locale
-
 import org.apache.spark.sql.DataFrame
 
 import com.microsoft.hyperspace.Hyperspace
@@ -40,54 +38,7 @@ case class CoveringIndexConfig(
     override val indexName: String,
     indexedColumns: Seq[String],
     includedColumns: Seq[String] = Seq())
-    extends IndexConfigTrait {
-  if (indexName.isEmpty || indexedColumns.isEmpty) {
-    throw new IllegalArgumentException("Empty index name or indexed columns are not allowed.")
-  }
-
-  val lowerCaseIndexedColumns = toLowerCase(indexedColumns)
-  val lowerCaseIncludedColumns = toLowerCase(includedColumns)
-  val lowerCaseIncludedColumnsSet = lowerCaseIncludedColumns.toSet
-
-  if (lowerCaseIndexedColumns.toSet.size < lowerCaseIndexedColumns.size) {
-    throw new IllegalArgumentException("Duplicate indexed column names are not allowed.")
-  }
-
-  if (lowerCaseIncludedColumnsSet.size < lowerCaseIncludedColumns.size) {
-    throw new IllegalArgumentException("Duplicate included column names are not allowed.")
-  }
-
-  for (indexedColumn <- lowerCaseIndexedColumns) {
-    if (lowerCaseIncludedColumns.contains(indexedColumn)) {
-      throw new IllegalArgumentException(
-        "Duplicate column names in indexed/included columns are not allowed.")
-    }
-  }
-
-  override def equals(that: Any): Boolean = {
-    that match {
-      case CoveringIndexConfig(thatIndexName, thatIndexedColumns, thatIncludedColumns) =>
-        indexName.equalsIgnoreCase(thatIndexName) &&
-          lowerCaseIndexedColumns.equals(toLowerCase(thatIndexedColumns)) &&
-          lowerCaseIncludedColumnsSet.equals(toLowerCase(thatIncludedColumns).toSet)
-      case _ => false
-    }
-  }
-
-  override def hashCode(): Int = {
-    lowerCaseIndexedColumns.hashCode + lowerCaseIncludedColumnsSet.hashCode
-  }
-
-  override def toString: String = {
-    val indexedColumnNames = lowerCaseIndexedColumns.mkString(", ")
-    val includedColumnNames = lowerCaseIncludedColumns.mkString(", ")
-    s"[indexName: $indexName; indexedColumns: $indexedColumnNames; " +
-      s"includedColumns: $includedColumnNames]"
-  }
-
-  private def toLowerCase(seq: Seq[String]): Seq[String] = seq.map(_.toLowerCase(Locale.ROOT))
-
-  override def referencedColumns: Seq[String] = indexedColumns ++ includedColumns
+    extends CoveringIndexConfigTrait {
 
   override def createIndex(
       ctx: IndexerContext,

--- a/src/main/scala/com/microsoft/hyperspace/index/covering/CoveringIndexConfigTrait.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/covering/CoveringIndexConfigTrait.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (2021) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index.covering
+
+import java.util.Locale
+
+import com.microsoft.hyperspace.index._
+
+trait CoveringIndexConfigTrait extends IndexConfigTrait {
+  val indexName: String
+  val indexedColumns: Seq[String]
+  val includedColumns: Seq[String]
+
+  if (indexName.isEmpty || indexedColumns.isEmpty) {
+    throw new IllegalArgumentException("Empty index name or indexed columns are not allowed.")
+  }
+
+  protected def toLowerCase(seq: Seq[String]): Seq[String] = seq.map(_.toLowerCase(Locale.ROOT))
+
+  val lowerCaseIndexedColumns = toLowerCase(indexedColumns)
+  val lowerCaseIncludedColumns = toLowerCase(includedColumns)
+  val lowerCaseIncludedColumnsSet = lowerCaseIncludedColumns.toSet
+
+  if (lowerCaseIndexedColumns.toSet.size < lowerCaseIndexedColumns.size) {
+    throw new IllegalArgumentException("Duplicate indexed column names are not allowed.")
+  }
+
+  if (lowerCaseIncludedColumnsSet.size < lowerCaseIncludedColumns.size) {
+    throw new IllegalArgumentException("Duplicate included column names are not allowed.")
+  }
+
+  for (indexedColumn <- lowerCaseIndexedColumns) {
+    if (lowerCaseIncludedColumns.contains(indexedColumn)) {
+      throw new IllegalArgumentException(
+        "Duplicate column names in indexed/included columns are not allowed.")
+    }
+  }
+
+  override def equals(that: Any): Boolean = {
+    that match {
+      case CoveringIndexConfig(thatIndexName, thatIndexedColumns, thatIncludedColumns) =>
+        indexName.equalsIgnoreCase(thatIndexName) &&
+          lowerCaseIndexedColumns.equals(toLowerCase(thatIndexedColumns)) &&
+          lowerCaseIncludedColumnsSet.equals(toLowerCase(thatIncludedColumns).toSet)
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = {
+    lowerCaseIndexedColumns.hashCode + lowerCaseIncludedColumnsSet.hashCode
+  }
+
+  override def toString: String = {
+    val indexedColumnNames = lowerCaseIndexedColumns.mkString(", ")
+    val includedColumnNames = lowerCaseIncludedColumns.mkString(", ")
+    s"[indexName: $indexName; indexedColumns: $indexedColumnNames; " +
+      s"includedColumns: $includedColumnNames]"
+  }
+
+  override def referencedColumns: Seq[String] = indexedColumns ++ includedColumns
+}

--- a/src/main/scala/com/microsoft/hyperspace/index/covering/CoveringIndexTrait.scala
+++ b/src/main/scala/com/microsoft/hyperspace/index/covering/CoveringIndexTrait.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright (2021) The Hyperspace Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.hyperspace.index.covering
+
+import org.apache.spark.sql.{DataFrame, SaveMode}
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.hyperspace.utils.StructTypeUtils
+import org.apache.spark.sql.types.StructType
+
+import com.microsoft.hyperspace.index._
+import com.microsoft.hyperspace.util.ResolverUtils.ResolvedColumn
+
+/**
+ * CoveringIndexTrait is a common interface for covering index type which contains a vertical
+ * slice of source data including indexedColumns and includedColumns.
+ */
+trait CoveringIndexTrait extends Index {
+  val schema: StructType
+  val includedColumns: Seq[String]
+  def bucketSpec: Option[BucketSpec]
+  protected def write(ctx: IndexerContext, indexData: DataFrame, mode: SaveMode)
+  protected def copyIndex(
+      indexedCols: Seq[String],
+      includedCols: Seq[String],
+      schema: StructType): CoveringIndexTrait
+  protected def simpleStatistics: Map[String, String]
+  protected def extendedStatistics: Map[String, String]
+
+  // override functions for Index
+  override def write(ctx: IndexerContext, indexData: DataFrame): Unit = {
+    write(ctx, indexData, SaveMode.Overwrite)
+  }
+
+  override def referencedColumns: Seq[String] = indexedColumns ++ includedColumns
+
+  override def statistics(extended: Boolean = false): Map[String, String] = {
+    simpleStatistics ++ (if (extended) extendedStatistics else Map.empty)
+  }
+
+  override def canHandleDeletedFiles: Boolean = hasLineageColumn
+
+  override def refreshIncremental(
+      ctx: IndexerContext,
+      appendedSourceData: Option[DataFrame],
+      deletedSourceDataFiles: Seq[FileInfo],
+      indexContent: Content): (CoveringIndexTrait, Index.UpdateMode) = {
+    val updatedIndex = if (appendedSourceData.nonEmpty) {
+      val (indexData, resolvedIndexedColumns, resolvedIncludedColumns) =
+        CoveringIndex.createIndexData(
+          ctx,
+          appendedSourceData.get,
+          indexedColumns.map(ResolvedColumn(_).name),
+          includedColumns.map(ResolvedColumn(_).name),
+          hasLineageColumn)
+      write(ctx, indexData)
+      copyIndex(
+        indexedCols = resolvedIndexedColumns.map(_.normalizedName),
+        includedCols = resolvedIncludedColumns.map(_.normalizedName),
+        schema = schema.merge(indexData.schema))
+    } else {
+      this
+    }
+    if (deletedSourceDataFiles.nonEmpty) {
+      // For an index with lineage, find all the source data files which have been deleted,
+      // and use index records' lineage to mark and remove index entries which belong to
+      // deleted source data files as those entries are no longer valid.
+      val refreshDF = ctx.spark.read
+        .parquet(indexContent.files.map(_.toString): _*)
+        .filter(!col(IndexConstants.DATA_FILE_NAME_ID).isin(deletedSourceDataFiles.map(_.id): _*))
+
+      // Write refreshed data using Append mode if there are index data files from appended files.
+      val writeMode = if (appendedSourceData.nonEmpty) {
+        SaveMode.Append
+      } else {
+        SaveMode.Overwrite
+      }
+
+      write(ctx, refreshDF, writeMode)
+    }
+
+    // If there is no deleted files, there are index data files only for appended data in this
+    // version and we need to add the index data files of previous index version.
+    // Otherwise, as previous index data is rewritten in this version while excluding
+    // indexed rows from deleted files, all necessary index data files exist in this version.
+    val updatedMode = if (deletedSourceDataFiles.isEmpty) {
+      Index.UpdateMode.Merge
+    } else {
+      Index.UpdateMode.Overwrite
+    }
+    (updatedIndex, updatedMode)
+  }
+
+  override def refreshFull(
+      ctx: IndexerContext,
+      sourceData: DataFrame): (CoveringIndexTrait, DataFrame) = {
+    val (indexData, resolvedIndexedColumns, resolvedIncludedColumns) =
+      CoveringIndex.createIndexData(
+        ctx,
+        sourceData,
+        // As indexed & included columns in previousLogEntry are resolved & prefixed names,
+        // need to remove the prefix to resolve with the dataframe for refresh.
+        indexedColumns.map(ResolvedColumn(_).name),
+        includedColumns.map(ResolvedColumn(_).name),
+        hasLineageColumn)
+    (
+      copyIndex(
+        indexedCols = resolvedIndexedColumns.map(_.normalizedName),
+        includedCols = resolvedIncludedColumns.map(_.normalizedName),
+        schema = indexData.schema),
+      indexData)
+  }
+
+  def hasLineageColumn: Boolean = IndexUtils.hasLineageColumn(properties)
+
+  override def optimize(ctx: IndexerContext, indexDataFilesToOptimize: Seq[FileInfo]): Unit = {
+    // Rewrite index using the eligible files to optimize.
+    val indexData = ctx.spark.read.parquet(indexDataFilesToOptimize.map(_.name): _*)
+    write(ctx, indexData)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/microsoft/hyperspace/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If your PR is addressing an issue, provide a concise example to reproduce the issue for a faster review.
-->

### What is the context for this pull request?
 - **Tracking Issue**: n/a
 - **Parent Issue**: #515
 - **Dependencies**: n/a

### What changes were proposed in this pull request?
CoveringIndex refactoring to support other covering index type - ZOrderCoveringIndex (#495)
Added CoveringIndexTrait & CoveringIndexConfigTrait to reduce duplicate code.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly, including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Refactoring change - tested by existing tests